### PR TITLE
feat(cli): withhold the matter domain behind an x-octo-disabled spec flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,14 @@
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
+> **`matter` is temporarily withheld** (backend API not yet stable). The spec
+> stays embedded — `octo schema matter.*` still introspects it — but the command
+> subtree and the `octo-matter` skill are hidden via the `x-octo-disabled` spec
+> flag (`internal/registry/specs/matter.json`) and the skill's `disabled: true`
+> frontmatter. Flip both off to re-enable. The tree below shows the full surface.
+
 ```
-octo matter    create | list | get | update | delete
+octo matter    create | list | get | update | delete        (withheld)
                transition | close | reopen | archive | extract
                assignee add|remove
                channel  link|unlink
@@ -51,7 +57,7 @@ octo version
 
 `octo auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter`, `octo-messaging`, `octo-files`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `matter`  | 14  | Todos/tasks — CRUD, transitions, assignees, channels, timeline |
+| `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 9   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
@@ -84,13 +84,7 @@ curl -fsSL https://raw.githubusercontent.com/Mininglamp-OSS/octo-cli/main/instal
 export OCTO_BOT_TOKEN="bf_your_user_bot_token"
 export OCTO_API_BASE_URL="https://api.example.com"
 
-# Matters (todos/tasks)
-octo matter list --status open --assignee me
-octo matter create --title "Deploy v2.0" --assignee user-123
-octo matter get matter-abc
-octo matter update matter-abc --title "Deploy v2.1"
-octo matter close matter-abc
-octo matter assignee add matter-abc user-456
+# NOTE: the `matter` domain is temporarily withheld (backend API stabilizing).
 
 # Messaging
 octo message send --data '{"chat_id":"chat-1","text":"hi"}'
@@ -108,13 +102,13 @@ octo file download abc123 --jq '.data.url'
 
 # Discover the API — fully offline, specs are embedded.
 octo schema --list              # all operations across all domains
-octo schema --list matter       # operations in one domain
-octo schema matter.create       # request/response schema for one op
+octo schema --list message      # operations in one domain
+octo schema message.send        # request/response schema for one op
 octo config show                # resolved config (token masked)
 
 # Generic passthrough for ops that aren't auto-registered.
-octo api GET  /v1/matters --params '{"status":"open"}'
-octo api POST /v1/matters --data @body.json
+octo api GET  /v1/messages --params '{"chat_id":"chat-1"}'
+octo api POST /v1/messages --data @body.json
 ```
 
 ## Authentication
@@ -190,16 +184,16 @@ Exit codes: `3` auth, `2` validation/config, `1` everything else.
 
 ```bash
 # Dry-run to inspect the resolved request — no side effects.
-octo matter create --title "Hello" --dry-run
+octo message send --data '{"chat_id":"chat-1","text":"Hello"}' --dry-run
 
 # Extract a single field with jq.
-octo matter list --jq '.data[0].id'
+octo group list --jq '.data[0].id'
 
-# Auto-paginate.
-octo matter list --status open --page-all --page-limit 20
+# Auto-paginate any list operation that reports a cursor.
+octo group list --page-all --page-limit 20
 
 # Tabular output for human eyes.
