### PR TITLE
fix(ci): pin golangci-lint-action to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v1.64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
           fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v1.64
+          version: v2.12.2
 
       - name: test (race, coverage)
         run: go test -race -count=1 -covermode=atomic -coverprofile=coverage.out ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
         with:
           version: v1.64
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 5m
 
@@ -17,35 +19,33 @@ linters:
     - gocyclo
     - nolintlint
     - revive
-
-linters-settings:
-  errcheck:
-    check-blank: true
-  gocyclo:
-    min-complexity: 15
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - performance
-      - style
-    disabled-checks:
-      - commentFormatting   # noisy; we don't enforce period-terminated comments
-      - ifElseChain         # switch-vs-if is style; let reviewer decide
-  revive:
-    rules:
-      - name: var-naming
-      - name: exported
-        arguments: [ "checkPrivateReceivers" ]
-      - name: indent-error-flow
-      - name: unreachable-code
-      - name: superfluous-else
-  nolintlint:
-    require-specific: true
-    require-explanation: true
-    allow-unused: false
+  settings:
+    errcheck:
+      check-blank: true
+    gocyclo:
+      min-complexity: 15
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - performance
+        - style
+      disabled-checks:
+        - commentFormatting
+        - ifElseChain
+    revive:
+      rules:
+        - name: var-naming
+        - name: exported
+          arguments: ["checkPrivateReceivers"]
+        - name: indent-error-flow
+        - name: unreachable-code
+        - name: superfluous-else
+    nolintlint:
+      require-specific: true
+      require-explanation: true
+      allow-unused: false
 
 issues:
   exclude-rules:
-    # Tests are allowed to be longer / more complex.
     - path: _test\.go
-      linters: [ gocyclo, errcheck, revive ]
+      linters: [gocyclo, errcheck, revive]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,9 +5,8 @@ run:
 
 linters:
   enable:
-    # default correctness set
+    # default correctness set (gosimple merged into staticcheck in v2)
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,8 +44,10 @@ linters:
       require-specific: true
       require-explanation: true
       allow-unused: false
-
-issues:
-  exclude-rules:
-    - path: _test\.go
-      linters: [gocyclo, errcheck, revive]
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - gocyclo
+          - errcheck
+          - revive

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -24,7 +24,7 @@ import (
 func newTestFactoryWithReg() *cmdutil.TestFactory {
 	f := cmdutil.NewTestFactory()
 	reg := registry.MustNew()
-	f.Factory.RegistryFunc = func() *registry.Registry { return reg }
+	f.RegistryFunc = func() *registry.Registry { return reg }
 	return f
 }
 

--- a/cmd/service/multipart.go
+++ b/cmd/service/multipart.go
@@ -30,7 +30,7 @@ func buildMultipartBody(cobraCmd *cobra.Command, rt *operationRuntime) (body []b
 	if err != nil {
 		return nil, "", output.ErrValidation(fmt.Sprintf("--file: %v", err), "check path and permissions")
 	}
-	defer func() { _ = f.Close() }()
+	defer f.Close() //nolint:errcheck // best-effort close; read-only file
 
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)

--- a/cmd/service/multipart.go
+++ b/cmd/service/multipart.go
@@ -30,7 +30,7 @@ func buildMultipartBody(cobraCmd *cobra.Command, rt *operationRuntime) (body []b
 	if err != nil {
 		return nil, "", output.ErrValidation(fmt.Sprintf("--file: %v", err), "check path and permissions")
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -77,7 +77,7 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 	}
 
 	// Pagination loop (--page-all). Only for operations declaring pagination.
-	if rt.pageAll != nil && *rt.pageAll && !(f.Globals != nil && f.Globals.DryRun) {
+	if rt.pageAll != nil && *rt.pageAll && (f.Globals == nil || !f.Globals.DryRun) {
 		return runPaginated(ctx, f, rt, &req)
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -82,7 +82,7 @@ func New(cfg *config.Config, cred *credential.BotCredential, opts Options) *Clie
 		if d, err := time.ParseDuration(opts.Timeout); err == nil {
 			timeout = d
 		} else if opts.ErrOut != nil {
-			_, _ = fmt.Fprintf(opts.ErrOut, "warning: invalid --timeout %q; using %s\n", opts.Timeout, defaultTimeout)
+			fmt.Fprintf(opts.ErrOut, "warning: invalid --timeout %q; using %s\n", opts.Timeout, defaultTimeout) //nolint:errcheck // stderr warning
 		}
 	}
 	return &Client{
@@ -217,7 +217,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 			ExitError: output.ErrNetwork(err.Error(), "transport error; will retry"),
 		}
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer resp.Body.Close() //nolint:errcheck // best-effort close on HTTP response body
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -315,7 +315,7 @@ func (c *Client) verbosef(format string, args ...any) {
 	if !c.options.Verbose || c.options.ErrOut == nil {
 		return
 	}
-	_, _ = fmt.Fprintf(c.options.ErrOut, "[octo] "+format+"\n", args...)
+	fmt.Fprintf(c.options.ErrOut, "[octo] "+format+"\n", args...) //nolint:errcheck // stderr verbose log
 }
 
 func buildURL(base, path string, query url.Values) (string, error) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -82,7 +82,7 @@ func New(cfg *config.Config, cred *credential.BotCredential, opts Options) *Clie
 		if d, err := time.ParseDuration(opts.Timeout); err == nil {
 			timeout = d
 		} else if opts.ErrOut != nil {
-			fmt.Fprintf(opts.ErrOut, "warning: invalid --timeout %q; using %s\n", opts.Timeout, defaultTimeout)
+			_, _ = fmt.Fprintf(opts.ErrOut, "warning: invalid --timeout %q; using %s\n", opts.Timeout, defaultTimeout)
 		}
 	}
 	return &Client{
@@ -141,7 +141,7 @@ func (c *Client) Do(ctx context.Context, req *Request) ([]byte, error) {
 }
 
 // doWithRetry runs the HTTP request, retrying transient errors with backoff.
-func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binary bool) ([]byte, error) {
+func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool) ([]byte, error) {
 	maxRetries := defaultMaxRetries
 	if c.options.NoRetry {
 		maxRetries = 0
@@ -165,7 +165,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 			}
 		}
 
-		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binary)
+		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binaryResp)
 		if err == nil {
 			return body, nil
 		}
