### PR TITLE
fix(specs): align bot_api specs and agent docs with the server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (7 domains, 51 operations)
+## Command Structure (7 domains, 48 operations / 51 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, and the cobra-generated `completion`.
 

--- a/docs/octo-cli-design.md
+++ b/docs/octo-cli-design.md
@@ -167,9 +167,8 @@ Notes:
 
 Flags:
 - register: --data (JSON, registration payload)
-- set-commands: --data (JSON, command list)
+- set-commands: --data (JSON, body shape: {"commands":[{"command","description"}]})
 - user-info: --uid* (query, required)
-- set-commands: body shape is {"commands":[{"command","description"}]} via --data
 - typing: --channel-id*, --channel-type*, --on-behalf-of
 
 Notes:

--- a/docs/octo-cli-design.md
+++ b/docs/octo-cli-design.md
@@ -13,6 +13,8 @@
 | `app_*` | App Bot | DM only, no group/thread write, no voice |
 | `bf_*` | User Bot | Full access (DM + group + thread + voice) |
 
+> The CLI recognizes the prefix for display only (`octo config show` → `bot_kind`); it does **not** gate commands by bot kind. An App Bot calling a User-Bot-only command sends the request and gets a server-side `FORBIDDEN`.
+
 ---
 
 ## Domain 1: matter (matters service, 17 commands)
@@ -65,7 +67,7 @@ Notes:
 | 21 | `octo message read-receipt` | POST | /v1/bot/readReceipt | Y | Y |
 
 Flags:
-- send: --channel-id*, --channel-type*(uint8), --payload*(JSON map), --stream-no
+- send: --channel-id*, --channel-type*(uint8), --stream-no, --on-behalf-of; payload (object) via --data
 - edit: --message-id*, --message-seq, --channel-id*, --channel-type*, --content-edit*
 - sync: --data (JSON body with channel_id, channel_type, etc.)
 - read-receipt: --channel-id*, --channel-type(default:1), --message-ids*(str[])
@@ -73,7 +75,7 @@ Flags:
 Notes:
 - App Bot sendMessage: checkSendPermission enforces channelType=1 (DM only), requires friend relationship.
 - User Bot sendMessage: DM + group (membership check) + thread (parent group membership check).
-- payload is map[string]interface{} — cannot auto-promote, must use --payload/--data JSON.
+- payload is map[string]interface{} — object fields aren't promoted to flags, so it goes inside --data JSON. payload.type is an integer code (1=Text…; see common.ContentType / octo-messaging skill).
 - sync: App Bot explicitly blocked for group channel type.
 
 ---
@@ -143,7 +145,7 @@ Notes:
 Flags:
 - upload: --file* (multipart), --type(default:"chat"), --path
 - credentials: --filename* (query)
-- presigned: --filename* (query)
+- presigned: --filename*, --fileSize* (query; fileSize in bytes is REQUIRED)
 
 Notes:
 - Upload is multipart form, not JSON body — special handling in engine.
@@ -166,8 +168,9 @@ Notes:
 Flags:
 - register: --data (JSON, registration payload)
 - set-commands: --data (JSON, command list)
-- user-info: --uid (query)
-- typing: --channel-id*, --channel-type*
+- user-info: --uid* (query, required)
+- set-commands: body shape is {"commands":[{"command","description"}]} via --data
+- typing: --channel-id*, --channel-type*, --on-behalf-of
 
 Notes:
 - register: NOT behind authBot middleware. Routes by token prefix (app_ → registerAppBot, bf_ → registerUserBot). Both supported.

--- a/internal/registry/specs/bot.json
+++ b/internal/registry/specs/bot.json
@@ -157,7 +157,8 @@
                 "required": ["channel_id", "channel_type"],
                 "properties": {
                   "channel_id": { "type": "string" },
-                  "channel_type": { "type": "integer" }
+                  "channel_type": { "type": "integer" },
+                  "on_behalf_of": { "type": "string", "description": "OBO: send the typing indicator as this user persona" }
                 }
               }
             }