-octo matter list --format table
+octo group list --format table
 ```
 
 ## Agent Skills
@@ -208,7 +202,8 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
 
 - [`octo-shared`](./skills/octo-shared/SKILL.md) — fundamentals (auth,
   output, flags, error taxonomy). Load first.
-- [`octo-matter`](./skills/octo-matter/SKILL.md) — matter (todo/task) domain.
+- `octo-matter` — matter (todo/task) domain. **Temporarily withheld** while the
+  backend API stabilizes (not listed by `octo skills`).
 - [`octo-messaging`](./skills/octo-messaging/SKILL.md) — messages, groups,
   threads, event polling.
 - [`octo-files`](./skills/octo-files/SKILL.md) — files and bot housekeeping.

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -315,7 +315,7 @@ func TestCmd_MissingTokenOnServiceCommand(t *testing.T) {
 	f := newTestFactoryWithReg()
 	f.SetConfig(&config.Config{APIBaseURL: "http://x", Format: "json"}) // no BotToken
 
-	_, _, err := execRoot(t, f, "matter", "list")
+	_, _, err := execRoot(t, f, "event", "list")
 	if err == nil {
 		t.Fatal("expected PersistentPreRunE to reject missing token")
 	}
@@ -419,8 +419,86 @@ func TestSkipValidation(t *testing.T) {
 	}
 
 	// Pick any real service leaf — should NOT skip.
-	matterCmd := findCmd("matter")
-	if skipValidation(matterCmd) {
-		t.Error("matter should NOT skip validation")
+	svcLeaf := findCmd("event", "list")
+	if skipValidation(svcLeaf) {
+		t.Error("service leaf should NOT skip validation")
+	}
+}
+
+// --- x-octo-disabled withholding (matter) ---
+//
+// These lock the three consumption surfaces in place: a disabled service must
+// vanish from the command tree and from global discovery, yet stay reachable
+// for explicit introspection. Without them a refactor could silently re-expose
+// an unstable domain.
+
+func topLevelCmd(root *cobra.Command, name string) *cobra.Command {
+	for _, c := range root.Commands() {
+		if c.Name() == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
+	root := NewRootCmd(newTestFactoryWithReg().Factory)
+	if topLevelCmd(root, "matter") != nil {
+		t.Error("disabled service `matter` must not appear in the command tree")
+	}
+	if topLevelCmd(root, "message") == nil {
+		t.Error("enabled service `message` must still appear")
+	}
+	if topLevelCmd(root, "event") == nil {
+		t.Error("enabled service `event` must still appear")
+	}
+}
+
+func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	out, _, err := execRoot(t, f, "schema", "--list")
+	if err != nil {
+		t.Fatalf("schema --list: %v", err)
+	}
+	var env map[string]any
+	if jerr := json.Unmarshal([]byte(out), &env); jerr != nil {
+		t.Fatalf("unmarshal: %v\n%s", jerr, out)
+	}
+	data, _ := env["data"].(map[string]any)
+
+	for _, s := range data["services"].([]any) {
+		if s == "matter" {
+			t.Error("global schema --list must not list disabled service `matter`")
+		}
+	}
+	for _, op := range data["operations"].([]any) {
+		m, _ := op.(map[string]any)
+		if m["service"] == "matter" {
+			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
+		}
+	}
+}
+
+func TestDisabledServiceStillIntrospectable(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{Format: "json"})
+
+	// Explicit domain listing still resolves.
+	out, _, err := execRoot(t, f, "schema", "--list", "matter")
+	if err != nil {
+		t.Fatalf("schema --list matter: %v", err)
+	}
+	var env map[string]any
+	_ = json.Unmarshal([]byte(out), &env)
+	data, _ := env["data"].(map[string]any)
+	if ops, _ := data["operations"].([]any); len(ops) == 0 {
+		t.Error("explicit `schema --list matter` must still return operations")
+	}
+
+	// Explicit operation lookup still resolves.
+	if _, _, err := execRoot(t, f, "schema", "matter.list"); err != nil {
+		t.Errorf("explicit `schema matter.list` must still resolve: %v", err)
 	}
 }

--- a/cmd/octo/main_test.go
+++ b/cmd/octo/main_test.go
@@ -70,7 +70,7 @@ func TestMain_MissingTokenExitCode(t *testing.T) {
 		t.Fatalf("build: %v", err)
 	}
 
-	cmd := exec.Command(bin, "matter", "list")
+	cmd := exec.Command(bin, "event", "list")
 	// Clear OCTO_BOT_TOKEN / OCTO_BOT_ID and point at an empty credential store
 	// so no profile resolves and Validate trips on the missing token.
 	cmd.Env = append(os.Environ(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,8 +54,33 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	root.AddCommand(newSkillsCmd(f))
 	root.AddCommand(newAuthCmd(f))
 	service.RegisterServiceCommands(root, f)
+	withholdDisabledServices(root, f)
 
 	return root
+}
+
+// withholdDisabledServices removes the command subtree for any service whose
+// spec sets x-octo-disabled (e.g. matter, whose backend API is not yet stable).
+// The spec stays embedded, so `octo schema` and the metadata-driven engine
+// still see it — flip the flag in the spec to re-enable. Done here (after
+// registration) rather than inside RegisterServiceCommands so the engine tests
+// that drive it directly keep their full fixture coverage.
+func withholdDisabledServices(root *cobra.Command, f *cmdutil.Factory) {
+	reg := f.Registry()
+	if reg == nil {
+		return
+	}
+	for _, svc := range reg.ListServices() {
+		if !reg.ServiceDisabled(svc) {
+			continue
+		}
+		for _, c := range root.Commands() {
+			if c.Name() == svc {
+				root.RemoveCommand(c)
+				break
+			}
+		}
+	}
 }
 
 // skipValidation is true for commands that must run without a configured

--- a/cmd/schema.go
+++ b/cmd/schema.go
@@ -74,10 +74,16 @@ func runSchemaList(f *cmdutil.Factory, args []string) error {
 			_ = f.EmitError(ee) //nolint:errcheck // best-effort emit before returning err
 			return ee
 		}
+		// An explicit domain (or operation lookup via runSchemaGet) still
+		// resolves a disabled service — introspection stays available even
+		// when the domain is withheld from the command tree.
 		payload["service"] = svc
 		payload["operations"] = ops
 	} else {
-		payload["operations"] = reg.ListAllOperations()
+		// Global discovery hides disabled domains so agents aren't pointed at
+		// a withheld surface. The registry owns the enabled view.
+		payload["services"] = reg.EnabledServices()
+		payload["operations"] = reg.EnabledOperations()
 	}
 	buf, err := json.Marshal(payload)
 	if err != nil {

--- a/cmd/skills.go
+++ b/cmd/skills.go
@@ -36,6 +36,12 @@ func loadSkills() ([]skillEntry, error) {
 		if err != nil {
 			return nil, err
 		}
+		// Skills marked `disabled: true` in their frontmatter are withheld
+		// (e.g. octo-matter, whose backend API is not yet stable). The file
+		// stays embedded — drop the flag to re-list it.
+		if skillDisabled(b) {
+			continue
+		}
 		out = append(out, skillEntry{
 			Name:        strings.SplitN(p, "/", 2)[0],
 			Description: parseSkillDescription(b),
@@ -67,6 +73,27 @@ func parseSkillDescription(b []byte) string {
 		}
 	}
 	return ""
+}
+
+// skillDisabled reports whether the SKILL.md frontmatter sets `disabled: true`.
+// Uses the same single-line frontmatter scan as parseSkillDescription, and the
+// same "true" truthiness as the spec's x-octo-disabled flag (registry.truthy).
+func skillDisabled(b []byte) bool {
+	inFrontmatter := false
+	for _, ln := range strings.Split(string(b), "\n") {
+		t := strings.TrimSpace(ln)
+		if t == "---" {
+			if inFrontmatter {
+				break
+			}
+			inFrontmatter = true
+			continue
+		}
+		if inFrontmatter && strings.HasPrefix(t, "disabled:") {
+			return strings.TrimSpace(strings.TrimPrefix(t, "disabled:")) == "true"
+		}
+	}
+	return false
 }
 
 // newSkillsCmd returns `octo skills`. Three mutually exclusive modes:

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/skills"
 )
 
 func TestParseSkillDescription(t *testing.T) {
@@ -64,6 +65,21 @@ func hasSkill(entries []skillEntry, name string) bool {
 		}
 	}
 	return false
+}
+
+// octo-matter sets `disabled: true` in its frontmatter — it must drop out of
+// the listing while staying embedded (so re-enabling is just a flag flip).
+func TestLoadSkillsExcludesDisabled(t *testing.T) {
+	entries, err := loadSkills()
+	if err != nil {
+		t.Fatalf("loadSkills: %v", err)
+	}
+	if hasSkill(entries, "octo-matter") {
+		t.Error("disabled skill `octo-matter` must not be listed")
+	}
+	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
+		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)
+	}
 }
 
 // A config without a token must still let `octo skills` run — the command is

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -81,6 +81,47 @@ func (r *Registry) GetSpec(service string) map[string]any {
 	return r.specs[service]
 }
 
+// ServiceDisabled reports the x-octo-disabled extension for a service.
+// Disabled services stay loaded — so schema lookups and the metadata-driven
+// engine still see them — but are withheld from the command tree and the
+// global discovery listing. Flip the flag in the spec to re-enable.
+//
+// The flag is truthy as either a JSON boolean (`true`) or the string
+// `"true"`, matching the skill frontmatter convention so the two surfaces
+// can't drift. ListServices / ListAllOperations are deliberately NOT filtered
+// — use EnabledServices / EnabledOperations for a caller-facing view.
+func (r *Registry) ServiceDisabled(service string) bool {
+	return truthy(r.specs[service]["x-octo-disabled"])
+}
+
+// EnabledServices is ListServices minus any service whose spec sets
+// x-octo-disabled. This is the single source of truth for "what callers
+// should see" — command registration and global discovery both use it so the
+// filter can't be forgotten at one site and applied at another.
+func (r *Registry) EnabledServices() []string {
+	all := r.ListServices()
+	out := make([]string, 0, len(all))
+	for _, s := range all {
+		if !r.ServiceDisabled(s) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// EnabledOperations is ListAllOperations minus operations belonging to a
+// disabled service.
+func (r *Registry) EnabledOperations() []OperationInfo {
+	all := r.ListAllOperations()
+	out := make([]OperationInfo, 0, len(all))
+	for _, op := range all {
+		if !r.ServiceDisabled(op.Service) {
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
 // OperationInfo is the summary view of an operation — what ListOperations
 // and ListAllOperations return. It carries the identifiers and metadata
 // needed to route to and describe the operation without loading its full
@@ -444,4 +485,18 @@ func stringOf(v any) string {
 func boolOf(v any) bool {
 	b, _ := v.(bool)
 	return b
+}
+
+// truthy accepts a JSON value that may be a boolean `true` or the string
+// `"true"`. It exists so the x-octo-disabled flag can't silently no-op when
+// written as a string in a spec — the same rule the skill frontmatter uses.
+func truthy(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return t == "true"
+	default:
+		return false
+	}
 }

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -165,3 +165,77 @@ func operationIDs(ops []OperationInfo) []string {
 	}
 	return out
 }
+
+// matter carries x-octo-disabled in its embedded spec — it must stay loaded
+// (engine + schema introspection depend on it) yet drop out of the
+// caller-facing enabled views.
+
+func TestServiceDisabled(t *testing.T) {
+	r := MustNew()
+	if !r.ServiceDisabled("matter") {
+		t.Error("matter should be disabled (x-octo-disabled in spec)")
+	}
+	if r.ServiceDisabled("message") {
+		t.Error("message should not be disabled")
+	}
+	if r.ServiceDisabled("nosuch") {
+		t.Error("unknown service should report not-disabled, not panic")
+	}
+}
+
+func TestEnabledServicesExcludesDisabledButKeepsLoaded(t *testing.T) {
+	r := MustNew()
+	// Invariant that protects the engine fixture + introspection: the raw
+	// listing still has matter even though the enabled view drops it.
+	if !contains(r.ListServices(), "matter") {
+		t.Fatal("ListServices must still include matter (raw view)")
+	}
+	if contains(r.EnabledServices(), "matter") {
+		t.Error("EnabledServices must exclude matter")
+	}
+	if !contains(r.EnabledServices(), "message") {
+		t.Error("EnabledServices must still include message")
+	}
+}
+
+func TestEnabledOperationsExcludesDisabledButResolvable(t *testing.T) {
+	r := MustNew()
+	for _, op := range r.EnabledOperations() {
+		if op.Service == "matter" {
+			t.Errorf("EnabledOperations leaked a matter op: %s", op.ID)
+		}
+	}
+	// Explicit lookup of a disabled service's op still resolves.
+	if _, ok := r.GetOperation("matter.create"); !ok {
+		t.Error("GetOperation(matter.create) must still resolve for introspection")
+	}
+}
+
+func TestTruthy(t *testing.T) {
+	cases := []struct {
+		in   any
+		want bool
+	}{
+		{true, true},
+		{"true", true},
+		{false, false},
+		{"false", false},
+		{"", false},
+		{nil, false},
+		{1, false},
+	}
+	for _, c := range cases {
+		if got := truthy(c.in); got != c.want {
+			t.Errorf("truthy(%#v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/registry/specs/matter.json
+++ b/internal/registry/specs/matter.json
@@ -6,6 +6,7 @@
     "description": "Matter (task) management. Backend: github.com/dmwork-org/matters."
   },
   "x-octo-service": "matter",
+  "x-octo-disabled": true,
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": true,
   "x-octo-status-values": ["open", "done", "archived"],

--- a/skills/octo-files/SKILL.md
+++ b/skills/octo-files/SKILL.md
@@ -28,7 +28,7 @@ octo file presigned   --filename report.pdf --fileSize 1048576   # --fileSize (b
 
 Unlike every other command, `file upload` sends a multipart `multipart/form-data` body, not JSON. The `--file` flag is **required** and names a local path; `--type` (default `chat`) and `--path` become form text fields. Promoted body flags declared in the spec go in as text fields alongside the binary.
 
-The response envelope carries the returned file descriptor under `data` — use it to build attachment references in `matter timeline add` or `message send`.
+The response envelope carries the returned file descriptor under `data` — use it to build attachment references in `message send`.
 
 ### `download` — returns a presigned URL
 
@@ -85,13 +85,13 @@ Use `bot register` exactly once per bot lifecycle (publish), then use `bot set-c
 owner=$(octo bot register --jq '.data.owner_uid')   # capture once at publish, then cache
 ```
 
-This is the value `matter extract` requires as `creator_uid` (see `octo-matter` skill §6).
+This is the value LLM-backed operations require as `creator_uid` (e.g. the withheld `matter extract`, once the matter domain is re-enabled).
 
 ### `typing` and `heartbeat`
 
 Both are fire-and-forget. `typing` signals an "…is typing" UI state in DM channels. `heartbeat` refreshes bot liveness — call it on a long-running poll loop so the platform knows the bot is alive.
 
-## 3. Common pattern: timeline attachment end-to-end
+## 3. Common pattern: message attachment end-to-end
 
 ```bash
 # 1. Upload the binary.
