### PR TITLE
chore: add @Mininglamp-OSS/cli-maintainers to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS — unified team ownership
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @Mininglamp-OSS/maintainers
+* @Mininglamp-OSS/maintainers @Mininglamp-OSS/cli-maintainers


### PR DESCRIPTION
Update `.github/CODEOWNERS` to add sub-maintainer team `@Mininglamp-OSS/cli-maintainers` alongside the existing `@Mininglamp-OSS/maintainers`.

Future member changes only require updating team membership — no CODEOWNERS edits needed.

/cc @lml2468