--- a/internal/registry/specs/file.json
+++ b/internal/registry/specs/file.json
@@ -110,7 +110,8 @@
         "summary": "Get a presigned PUT URL for direct upload",
         "x-octo-risk": "read",
         "parameters": [
-          { "name": "filename", "in": "query", "required": true, "schema": { "type": "string" } }
+          { "name": "filename", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "fileSize", "in": "query", "required": true, "schema": { "type": "integer", "format": "int64", "minimum": 1 }, "description": "file size in bytes; required, must be a positive integer within the server max" }
         ],
         "responses": {
           "200": {
@@ -126,7 +127,9 @@
                     "contentType": { "type": "string" },
                     "key": { "type": "string" },
                     "expiresIn": { "type": "integer" },
-                    "expiredTime": { "type": "integer" }
+                    "expiredTime": { "type": "integer" },
+                    "maxFileSize": { "type": "integer", "format": "int64", "description": "echoed fileSize (bytes) signed into the PUT Content-Length" },
+                    "contentDisposition": { "type": "string", "description": "present when set; must be echoed verbatim on the PUT or the gateway rejects with 403" }
                   }
                 }
               }

--- a/internal/registry/specs/message.json
+++ b/internal/registry/specs/message.json
@@ -26,7 +26,8 @@
                   "channel_id": { "type": "string" },
                   "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
                   "stream_no": { "type": "string", "description": "optional stream session identifier" },
-                  "payload": { "type": "object", "description": "message payload (content, type, mention, etc.)" }
+                  "on_behalf_of": { "type": "string", "description": "OBO: send as this user persona; requires an active OBO grant + channel scope" },
+                  "payload": { "type": "object", "description": "message payload (content, type, mention, etc.). Pass via --data (object, not a flag)." }
                 }
               }
             }
@@ -40,7 +41,8 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message_id": { "type": "string" },
+                    "client_msg_no": { "type": "string", "description": "client message number echoed back by the server" },
+                    "message_id": { "type": "integer", "format": "int64", "description": "int64; stringify it when passing to message.edit" },
                     "message_seq": { "type": "integer" }
                   }
                 }