@@ -99,10 +99,10 @@ up=$(octo file upload --file ./log.txt --type chat)
 url=$(jq -r '.data.url'  <<<"$up")
 name=$(jq -r '.data.name' <<<"$up")
 
-# 2. Attach it to a matter timeline entry.
-octo matter timeline add <matter_id> --data "$(jq -n \
-  --arg u "$url" --arg n "$name" \
-  '{content:"see log", attachments:[{url:$u, name:$n, type:"text/plain"}]}')"
+# 2. Attach it to a message.
+octo message send --data "$(jq -n \
+  --arg c "chat-1" --arg u "$url" --arg n "$name" \
+  '{chat_id:$c, text:"see log", attachments:[{url:$u, name:$n, type:"text/plain"}]}')"
 ```
 
 ## 4. Error recovery

--- a/skills/octo-matter/SKILL.md
+++ b/skills/octo-matter/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octo-matter
 version: 0.4.0
+disabled: true
 description: Matter (todo/task) domain — CRUD, status transitions, assignees, channels, timeline, and AI extract from chat messages. Load after octo-shared.
 metadata:
   requires:

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -11,6 +11,8 @@ metadata:
 
 `octo` is a thin REST client that exposes the Octo ecosystem (matters, messaging, groups, threads, files, bot, events) as a single binary. Every service command is auto-generated from an embedded OpenAPI registry; output is a JSON envelope designed to be parsed by agents.
 
+> **The `matter` domain is temporarily withheld** while its backend API stabilizes — `octo matter ...` is not registered and the `octo-matter` skill is not listed. Do not emit `matter` commands until it is re-enabled. The examples below use other domains.
+
 ## 1. Authentication
 
 Bots authenticate with a bearer token. There is no user login. Two ways to supply it:
@@ -147,9 +149,9 @@ The `hint` field is a one-line next action meant for an agent: follow it literal
 Simple top-level body fields auto-promote to typed flags (strings, integers, booleans, `[]string`). For objects, arrays-of-objects, or when sending a large payload, use `--data`:
 
 ```bash
