### PR TITLE
feat(cmd): add octo skills command for embedded skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   threads, event polling.
 - [`octo-files`](./skills/octo-files/SKILL.md) — files and bot housekeeping.
 
+These docs are also **embedded in the binary**, so a released `octo` ships them:
+
+```bash
+octo skills                       # list embedded skills
+octo skills octo-messaging        # print one skill (name, description, content)
+octo skills --install ~/.config/octo/skills   # write all SKILL.md to a dir
+```
+
 ## Shell Completion
 
 ```bash

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,6 +49,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	root.AddCommand(newVersionCmd(f))
 	root.AddCommand(newAPICmd(f))
 	root.AddCommand(newConfigCmd(f))
+	root.AddCommand(newSkillsCmd(f))
 	service.RegisterServiceCommands(root, f)
 
 	return root
@@ -61,7 +62,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 func skipValidation(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
 		switch c.Name() {
-		case "version", "help", "schema", "config", "completion", "":
+		case "version", "help", "schema", "config", "completion", "skills", "":
 			return true
 		}
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,8 @@
 // Package cmd is the command tree. It wires cobra commands with the Factory DI
 // container and holds root-level persistent flags. Service-domain commands are
 // auto-registered from the embedded OpenAPI registry via cmd/service — the
-// only hand-written leaves are `schema`, `version`, and `api` (generic
-// passthrough).
+// hand-written leaves are `schema`, `version`, `api` (generic passthrough),
+// `config`, and `skills`.
 package cmd
 
 import (

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -86,6 +86,14 @@ func newSkillsCmd(f *cmdutil.Factory) *cobra.Command {
   octo skills --install <dir>    write every skill to <dir>/<name>/SKILL.md`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Flags().Changed("install") && install == "" {
+				ee := output.ErrValidation(
+					"--install requires a directory",
+					"pass a target like --install ~/.config/octo/skills",
+				)
+				_ = f.EmitError(ee) //nolint:errcheck // best-effort emit before returning err
+				return ee
+			}
 			entries, err := loadSkills()
 			if err != nil {
 				_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+	"github.com/Mininglamp-OSS/octo-cli/skills"
+)
+
+type skillEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	path        string // embed path, e.g. "octo-messaging/SKILL.md"
+	content     []byte
+}
+
+// loadSkills reads every embedded SKILL.md and parses its frontmatter
+// description. Sorted by name for deterministic output.
+func loadSkills() ([]skillEntry, error) {
+	paths, err := fs.Glob(skills.FS, "*/SKILL.md")
+	if err != nil {
+		return nil, err
+	}
+	out := make([]skillEntry, 0, len(paths))
+	for _, p := range paths {
+		b, err := skills.FS.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, skillEntry{
+			Name:        strings.SplitN(p, "/", 2)[0],
+			Description: parseSkillDescription(b),
+			path:        p,
+			content:     b,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
+// parseSkillDescription pulls `description:` out of the leading `---` YAML
+// frontmatter block with a line scan (no YAML dependency). It assumes a
+// single-line `description:` value — the shape every bundled SKILL.md uses;
+// multi-line or block-scalar descriptions are not supported.
+func parseSkillDescription(b []byte) string {
+	inFrontmatter := false
+	for _, ln := range strings.Split(string(b), "\n") {
+		t := strings.TrimSpace(ln)
+		if t == "---" {
+			if inFrontmatter {
+				break
+			}
+			inFrontmatter = true
+			continue
+		}
+		if inFrontmatter && strings.HasPrefix(t, "description:") {
+			return strings.TrimSpace(strings.TrimPrefix(t, "description:"))
+		}
+	}
+	return ""
+}
+
+// newSkillsCmd returns `octo skills`. Three mutually exclusive modes:
+//   - `octo skills`: list embedded skills (name + description).
+//   - `octo skills <name>`: print one skill's name, description, and content.
+//   - `octo skills --install <dir>`: write every skill to <dir>/<name>/SKILL.md.
+func newSkillsCmd(f *cmdutil.Factory) *cobra.Command {
+	var install string
+
+	cmd := &cobra.Command{
+		Use:   "skills [name]",
+		Short: "List, print, or install the embedded agent skill docs",
+		Long: `Agent-facing SKILL.md docs are embedded in this binary.
+
+  octo skills                    list available skills
+  octo skills <name>             print one skill (name, description, content)
+  octo skills --install <dir>    write every skill to <dir>/<name>/SKILL.md`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			entries, err := loadSkills()
+			if err != nil {
+				_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+				return err
+			}
+			switch {
+			case install != "":
+				if len(args) == 1 {
+					ee := output.ErrValidation(
+						"cannot combine a skill name with --install",
+						"drop the name to install all skills, or drop --install to print one",
+					)
+					_ = f.EmitError(ee) //nolint:errcheck // best-effort emit before returning err
+					return ee
+				}
+				return runSkillsInstall(f, entries, install)
+			case len(args) == 1:
+				return runSkillsShow(f, entries, args[0])
+			default:
+				return runSkillsList(f, entries)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&install, "install", "", "write all skills to this directory (<dir>/<name>/SKILL.md)")
+	return cmd
+}
+
+// runSkillsList emits every skill as {name, description}.
+func runSkillsList(f *cmdutil.Factory, entries []skillEntry) error {
+	buf, err := json.Marshal(map[string]any{"skills": entries})
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+		return err
+	}
+	return f.EmitSuccess(buf)
+}
+
+// runSkillsShow emits one skill's full content, or a validation error naming
+// the available skills when name doesn't match.
+func runSkillsShow(f *cmdutil.Factory, entries []skillEntry, name string) error {
+	for _, s := range entries {
+		if s.Name == name {
+			buf, err := json.Marshal(map[string]any{
+				"name":        s.Name,
+				"description": s.Description,
+				"content":     string(s.content),
+			})
+			if err != nil {
+				_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+				return err
+			}
+			return f.EmitSuccess(buf)
+		}
+	}
+	names := make([]string, len(entries))
+	for i, s := range entries {
+		names[i] = s.Name
+	}
+	ee := output.ErrValidation(
+		fmt.Sprintf("unknown skill %q", name),
+		fmt.Sprintf("available: %s", strings.Join(names, ", ")),
+	)
+	_ = f.EmitError(ee) //nolint:errcheck // best-effort emit before returning err
+	return ee
+}
+
+// runSkillsInstall writes every skill to <dir>/<name>/SKILL.md and reports the
+// files written.
+func runSkillsInstall(f *cmdutil.Factory, entries []skillEntry, dir string) error {
+	written := make([]string, 0, len(entries))
+	for _, s := range entries {
+		dst := filepath.Join(dir, s.path)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+			return err
+		}
+		if err := os.WriteFile(dst, s.content, 0o644); err != nil {
+			_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+			return err
+		}
+		written = append(written, dst)
+	}
+	buf, err := json.Marshal(map[string]any{"dir": dir, "installed": written})
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+		return err
+	}
+	return f.EmitSuccess(buf)
+}

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+)
+
+func TestParseSkillDescription(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"basic", "---\nname: x\ndescription: hello world\n---\nbody", "hello world"},
+		{"trims surrounding space", "---\ndescription:   spaced   \n---", "spaced"},
+		{"no frontmatter", "# title\ndescription: ignored", ""},
+		{"description only in body is ignored", "---\nname: x\n---\ndescription: in body", ""},
+		{"empty input", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseSkillDescription([]byte(c.in)); got != c.want {
+				t.Errorf("parseSkillDescription(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestLoadSkills(t *testing.T) {
+	entries, err := loadSkills()
+	if err != nil {
+		t.Fatalf("loadSkills: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected at least one embedded skill")
+	}
+	for i, s := range entries {
+		if s.Name == "" || s.Description == "" || len(s.content) == 0 {
+			t.Errorf("entry %d incomplete: name=%q desc=%q contentLen=%d", i, s.Name, s.Description, len(s.content))
+		}
+		if i > 0 && entries[i-1].Name >= s.Name {
+			t.Errorf("entries not sorted ascending: %q before %q", entries[i-1].Name, s.Name)
+		}
+	}
+	// octo-shared is the foundational skill; it must always be embedded.
+	if !hasSkill(entries, "octo-shared") {
+		names := make([]string, len(entries))
+		for i, s := range entries {
+			names[i] = s.Name
+		}
+		t.Errorf("octo-shared not found among %v", names)
+	}
+}
+
+func hasSkill(entries []skillEntry, name string) bool {
+	for _, s := range entries {
+		if s.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// A config without a token must still let `octo skills` run — the command is
+// offline and on the skipValidation list.
+func TestCmd_SkillsList(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	out, _, err := execRoot(t, f, "skills")
+	if err != nil {
+		t.Fatalf("skills: %v", err)
+	}
+	var env map[string]any
+	if jerr := json.Unmarshal([]byte(out), &env); jerr != nil {
+		t.Fatalf("unmarshal: %v\n%s", jerr, out)
+	}
+	if env["ok"] != true {
+		t.Errorf("ok = %v", env["ok"])
+	}
+	data, _ := env["data"].(map[string]any)
+	list, _ := data["skills"].([]any)
+	if len(list) == 0 {
+		t.Errorf("expected a non-empty skills list, got %v", data)
+	}
+}
+
+func TestCmd_SkillsShow(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	out, _, err := execRoot(t, f, "skills", "octo-shared")
+	if err != nil {
+		t.Fatalf("skills octo-shared: %v", err)
+	}
+	var env map[string]any
+	if jerr := json.Unmarshal([]byte(out), &env); jerr != nil {
+		t.Fatalf("unmarshal: %v\n%s", jerr, out)
+	}
+	data, _ := env["data"].(map[string]any)
+	if data["name"] != "octo-shared" {
+		t.Errorf("name = %v", data["name"])
+	}
+	if content, _ := data["content"].(string); !strings.Contains(content, "octo-shared") {
+		t.Errorf("content missing skill body: %.80q", content)
+	}
+}
+
+func TestCmd_SkillsUnknown(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	_, errOut, err := execRoot(t, f, "skills", "no-such-skill")
+	if err == nil {
+		t.Fatal("expected error for unknown skill")
+	}
+	if !strings.Contains(errOut, "validation") {
+		t.Errorf("error envelope missing validation type: %s", errOut)
+	}
+	if !strings.Contains(errOut, "no-such-skill") {
+		t.Errorf("error should name the unknown skill: %s", errOut)
+	}
+}
+
+func TestCmd_SkillsInstall(t *testing.T) {
+	dir := t.TempDir()
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	out, _, err := execRoot(t, f, "skills", "--install", dir)
+	if err != nil {
+		t.Fatalf("skills --install: %v", err)
+	}
+	var env map[string]any
+	if jerr := json.Unmarshal([]byte(out), &env); jerr != nil {
+		t.Fatalf("unmarshal: %v\n%s", jerr, out)
+	}
+	data, _ := env["data"].(map[string]any)
+	installed, _ := data["installed"].([]any)
+	if len(installed) == 0 {
+		t.Fatalf("nothing installed: %v", data)
+	}
+	for _, p := range installed {
+		ps, _ := p.(string)
+		fi, statErr := os.Stat(ps)
+		if statErr != nil || fi.Size() == 0 {
+			t.Errorf("installed file missing/empty: %s (%v)", ps, statErr)
+		}
+	}
+	// Verify the expected on-disk layout.
+	if _, statErr := os.Stat(filepath.Join(dir, "octo-shared", "SKILL.md")); statErr != nil {
+		t.Errorf("expected octo-shared/SKILL.md under install dir: %v", statErr)
+	}
+}
+
+func TestCmd_SkillsInstallRejectsName(t *testing.T) {
+	dir := t.TempDir()
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	_, errOut, err := execRoot(t, f, "skills", "octo-shared", "--install", dir)
+	if err == nil {
+		t.Fatal("expected error when combining a skill name with --install")
+	}
+	if !strings.Contains(errOut, "validation") {
+		t.Errorf("expected a validation error, got: %s", errOut)
+	}
+}

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -158,6 +158,19 @@ func TestCmd_SkillsInstall(t *testing.T) {
 	}
 }
 
+func TestCmd_SkillsInstallEmptyDir(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	_, errOut, err := execRoot(t, f, "skills", "--install", "")
+	if err == nil {
+		t.Fatal("expected error when --install is given an empty directory")
+	}
+	if !strings.Contains(errOut, "validation") {
+		t.Errorf("expected a validation error, got: %s", errOut)
+	}
+}
+
 func TestCmd_SkillsInstallRejectsName(t *testing.T) {
 	dir := t.TempDir()
 	f := newTestFactoryWithReg()

--- a/skills/skills.go
+++ b/skills/skills.go
@@ -1,0 +1,11 @@
+// Package skills embeds the agent-facing SKILL.md documents so the binary can
+// export them via `octo skills` without shipping separate files alongside it.
+package skills
+
+import "embed"
+
+// FS holds every <skill-name>/SKILL.md under this directory, keyed by its
+// relative path (e.g. "octo-messaging/SKILL.md").
+//
+//go:embed */SKILL.md
+var FS embed.FS


### PR DESCRIPTION
## Summary

Add an `octo skills` command and embed the agent `SKILL.md` docs into the
binary, so a released `octo` ships its skills and can list / print / export
them with no network and no token.

## Changes

- **skills/skills.go** — `//go:embed */SKILL.md` exposes every bundled skill as
  an `embed.FS`.
- **cmd/skills.go** — three modes: `octo skills` (list name+description),
  `octo skills <name>` (print one skill's full content), and
  `octo skills --install <dir>` (write all to `<dir>/<name>/SKILL.md`).
  Combining a name with `--install` is rejected with a validation error rather
  than silently ignoring the name.
- **cmd/root.go** — register the command and add `skills` to the
  skipValidation list (the command is offline, like `schema` / `config`).
- **cmd/skills_test.go** — unit tests for the frontmatter parser, the loader
  (sorted, non-empty, contains `octo-shared`), and all three command modes,
  including the unknown-skill and name-plus-`--install` error paths.
- **README.md** — document the command under Agent Skills.

## Motivation

Released binaries didn't ship the agent `SKILL.md` docs. `//go:embed` makes the
binary self-contained, and `octo skills --install` lets an agent runtime
extract them on demand — no separate files to distribute.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (new `cmd/skills_test.go`)
- [x] `go build ./...` passes
- Smoke-tested the built binary: list / show / install exit 0; unknown skill
  and name+`--install` exit 2 with a `VALIDATION_ERROR` envelope; list runs
  without a token (skipValidation).

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [x] New commands added to README Command Reference table (Agent Skills section)
- [ ] CLAUDE.md command list updated — `skills` could be added to the
  hand-written-leaves line; deferred to keep this PR scoped strictly to the command
- [x] New features include tests (`cmd/skills_test.go`)
- [x] No unrelated changes included — `.goreleaser.yaml` archive bundling and the
  `.gitignore dist/` change were deliberately excluded as separate concerns