--- a/skills/octo-files/SKILL.md
+++ b/skills/octo-files/SKILL.md
@@ -19,9 +19,9 @@ Two small domains are covered here because they share a base URL (`$OCTO_API_BAS
 
 ```bash
 octo file upload      --file ./report.pdf [--type chat] [--path subdir/]
-octo file download    <path> --format json > saved.bin      # see note below
+octo file download    <path> --format json > saved.bin      # <path> = storage key (no bucket prefix), see note below
 octo file credentials --filename report.pdf
-octo file presigned   --filename report.pdf
+octo file presigned   --filename report.pdf --fileSize 1048576   # --fileSize (bytes) is REQUIRED
 ```
 
 ### `upload` — multipart form
@@ -50,22 +50,23 @@ octo file download /chat/2026/05/abc123.png --jq '.data.url' | xargs curl -o out
 For files too large for multipart, ask the backend for a presigned target and upload directly:
 
 ```bash
-cred=$(octo file presigned --filename big.zip)
+size=$(wc -c < big.zip)                                       # fileSize is REQUIRED (bytes)
+cred=$(octo file presigned --filename big.zip --fileSize "$size")
 url=$(jq  -r '.data.uploadUrl'   <<<"$cred")
 ctype=$(jq -r '.data.contentType' <<<"$cred")
 curl -X PUT -T big.zip -H "Content-Type: $ctype" "$url"
 ```
 
-`file presigned` returns `{uploadUrl, downloadUrl, method, contentType, key, expiresIn, expiredTime}` — a one-shot signed URL. `file credentials` returns STS-style temporary credentials (`{bucket, region, key, credentials:{tmpSecretId, tmpSecretKey, sessionToken}, cdnBaseUrl, ...}`) for SDK-driven uploads. Pick the shape the backend gives you.
+`file presigned` **requires `--fileSize` (bytes)** — the size is signed into the PUT Content-Length, so a missing/oversized value is rejected (`HTTP 400 fileSize 参数必填`). It returns `{method, uploadUrl, downloadUrl, contentType, key, expiresIn, expiredTime, maxFileSize, [contentDisposition]}` — a one-shot signed URL (echo `contentDisposition` verbatim on the PUT if present). `file credentials` returns STS-style temporary credentials (`{bucket, region, key, credentials:{tmpSecretId, tmpSecretKey, sessionToken}, startTime, expiredTime, cdnBaseUrl}`) for SDK-driven uploads. Pick the shape the backend gives you.
 
 ## 2. Bot housekeeping
 
 ```bash
-octo bot register       --data '{...registration payload...}'
-octo bot set-commands   --data '[{"name":"fix","desc":"create a matter"}, ...]'
-octo bot user-info      [--uid <uid>]      # no uid → info about *this* bot
-octo bot space-members                      # paginated (100 cap typical)
-octo bot typing         --channel-id <cid> --channel-type 1
+octo bot register       [--data '{"agent_platform":"…","agent_version":"…","plugin_version":"…"}']
+octo bot set-commands   --data '{"commands":[{"command":"fix","description":"create a matter"}]}'
+octo bot user-info      --uid <uid>         # --uid is REQUIRED; returns {uid,name,avatar} for that user
+octo bot space-members  [--keyword <q>]     # members of the bot's space (limit cap 200)
+octo bot typing         --channel-id <cid> --channel-type 1 [--on-behalf-of <uid>]
 octo bot heartbeat
 ```
 
@@ -75,10 +76,12 @@ octo bot heartbeat
 
 Use `bot register` exactly once per bot lifecycle (publish), then use `bot set-commands` to advertise slash-command metadata.
 
-### `user-info` gives you the owner_uid
+### Get the owner_uid from `bot register`
+
+`bot user-info` needs `--uid` and returns only `{uid, name, avatar}` — it does **not** carry `owner_uid`. The bot's `owner_uid` comes from `bot register`:
 
 ```bash
-owner=$(octo bot user-info --jq '.data.owner_uid')
+owner=$(octo bot register --jq '.data.owner_uid')
 ```
 
 This is the value `matter extract` requires as `creator_uid` (see `octo-matter` skill §6).

--- a/skills/octo-files/SKILL.md
+++ b/skills/octo-files/SKILL.md
@@ -50,14 +50,15 @@ octo file download /chat/2026/05/abc123.png --jq '.data.url' | xargs curl -o out
 For files too large for multipart, ask the backend for a presigned target and upload directly:
 
 ```bash
-size=$(wc -c < big.zip)                                       # fileSize is REQUIRED (bytes)
+size=$(stat -f%z big.zip 2>/dev/null || stat -c%s big.zip)    # fileSize in bytes (REQUIRED; no padding)
 cred=$(octo file presigned --filename big.zip --fileSize "$size")
-url=$(jq  -r '.data.uploadUrl'   <<<"$cred")
-ctype=$(jq -r '.data.contentType' <<<"$cred")
-curl -X PUT -T big.zip -H "Content-Type: $ctype" "$url"
+url=$(jq   -r '.data.uploadUrl'                   <<<"$cred")
+ctype=$(jq -r '.data.contentType'                 <<<"$cred")
+cdisp=$(jq -r '.data.contentDisposition // empty' <<<"$cred")
+curl -X PUT -T big.zip -H "Content-Type: $ctype" ${cdisp:+-H "Content-Disposition: $cdisp"} "$url"
 ```
 
-`file presigned` **requires `--fileSize` (bytes)** — the size is signed into the PUT Content-Length, so a missing/oversized value is rejected (`HTTP 400 fileSize 参数必填`). It returns `{method, uploadUrl, downloadUrl, contentType, key, expiresIn, expiredTime, maxFileSize, [contentDisposition]}` — a one-shot signed URL (echo `contentDisposition` verbatim on the PUT if present). `file credentials` returns STS-style temporary credentials (`{bucket, region, key, credentials:{tmpSecretId, tmpSecretKey, sessionToken}, startTime, expiredTime, cdnBaseUrl}`) for SDK-driven uploads. Pick the shape the backend gives you.
+`file presigned` **requires `--fileSize` (bytes)** — the size is signed into the PUT Content-Length, so a missing/oversized value is rejected (`HTTP 400` — fileSize is required). It returns `{method, uploadUrl, downloadUrl, contentType, key, expiresIn, expiredTime, maxFileSize, [contentDisposition]}` — a one-shot signed URL (echo `contentDisposition` verbatim on the PUT if present). `file credentials` returns STS-style temporary credentials (`{bucket, region, key, credentials:{tmpSecretId, tmpSecretKey, sessionToken}, startTime, expiredTime, cdnBaseUrl}`) for SDK-driven uploads. Pick the shape the backend gives you.
 
 ## 2. Bot housekeeping
 
@@ -78,10 +79,10 @@ Use `bot register` exactly once per bot lifecycle (publish), then use `bot set-c
 
 ### Get the owner_uid from `bot register`
 
-`bot user-info` needs `--uid` and returns only `{uid, name, avatar}` — it does **not** carry `owner_uid`. The bot's `owner_uid` comes from `bot register`:
+`bot user-info` needs `--uid` and returns only `{uid, name, avatar}` — it does **not** carry `owner_uid`. The bot's `owner_uid` comes from the one-time `bot register` at publish; capture it then and cache it (env/config) rather than re-registering:
 
 ```bash
-owner=$(octo bot register --jq '.data.owner_uid')
+owner=$(octo bot register --jq '.data.owner_uid')   # capture once at publish, then cache
 ```
 
 This is the value `matter extract` requires as `creator_uid` (see `octo-matter` skill §6).

--- a/skills/octo-matter/SKILL.md
+++ b/skills/octo-matter/SKILL.md
@@ -93,7 +93,7 @@ octo matter extract --data '{
 }'
 ```
 
-**Critical**: a bot must set `creator_uid` to its **owner_uid**, not its own bot_uid — the backend rejects the request otherwise. Retrieve the owner from `octo bot register --jq '.data.owner_uid'` (NOT `bot user-info`, which requires a `--uid` and returns only `{uid,name,avatar}` — no owner_uid).
+**Critical**: a bot must set `creator_uid` to its **owner_uid**, not its own bot_uid — the backend rejects the request otherwise. Capture `owner_uid` from the one-time `octo bot register` response at publish (`--jq '.data.owner_uid'`) and cache it (env/config); reuse the cached value rather than re-registering on every extract. Note `bot user-info` does not return it (it needs `--uid` and returns only `{uid,name,avatar}`).
 
 ## 7. Common patterns
 

--- a/skills/octo-matter/SKILL.md
+++ b/skills/octo-matter/SKILL.md
@@ -93,7 +93,7 @@ octo matter extract --data '{
 }'
 ```
 