-octo matter create --title "Fix login" --assignee me --assignee alice
-octo matter create --data '{"title":"Fix login","assignees":["me","alice"]}'
-octo matter create --data @body.json
+octo thread create --chat-id chat-1 --name "design review"
+octo message send --data '{"chat_id":"chat-1","text":"hi"}'
+octo message send --data @body.json
 octo some-cmd --data @-            # read JSON from stdin
 ```
 
@@ -158,21 +160,21 @@ Explicit flags override fields set in `--data`. The `--data` escape hatch exists
 ### Piping with `--jq`
 
 ```bash
-octo matter list --status open --jq '.data[].id' | xargs -I{} octo matter get {}
+octo group list --jq '.data[].id' | xargs -I{} octo group get {}
 ```
 
 ### Paginating
 
 ```bash
-octo matter list --status open --page-all --page-limit 20
+octo group list --page-all --page-limit 20
 ```
 
-The merged output drops `_pagination` — you get a flat `data` array.
+`--page-all` applies to any list operation that reports a cursor in `_pagination`. The merged output drops `_pagination` — you get a flat `data` array.
 
 ### Dry-run for agent self-verification
 
 ```bash
-octo matter create --title foo --dry-run
+octo message send --data '{"chat_id":"chat-1","text":"foo"}' --dry-run
 ```
 
 Prints the exact HTTP request body and URL, emits no side effect.
@@ -183,8 +185,8 @@ The registry is embedded in the binary — no network needed:
 
 ```bash
 octo schema --list                # all services + operation IDs