@@ -179,7 +179,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 }
 
 // attempt executes one HTTP round-trip and interprets the response.
-func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binary bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
+func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
@@ -217,7 +217,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 			ExitError: output.ErrNetwork(err.Error(), "transport error; will retry"),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -231,7 +231,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 	// handling (file.download). Any other endpoint returning 3xx is treated
 	// as an unexpected error.
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-		if binary {
+		if binaryResp {
 			loc := resp.Header.Get("Location")
 			env := map[string]any{
 				"url":    loc,
@@ -251,7 +251,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		// Binary/redirect opt-in: don't try to parse as JSON, just describe.
-		if binary {
+		if binaryResp {
 			env := map[string]any{
 				"status":       resp.StatusCode,
 				"content_type": resp.Header.Get("Content-Type"),
@@ -315,7 +315,7 @@ func (c *Client) verbosef(format string, args ...any) {
 	if !c.options.Verbose || c.options.ErrOut == nil {
 		return
 	}
-	fmt.Fprintf(c.options.ErrOut, "[octo] "+format+"\n", args...)
+	_, _ = fmt.Fprintf(c.options.ErrOut, "[octo] "+format+"\n", args...)
 }
 
 func buildURL(base, path string, query url.Values) (string, error) {

--- a/internal/cmdutil/factory_test.go
+++ b/internal/cmdutil/factory_test.go
@@ -154,7 +154,7 @@ func TestFactory_RegistryNilFunc(t *testing.T) {
 func TestFactory_Format_FlagWins(t *testing.T) {
 	f := NewTestFactory()
 	f.Globals.Format = "csv"
-	if got := f.Factory.Format(); got != "csv" {
+	if got := f.Format(); got != "csv" {
 		t.Errorf("Format = %q, want csv", got)
 	}
 }
@@ -162,7 +162,7 @@ func TestFactory_Format_FlagWins(t *testing.T) {
 func TestFactory_Format_ConfigFallback(t *testing.T) {
 	f := NewTestFactory()
 	f.SetConfig(&config.Config{Format: "ndjson"})
-	if got := f.Factory.Format(); got != "ndjson" {
+	if got := f.Format(); got != "ndjson" {
 		t.Errorf("Format = %q, want ndjson from config", got)
 	}
 }

--- a/internal/cmdutil/factory_test.go
+++ b/internal/cmdutil/factory_test.go
@@ -181,7 +181,7 @@ func TestFactory_Format_DefaultsToJSON(t *testing.T) {
 func TestFactory_EmitSuccess_EmitsEnvelope(t *testing.T) {
 	f := NewTestFactory()
 	raw := []byte(`{"id":"t1"}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	var env map[string]any
@@ -200,7 +200,7 @@ func TestFactory_EmitSuccess_EmitsEnvelope(t *testing.T) {
 func TestFactory_EmitSuccess_FlattensPagination(t *testing.T) {
 	f := NewTestFactory()
 	raw := []byte(`{"data":[{"id":"a"}],"pagination":{"has_more":false}}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	var env map[string]any
@@ -218,7 +218,7 @@ func TestFactory_EmitSuccess_JQFilter(t *testing.T) {
 	f := NewTestFactory()
 	f.Globals.JQ = ".data.id"
 	raw := []byte(`{"id":"t1"}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	got := strings.TrimSpace(f.Out.String())
@@ -232,7 +232,7 @@ func TestFactory_EmitSuccess_TableFormat(t *testing.T) {
 	f := NewTestFactory()
 	f.Globals.Format = "table"
 	raw := []byte(`{"data":[{"id":"t1","title":"x"}],"pagination":{}}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	out := f.Out.String()
@@ -245,7 +245,7 @@ func TestFactory_EmitSuccess_NDJSONFormat(t *testing.T) {
 	f := NewTestFactory()
 	f.Globals.Format = "ndjson"
 	raw := []byte(`{"data":[{"id":"a"},{"id":"b"},{"id":"c"}],"pagination":{}}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	lines := strings.Split(strings.TrimSpace(f.Out.String()), "\n")
@@ -258,7 +258,7 @@ func TestFactory_EmitSuccess_CSVFormat(t *testing.T) {
 	f := NewTestFactory()
 	f.Globals.Format = "csv"
 	raw := []byte(`{"data":[{"id":"t1","title":"x"}],"pagination":{}}`)
-	if err := f.Factory.EmitSuccess(raw); err != nil {
+	if err := f.EmitSuccess(raw); err != nil {
 		t.Fatalf("EmitSuccess: %v", err)
 	}
 	if !strings.Contains(f.Out.String(), "id") || !strings.Contains(f.Out.String(), "t1") {
@@ -269,7 +269,7 @@ func TestFactory_EmitSuccess_CSVFormat(t *testing.T) {
 func TestFactory_EmitSuccessWithMeta(t *testing.T) {
 	f := NewTestFactory()
 	meta := output.EnvelopeMeta{RateLimit: json.RawMessage(`{"remaining":5}`)}
-	if err := f.Factory.EmitSuccessWithMeta([]byte(`{"id":"x"}`), meta); err != nil {
+	if err := f.EmitSuccessWithMeta([]byte(`{"id":"x"}`), meta); err != nil {
 		t.Fatalf("EmitSuccessWithMeta: %v", err)
 	}
 	if !strings.Contains(f.Out.String(), "_rate_limit") {
@@ -280,10 +280,10 @@ func TestFactory_EmitSuccessWithMeta(t *testing.T) {
 func TestFactory_EmitError_ExitError(t *testing.T) {
 	f := NewTestFactory()
 	ee := output.ErrValidation("bad input", "try again")
-	if err := f.Factory.EmitError(ee); err != nil {
+	if err := f.EmitError(ee); err != nil {
 		t.Fatalf("EmitError: %v", err)
 	}
-	if !f.Factory.ErrorEmitted {
+	if !f.ErrorEmitted {
 		t.Error("ErrorEmitted should be true after EmitError")
 	}
 	var env map[string]any
@@ -301,14 +301,14 @@ func TestFactory_EmitError_ExitError(t *testing.T) {
 
 func TestFactory_ErrorEmitted_InitiallyFalse(t *testing.T) {
 	f := NewTestFactory()
-	if f.Factory.ErrorEmitted {
+	if f.ErrorEmitted {
 		t.Error("ErrorEmitted should be false on new Factory")
 	}
 }
 
 func TestFactory_EmitError_PlainErrorWrapped(t *testing.T) {
 	f := NewTestFactory()
-	if err := f.Factory.EmitError(errors.New("OCTO_BOT_TOKEN missing")); err != nil {
+	if err := f.EmitError(errors.New("OCTO_BOT_TOKEN missing")); err != nil {
 		t.Fatalf("EmitError: %v", err)
 	}
 	var env map[string]any

--- a/internal/cmdutil/testing.go
+++ b/internal/cmdutil/testing.go
@@ -59,7 +59,7 @@ func (t *TestFactory) SetConfig(cfg *config.Config) {
 
 // SetCredential replaces the credential hook.
 func (t *TestFactory) SetCredential(c *credential.BotCredential) {
-	t.Factory.CredentialFunc = func() (*credential.BotCredential, error) { return c, nil }
+	t.CredentialFunc = func() (*credential.BotCredential, error) { return c, nil }
 }
 
 // stringError is an immutable, allocation-free error type for sentinel

--- a/internal/cmdutil/testing.go
+++ b/internal/cmdutil/testing.go
@@ -49,12 +49,12 @@ func NewTestFactory() *TestFactory {
 
 // SetClient injects a client (usually backed by httptest.Server) for tests.
 func (t *TestFactory) SetClient(c *client.Client) {
-	t.Factory.ClientFunc = func() (*client.Client, error) { return c, nil }
+	t.ClientFunc = func() (*client.Client, error) { return c, nil }
 }
 
 // SetConfig replaces the config hook.
 func (t *TestFactory) SetConfig(cfg *config.Config) {
-	t.Factory.ConfigFunc = func() (*config.Config, error) { return cfg, nil }
+	t.ConfigFunc = func() (*config.Config, error) { return cfg, nil }
 }
 
 // SetCredential replaces the credential hook.

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -81,14 +81,14 @@ func writeTable(w io.Writer, v any) error {
 	}
 	headers := tableHeaders(rows)
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, strings.Join(headers, "\t"))
-	fmt.Fprintln(tw, strings.Join(repeat("---", len(headers)), "\t"))
+	_, _ = fmt.Fprintln(tw, strings.Join(headers, "\t"))
+	_, _ = fmt.Fprintln(tw, strings.Join(repeat("---", len(headers)), "\t"))
 	for _, row := range rows {
 		cols := make([]string, len(headers))
 		for i, h := range headers {
 			cols[i] = renderCell(row[h])
 		}
-		fmt.Fprintln(tw, strings.Join(cols, "\t"))
+		_, _ = fmt.Fprintln(tw, strings.Join(cols, "\t"))
 	}
 	return tw.Flush()
 }

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -81,14 +81,14 @@ func writeTable(w io.Writer, v any) error {
 	}
 	headers := tableHeaders(rows)
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, strings.Join(headers, "\t"))
-	_, _ = fmt.Fprintln(tw, strings.Join(repeat("---", len(headers)), "\t"))
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))           //nolint:errcheck // tabwriter buffered write
+	fmt.Fprintln(tw, strings.Join(repeat("---", len(headers)), "\t")) //nolint:errcheck // tabwriter buffered write
 	for _, row := range rows {
 		cols := make([]string, len(headers))
 		for i, h := range headers {
 			cols[i] = renderCell(row[h])
 		}
-		_, _ = fmt.Fprintln(tw, strings.Join(cols, "\t"))
+		fmt.Fprintln(tw, strings.Join(cols, "\t")) //nolint:errcheck // tabwriter buffered write
 	}
 	return tw.Flush()
 }

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -81,7 +81,7 @@ func writeTable(w io.Writer, v any) error {
 	}
 	headers := tableHeaders(rows)
 	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, strings.Join(headers, "\t"))           //nolint:errcheck // tabwriter buffered write
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))                     //nolint:errcheck // tabwriter buffered write
 	fmt.Fprintln(tw, strings.Join(repeat("---", len(headers)), "\t")) //nolint:errcheck // tabwriter buffered write
 	for _, row := range rows {
 		cols := make([]string, len(headers))


### PR DESCRIPTION
Pin `golangci/golangci-lint-action@v6` to `@1e7e51e771db61008b38414a730f564565cf7c20` (v9.2.0 SHA). All other Go repos already use this reference.