-**Critical**: a bot must set `creator_uid` to its **owner_uid**, not its own bot_uid — the backend rejects the request otherwise. Retrieve the owner from `octo bot user-info`.
+**Critical**: a bot must set `creator_uid` to its **owner_uid**, not its own bot_uid — the backend rejects the request otherwise. Retrieve the owner from `octo bot register --jq '.data.owner_uid'` (NOT `bot user-info`, which requires a `--uid` and returns only `{uid,name,avatar}` — no owner_uid).
 
 ## 7. Common patterns
 

--- a/skills/octo-messaging/SKILL.md
+++ b/skills/octo-messaging/SKILL.md
@@ -24,15 +24,17 @@ Before attempting a write, confirm the token type with `octo config show` — Ap
 ## 1. `message` — 4 commands
 
 ```bash
-# Send a message. payload is a JSON object and cannot be auto-promoted — use --data.
+# Send a message. payload is a JSON object (not a flag) — pass it inside --data.
+# payload.type is an INTEGER code (1=text); see the payload table below.
 octo message send --channel-id <cid> --channel-type 1 \
-  --data '{"payload":{"type":"text","content":"hello"}}' \
-  [--stream-no <n>]
+  --data '{"payload":{"type":1,"content":"hello"}}' \
+  [--stream-no <n>] [--on-behalf-of <uid>]
 
-# Edit by (message-id, channel-id, channel-type); content-edit is the new body.
+# Edit by (message-id, channel-id, channel-type). content-edit is the new
+# content, stored opaquely server-side — carry the new payload, same shape as send.
 octo message edit --message-id <mid> --message-seq <seq> \
   --channel-id <cid> --channel-type <t> \
-  --content-edit '{"type":"text","content":"updated"}'
+  --content-edit '{"type":1,"content":"updated"}'
 
 # Pull history for a channel. Use --data for non-trivial filters.
 octo message sync --data '{"channel_id":"ch_abc","channel_type":1,"limit":50}'
@@ -54,7 +56,31 @@ octo message read-receipt --channel-id <cid> --channel-type 1 \
 
 ### `payload` shape
 
-Message payloads are free-form maps — text, markdown, quote, attachment, etc. — so they **never** auto-promote to a flag. Wrap the payload under the top-level `payload` key and pass the whole body via `--data '{"channel_id":"…","channel_type":1,"payload":{…}}'` (or `--data @file.json`, `--data @-`).
+`payload` is an object (never auto-promoted to a flag). Wrap it under the top-level `payload` key and pass the whole body via `--data '{"channel_id":"…","channel_type":1,"payload":{…}}'` (or `--data @file.json`, `--data @-`).
+
+**`payload.type` is an integer code (NOT a string like `"text"`).** Authoritative source: `common.ContentType` in `octo-lib/common/msg.go` (the server reads it as an int).
+
+Chat content types:
+
+| type | meaning           | common payload fields          |
+|------|-------------------|--------------------------------|
+| 1    | Text              | `content`                      |
+| 2    | Image             | `url, width, height`           |
+| 3    | GIF               | `url, width, height`           |
+| 4    | Voice             | `url, duration`                |
+| 5    | Video             | `url, width, height, duration` |
+| 6    | Location          | `latitude, longitude`          |
+| 7    | Card              | `uid, name`                    |
+| 8    | File              | `url, name, size`              |
+| 11   | MultipleForward   | (merged-forward)               |
+| 12   | VectorSticker     | (sticker)                      |
+| 13   | EmojiSticker      | (emoji sticker)                |
+| 14   | RichText          | (rich text)                    |
+| 16   | InviteJoinOrg     | (org invite)                   |
+
+(System/notification types — 1000+ for group events, 2000 Tip — are server-generated, not sent by bots.) Text example: `{"type":1,"content":"hello"}`.
+
+`--on-behalf-of <uid>` makes `send`/`typing` act as a user persona (OBO) — requires an active OBO grant + channel scope, else the server returns `OBO not authorized`.
 
 ## 2. `group` — 9 commands (5 read + 4 write)
 
@@ -115,8 +141,9 @@ Even though the semantics are "list", the handler is `POST /v1/bot/events` — t
 cursor=0
 while :; do
   batch=$(octo event list --event-id "$cursor" --limit 100)
-  echo "$batch" | jq -c '.data[]' | while read -r ev; do
-    id=$(jq -r '.id' <<<"$ev")
+  # response shape: {ok, data:{status, results:[{event_id, event_type, message{...}}]}}
+  echo "$batch" | jq -c '.data.results[]' | while read -r ev; do
+    id=$(jq -r '.event_id' <<<"$ev")
     process "$ev"
     octo event ack "$id"
     cursor=$id
@@ -135,7 +162,7 @@ done
 | `send` → `permission` on DM                            | No friend relationship; add the bot as a friend first.         |
 | `sync` rejected with `channel-type=2`                  | App Bot cannot sync groups — use User Bot.                     |
 | `VALIDATION_ERROR` on `send`                           | `payload` must be an object, not a string.                     |
-| `event list` returns empty page with `has_more:false`  | No events since the cursor; keep the cursor and poll again.    |
+| `event list` returns `data.results: []`                | No events since the cursor; keep the cursor and poll again.    |
 
 ## 6. Schema lookup
 


### PR DESCRIPTION
## Summary

Align the embedded bot_api OpenAPI specs and the agent `SKILL.md` docs with the
actual octo-server behavior. Headline fix: `octo file presigned` was unusable
because the spec omitted the required `fileSize` query param, so every call
failed with `HTTP 400 fileSize 参数必填`.

## Changes

- **specs/file.json** — `file.presigned`: add the required `fileSize` query
  param; surface `maxFileSize` and `contentDisposition` in the response (the
  gateway signs `fileSize` into the PUT `Content-Length` and rejects a mismatch).
- **specs/message.json** — `message.send`: add `on_behalf_of` (OBO) to the
  request, correct `message_id` to `int64`, and add `client_msg_no` to the
  response.
- **specs/bot.json** — `bot.typing`: add `on_behalf_of` (OBO) to the request.
- **skills/octo-{files,matter,messaging}/SKILL.md, docs/octo-cli-design.md,
  CLAUDE.md** — correct the agent docs and command reference to match the
  server: `payload.type` integer codes 1–16 (authoritative source
  `common.ContentType`), `set-commands` request shape, presigned `--fileSize`,
  `user-info --uid` required with `owner_uid` sourced from `bot register`,
  event-poll `data.results[]`, and the 48-operation / 51-command count.

## Motivation

The specs are hand-maintained and octo-server has no OpenAPI export, so they
drift from the server. A field-by-field audit of every bot_api operation
against the server source plus live E2E found 6 inconsistencies: `file.presigned`
was a hard break (HTTP 400), the rest were request/response schema mismatches
that would mislead an agent. No tracking issue — surfaced during the audit.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `go build ./...` passes
- Live E2E against the bot_api server for every touched operation, including a
  re-run of `file presigned` confirming the HTTP 400 is resolved.
- Note: the spec/server contract has no automated test yet (an OpenAPI
  validation test is tracked as a follow-up); these changes are validated at the
  integration boundary via E2E.

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [ ] New commands added to README Command Reference table — N/A (no new commands)
- [x] CLAUDE.md command list updated if commands changed (op/command count corrected)
- [ ] New features include tests — N/A (spec/doc fix, not a feature; validated by E2E)
- [x] No unrelated changes included