-octo schema --list matter         # operations in one domain
-octo schema matter.create         # full request/response schema
+octo schema --list message        # operations in one domain
+octo schema message.send          # full request/response schema
 octo config show                  # resolved config (token masked)
 octo auth status                  # active bot identity (whoami)
 octo auth list                    # stored profiles (no tokens)
@@ -193,14 +195,14 @@ octo auth list                    # stored profiles (no tokens)
 When an operation isn't auto-registered yet or you need low-level control:
 
 ```bash
-octo api GET  /api/v1/matters --params '{"status":"open"}'
-octo api POST /api/v1/matters --data @body.json
+octo api GET  /api/v1/messages --params '{"chat_id":"chat-1"}'
+octo api POST /api/v1/messages --data @body.json
 ```
 
 ## 8. Domain skills
 
 Once these fundamentals are understood, load the skill for the domain you need:
 
-- `octo-matter` — matters (todos/tasks), assignees, channels, timeline, AI extract
+- `octo-matter` — matters (todos/tasks), assignees, channels, timeline, AI extract — **temporarily withheld** (backend API stabilizing; not currently loadable)
 - `octo-messaging` — message send/edit/sync/read-receipt, groups, threads, events
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping


### PR DESCRIPTION
## Summary

Temporarily withhold the `matter` command domain from the CLI surface while its
backend API stabilizes, driven by a `x-octo-disabled` flag on the service spec.
The spec stays embedded — introspection and the metadata-driven engine are
unaffected — and re-enabling is a one-line flag flip.

## Changes

**Mechanism — `x-octo-disabled` (spec-driven, not hardcoded to matter)**
- `internal/registry/specs/matter.json`: top-level `"x-octo-disabled": true`.
- `internal/registry/loader.go`: `ServiceDisabled` (truthy = bool `true` or
  string `"true"`, shared with the skill convention) plus `EnabledServices` /
  `EnabledOperations` as the single caller-facing view. `ListServices` /
  `ListAllOperations` are deliberately left unfiltered so the engine fixture and
  explicit introspection still see matter.

**Presentation layers (honour the flag)**
- `cmd/root.go`: `NewRootCmd` drops disabled service subtrees *after*
  registration, so `octo matter ...` disappears from help/completion. Done after
  `RegisterServiceCommands` so the engine tests that drive it directly keep their
  full matter fixture.
- `cmd/schema.go`: global `schema --list` uses the enabled views; explicit
  `schema --list matter` / `schema matter.list` still resolve (read-only
  introspection preserved).
- `cmd/skills.go` + `skills/octo-matter/SKILL.md`: `disabled: true` frontmatter
  removes octo-matter from list/print/install; the file stays embedded.

**Tests**
- New regression tests lock all three surfaces (command tree absent, global list
  hidden, explicit introspection preserved, skill unlisted) plus the registry
  enabled-view invariants and `truthy`. Mutation-checked: flipping the flag off
  makes the guards fail.
- Three existing auth-gate tests swap their incidental `matter list` fixture to
  `event list`.

**Docs**
- README / CLAUDE.md annotate matter as withheld; octo-shared / octo-files swap
  runnable `octo matter` examples to live domains.

## Motivation

The matter backend API is not yet stable; offering `octo matter ...` to agents
now risks them building on a moving surface. This withholds it cleanly and
reversibly without removing the spec — which is also the engine's primary test
fixture, so a hard removal would gut loader/service coverage and the matter-only
transition aliases.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `go build ./...` passes
- Manual: `octo --help` has no `matter`; `octo matter list` exits 2;
  `octo skills` excludes octo-matter; `octo schema matter.list` still resolves.

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [x] New commands added to README Command Reference table — N/A (no new commands; matter annotated as withheld)
- [x] CLAUDE.md command list updated
- [x] New features include tests
- [x] No unrelated changes included

> Re-enable by clearing `x-octo-disabled` in `matter.json` and `disabled` in the
> octo-matter skill frontmatter.