### PR TITLE
feat(thread): remove the destructive thread.delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- `octo thread delete` — withdrew the thread-deletion command. Threads expose no
+  bot-accessible archive or soft-close path, so a hard delete was inconsistent
+  with the convention that bots get no destructive operations. The backend route
+  is untouched; only the CLI command and its `thread.delete` spec entry are
+  removed. Command/operation totals drop 51/48 → 50/47.
+
 ## [0.4.0] — 2026-05
 
 ### Architectural overhaul — metadata-driven command tree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is untouched; only the CLI command and its `thread.delete` spec entry are
   removed. Command/operation totals drop 51/48 → 50/47.
 
+### Changed
+- Service-domain parent commands (`octo thread`, `octo group`, `octo file`, …)
+  now reject unknown subcommands with `unknown subcommand %q for %q` and exit 2
+  instead of silently printing help and exiting 0. Required by the `thread
+  delete` removal above so automation can detect a missing operation; also
+  catches typos like `octo group lisst`. Parent help (`octo thread`,
+  `octo thread --help`) is unchanged and still works without a token; only
+  leaf operations require authentication.
+
 ## [0.4.0] — 2026-05
 
 ### Architectural overhaul — metadata-driven command tree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (7 domains, 48 operations / 51 commands incl. 3 matter transition aliases)
+## Command Structure (7 domains, 47 operations / 50 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -41,7 +41,7 @@ octo matter    create | list | get | update | delete        (withheld)
 octo message   send | edit | sync | read-receipt
 octo group     list | get | members | md-get | md-update
                create | update | member-add | member-remove       (User Bot only)
-octo thread    create | list | get | delete | members
+octo thread    create | list | get | members
                join | leave | md-get | md-update                  (User Bot only)
 octo file      upload | download | credentials | presigned
 octo bot       register | set-commands | user-info | space-members | typing | heartbeat

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Key properties:
 |-----------|-----|----------------------------------------------------------------|
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
-| `thread`  | 9   | Threads — create, list, get, members, join/leave, metadata     |
+| `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
 | `message` | 4   | Messaging — send, edit, sync, read-receipt                     |
 | `file`    | 4   | Files — upload, download, credentials, presigned URLs          |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 48 operations
+octo-cli is **metadata-driven**. The entire command tree — 47 operations
 across 7 domains — is auto-registered at startup from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,13 @@ func withholdDisabledServices(root *cobra.Command, f *cmdutil.Factory) {
 // `octo auth`, and cobra's generated `completion`). Walks the parent chain so
 // leaves like `config show` match through their parent.
 func skipValidation(cmd *cobra.Command) bool {
+	// Per-command annotation, deliberately NOT inherited through the parent
+	// chain: service parents (`octo thread`, `octo group`, …) opt out of the
+	// auth gate so their help / unknown-subcommand path works without a token,
+	// but their leaf operations (`octo thread create …`) must still authenticate.
+	if cmd.Annotations["skipValidation"] == "true" {
+		return true
+	}
 	for c := cmd; c != nil; c = c.Parent() {
 		switch c.Name() {
 		case "version", "help", "schema", "config", "completion", "skills", "auth", "":

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+// TestNewRootCmd_ParentCommandSkipAuthAndRejectUnknown drives the real
+// NewRootCmd so PersistentPreRunE and WrapCLIError are in the loop. Service
+// parents must:
+//  1. skip the auth gate so help works zero-config, and
+//  2. reject unknown subcommands with a validation envelope (not auth_error).
+//
+// Regression guard for PR #20 review: the parent-`RunE` change made parents
+// Runnable() and routed them through the auth gate, turning
+// `octo thread bogus` into UNAUTHORIZED instead of "unknown subcommand".
+func TestNewRootCmd_ParentCommandSkipAuthAndRejectUnknown(t *testing.T) {
+	cases := []struct {
+		name          string
+		args          []string
+		wantErr       bool
+		wantErrType   string
+		wantErrSubstr string
+	}{
+		{
+			name: "thread no args prints help without a token",
+			args: []string{"thread"},
+		},
+		{
+			name:          "thread unknown subcommand -> validation, not auth_error",
+			args:          []string{"thread", "bogus"},
+			wantErr:       true,
+			wantErrType:   "validation",
+			wantErrSubstr: "unknown subcommand",
+		},
+		{
+			name:          "thread delete (removed) -> validation, not auth_error",
+			args:          []string{"thread", "delete", "g", "s"},
+			wantErr:       true,
+			wantErrType:   "validation",
+			wantErrSubstr: "unknown subcommand",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newTestFactoryWithReg()
+			// Empty token: the auth gate would fail loudly if it ran. The
+			// whole point of the annotation is that it does NOT run for
+			// service parents.
+			f.SetConfig(&config.Config{APIBaseURL: "http://localhost", BotToken: ""})
+			root := NewRootCmd(f.Factory)
+			root.SetArgs(tc.args)
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			err := root.Execute()
+
+			if !tc.wantErr {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v; output=%s", err, buf.String())
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil; output=%s", buf.String())
+			}
+			// Same path main.go uses to derive exit code and envelope shape.
+			wrapped := cmdutil.WrapCLIError(err)
+			ee := output.AsExitError(wrapped)
+			if ee == nil {
+				t.Fatalf("expected ExitError after WrapCLIError, got %T: %v", wrapped, wrapped)
+			}
+			if ee.Type != tc.wantErrType {
+				t.Errorf("error type: got %q, want %q (msg=%s)", ee.Type, tc.wantErrType, ee.Message)
+			}
+			if !strings.Contains(strings.ToLower(ee.Message), tc.wantErrSubstr) {
+				t.Errorf("error msg %q should contain %q", ee.Message, tc.wantErrSubstr)
+			}
+		})
+	}
+}
+
+// TestNewRootCmd_LeafStillRequiresAuth proves the per-command skipValidation
+// annotation does NOT inherit through the parent chain: a leaf operation
+// under a service parent (which has the annotation) must still authenticate.
+// Without this guard the annotation fix would silently exempt every real
+// command from auth.
+func TestNewRootCmd_LeafStillRequiresAuth(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{APIBaseURL: "http://localhost", BotToken: ""})
+	root := NewRootCmd(f.Factory)
+	// `octo group list` is a leaf under `group` (which has the annotation).
+	root.SetArgs([]string{"group", "list"})
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected leaf to require auth, got nil; output=%s", buf.String())
+	}
+	wrapped := cmdutil.WrapCLIError(err)
+	ee := output.AsExitError(wrapped)
+	if ee == nil {
+		t.Fatalf("expected ExitError, got %T: %v", wrapped, wrapped)
+	}
+	if ee.Type != "auth_error" {
+		t.Errorf("leaf should hit auth gate (type=auth_error), got type=%q msg=%s", ee.Type, ee.Message)
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -51,9 +51,10 @@ func ensureServiceCmd(parent *cobra.Command, svc string) *cobra.Command {
 		return existing
 	}
 	c := &cobra.Command{
-		Use:   svc,
-		Short: fmt.Sprintf("Operations on the %s domain", svc),
-		RunE:  rejectUnknownSubcommand,
+		Use:         svc,
+		Short:       fmt.Sprintf("Operations on the %s domain", svc),
+		RunE:        rejectUnknownSubcommand,
+		Annotations: map[string]string{"skipValidation": "true"},
 	}
 	parent.AddCommand(c)
 	return c
@@ -74,9 +75,10 @@ func attachOperation(svcCmd *cobra.Command, f *cmdutil.Factory, d *registry.Oper
 		sub := findChild(cur, name)
 		if sub == nil {
 			sub = &cobra.Command{
-				Use:   name,
-				Short: fmt.Sprintf("%s %s operations", cur.Use, name),
-				RunE:  rejectUnknownSubcommand,
+				Use:         name,
+				Short:       fmt.Sprintf("%s %s operations", cur.Use, name),
+				RunE:        rejectUnknownSubcommand,
+				Annotations: map[string]string{"skipValidation": "true"},
 			}
 			cur.AddCommand(sub)
 		}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -53,6 +53,7 @@ func ensureServiceCmd(parent *cobra.Command, svc string) *cobra.Command {
 	c := &cobra.Command{
 		Use:   svc,
 		Short: fmt.Sprintf("Operations on the %s domain", svc),
+		RunE:  rejectUnknownSubcommand,
 	}
 	parent.AddCommand(c)
 	return c
@@ -75,6 +76,7 @@ func attachOperation(svcCmd *cobra.Command, f *cmdutil.Factory, d *registry.Oper
 			sub = &cobra.Command{
 				Use:   name,
 				Short: fmt.Sprintf("%s %s operations", cur.Use, name),
+				RunE:  rejectUnknownSubcommand,
 			}
 			cur.AddCommand(sub)
 		}
@@ -91,6 +93,18 @@ func findChild(parent *cobra.Command, name string) *cobra.Command {
 		}
 	}
 	return nil
+}
+
+// rejectUnknownSubcommand makes parent commands fail loudly on an
+// unrecognised subcommand. Without it, cobra treats the unknown token
+// as args, finds no RunE on the parent (Runnable()==false), prints
+// help, and exits 0 — which can let automation treat a removed
+// command as a success.
+func rejectUnknownSubcommand(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown subcommand %q for %q", args[0], cmd.CommandPath())
+	}
+	return cmd.Help()
 }
 
 // buildOperationCmd builds the leaf cobra.Command for one operation.

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -521,3 +521,37 @@ func TestBuildMultipartBody_MissingFile(t *testing.T) {
 		t.Errorf("expected validation ExitError, got %T: %v", err, err)
 	}
 }
+
+// TestParentCommand_RejectsUnknownSubcommand guards against cobra's default
+// fallback: a parent command with no RunE silently prints help and exits 0
+// when given an unknown token, which can let automation treat a removed or
+// mistyped command as a success. Regression test for the removal of
+// thread.delete (where `octo thread delete ...` previously printed help).
+func TestParentCommand_RejectsUnknownSubcommand(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"thread + removed leaf (delete)", []string{"thread", "delete", "g", "s"}},
+		{"thread + bogus", []string{"thread", "bogus"}},
+		{"group + bogus", []string{"group", "nope"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("HTTP handler must not be called when subcommand is unknown")
+			})
+			root.SetArgs(tc.args)
+			var buf bytes.Buffer
+			root.SetOut(&buf)
+			root.SetErr(&buf)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected error for %v, got nil; output=%s", tc.args, buf.String())
+			}
+			if !strings.Contains(err.Error(), "unknown subcommand") {
+				t.Errorf("error should mention 'unknown subcommand', got %q", err.Error())
+			}
+		})
+	}
+}

--- a/docs/octo-cli-design.md
+++ b/docs/octo-cli-design.md
@@ -109,19 +109,18 @@ Notes:
 
 ---
 
-## Domain 4: thread (dmworkim bot_api, 9 commands)
+## Domain 4: thread (dmworkim bot_api, 8 commands)
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
 | 31 | `octo thread create <group_no>` | POST | /v1/bot/groups/:group_no/threads | **N** | Y |
 | 32 | `octo thread list <group_no>` | GET | /v1/bot/groups/:group_no/threads | **N** | Y |
 | 33 | `octo thread get <group_no> <short_id>` | GET | .../:short_id | **N** | Y |
-| 34 | `octo thread delete <group_no> <short_id>` | DELETE | .../:short_id | **N** | Y |
-| 35 | `octo thread members <group_no> <short_id>` | GET | .../:short_id/members | **N** | Y |
-| 36 | `octo thread join <group_no> <short_id>` | POST | .../:short_id/join | **N** | Y |
-| 37 | `octo thread leave <group_no> <short_id>` | POST | .../:short_id/leave | **N** | Y |
-| 38 | `octo thread md-get <group_no> <short_id>` | GET | .../:short_id/md | **N** | Y |
-| 39 | `octo thread md-update <group_no> <short_id>` | PUT | .../:short_id/md | **N** | Y |
+| 34 | `octo thread members <group_no> <short_id>` | GET | .../:short_id/members | **N** | Y |
+| 35 | `octo thread join <group_no> <short_id>` | POST | .../:short_id/join | **N** | Y |
+| 36 | `octo thread leave <group_no> <short_id>` | POST | .../:short_id/leave | **N** | Y |
+| 37 | `octo thread md-get <group_no> <short_id>` | GET | .../:short_id/md | **N** | Y |
+| 38 | `octo thread md-update <group_no> <short_id>` | PUT | .../:short_id/md | **N** | Y |
 
 Flags:
 - create: --name* (thread name), --data (additional fields)
@@ -137,10 +136,10 @@ Notes:
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
-| 40 | `octo file upload` | POST | /v1/bot/file/upload | Y | Y |
-| 41 | `octo file download <path>` | GET | /v1/bot/file/download/*path | Y | Y |
-| 42 | `octo file credentials` | GET | /v1/bot/upload/credentials | Y | Y |
-| 43 | `octo file presigned` | GET | /v1/bot/upload/presigned | Y | Y |
+| 39 | `octo file upload` | POST | /v1/bot/file/upload | Y | Y |
+| 40 | `octo file download <path>` | GET | /v1/bot/file/download/*path | Y | Y |
+| 41 | `octo file credentials` | GET | /v1/bot/upload/credentials | Y | Y |
+| 42 | `octo file presigned` | GET | /v1/bot/upload/presigned | Y | Y |
 
 Flags:
 - upload: --file* (multipart), --type(default:"chat"), --path
@@ -158,12 +157,12 @@ Notes:
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
-| 44 | `octo bot register` | POST | /v1/bot/register | Y | Y |
-| 45 | `octo bot set-commands` | POST | /v1/bot/setCommands | Y | Y |
-| 46 | `octo bot user-info` | GET | /v1/bot/user/info | Y | Y |
-| 47 | `octo bot space-members` | GET | /v1/bot/space/members | Y | Y |
-| 48 | `octo bot typing` | POST | /v1/bot/typing | Y | Y |
-| 49 | `octo bot heartbeat` | POST | /v1/bot/heartbeat | Y | Y |
+| 43 | `octo bot register` | POST | /v1/bot/register | Y | Y |
+| 44 | `octo bot set-commands` | POST | /v1/bot/setCommands | Y | Y |
+| 45 | `octo bot user-info` | GET | /v1/bot/user/info | Y | Y |
+| 46 | `octo bot space-members` | GET | /v1/bot/space/members | Y | Y |
+| 47 | `octo bot typing` | POST | /v1/bot/typing | Y | Y |
+| 48 | `octo bot heartbeat` | POST | /v1/bot/heartbeat | Y | Y |
 
 Flags:
 - register: --data (JSON, registration payload)
@@ -180,8 +179,8 @@ Notes:
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
-| 50 | `octo event list` | POST | /v1/bot/events | Y | Y |
-| 51 | `octo event ack <event_id>` | POST | /v1/bot/events/:event_id/ack | Y | Y |
+| 49 | `octo event list` | POST | /v1/bot/events | Y | Y |
+| 50 | `octo event ack <event_id>` | POST | /v1/bot/events/:event_id/ack | Y | Y |
 
 Flags:
 - list: --event-id (int64, start cursor), --limit (int64, default:20, max:100)
@@ -198,12 +197,12 @@ Notes:
 | matter | 17 | 17 | 0 | 17 | 0 |
 | message | 4 | 4 (DM only) | 0 | 4 | 0 |
 | group | 9 | 5 | 4 | 9 | 0 |
-| thread | 9 | 0 | 9 | 9 | 0 |
+| thread | 8 | 0 | 8 | 8 | 0 |
 | file | 4 | 4 | 0 | 4 | 0 |
 | bot | 6 | 6 | 0 | 6 | 0 |
 | event | 2 | 2 | 0 | 2 | 0 |
-| **Total** | **51** | **38** | **13** | **51** | **0** |
+| **Total** | **50** | **38** | **12** | **50** | **0** |
 
-- **App Bot**: 38/51 commands available (75%)
-- **User Bot**: 51/51 commands available (100%)
-- **App Bot blocked**: group write (4) + thread all (9) = 13 commands
+- **App Bot**: 38/50 commands available (76%)
+- **User Bot**: 50/50 commands available (100%)
+- **App Bot blocked**: group write (4) + thread all (8) = 12 commands

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -355,6 +355,7 @@ func WrapCLIError(err error) error {
 		return output.ErrAuth(msg, "set OCTO_BOT_TOKEN to an app_* or bf_* token")
 	case strings.Contains(lower, "unknown flag"),
 		strings.Contains(lower, "unknown command"),
+		strings.Contains(lower, "unknown subcommand"),
 		strings.Contains(lower, "unknown shorthand"),
 		strings.Contains(lower, "required flag"),
 		strings.Contains(lower, "invalid argument"),

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -37,7 +37,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"matter":  14,
 		"message": 4,
 		"group":   9,
-		"thread":  9,
+		"thread":  8,
 		"file":    4,
 		"bot":     6,
 		"event":   2,

--- a/internal/registry/specs/thread.json
+++ b/internal/registry/specs/thread.json
@@ -56,16 +56,6 @@
           { "name": "short_id", "in": "path", "required": true, "schema": { "type": "string" } }
         ],
         "responses": { "200": { "description": "Thread detail" } }
-      },
-      "delete": {
-        "operationId": "thread.delete",
-        "summary": "Delete a thread (User Bot only)",
-        "x-octo-risk": "high-risk-write",
-        "parameters": [
-          { "name": "group_no", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "short_id", "in": "path", "required": true, "schema": { "type": "string" } }
-        ],
-        "responses": { "200": { "description": "Deleted" } }
       }
     },
     "/v1/bot/groups/{group_no}/threads/{short_id}/members": {

--- a/skills/octo-messaging/SKILL.md
+++ b/skills/octo-messaging/SKILL.md
@@ -105,7 +105,7 @@ octo group member-remove <group_no> --members u3
 
 App Bot attempting any of the four write operations gets `FORBIDDEN` with message `"app bot does not support group operations"`.
 
-## 3. `thread` — 9 commands, **User Bot only**
+## 3. `thread` — 8 commands, **User Bot only**
 
 Every thread operation calls `validateBotGroupAccess()` on the backend and rejects App Bot unconditionally. Don't attempt these with an `app_*` token.
 
@@ -113,7 +113,6 @@ Every thread operation calls `validateBotGroupAccess()` on the backend and rejec
 octo thread create    <group_no> --name "Incident #42"
 octo thread list      <group_no>                          # paginated
 octo thread get       <group_no> <short_id>
-octo thread delete    <group_no> <short_id>
 octo thread members   <group_no> <short_id>
 octo thread join      <group_no> <short_id>
 octo thread leave     <group_no> <short_id>


### PR DESCRIPTION
## What

`thread.delete` was the only `x-octo-risk: high-risk-write` operation left
in any enabled spec, and it sat at odds with the project's "bots get no
destructive operations" convention. The classic destructive endpoints —
message revoke, group disband, conversation delete — are user-only on the
server and were never exposed to bots; `thread.delete` was the lone
exception. Threads also have no bot-accessible archive or soft-close path,
so a hard delete was the only way for a bot to "finish" a thread, which
made the inconsistency particularly sharp.

This PR removes the spec entry. Shape mirrors #19 (matter-domain withhold),
except the operation is deleted outright rather than marked `x-octo-disabled`,
because — unlike `matter` — there is no plan to re-enable `thread.delete`.
The backend route is unchanged; callers that genuinely need to delete a
thread can still construct the call via
`octo api DELETE /v1/bot/groups/{group_no}/threads/{short_id}`.

## How

- **`internal/registry/specs/thread.json`** — drop the `delete` block under
  `/v1/bot/groups/{group_no}/threads/{short_id}`; the path keeps its `get`
  sibling untouched. The metadata-driven engine then removes the command
  from the cobra tree, the `schema --list` output, and shell completions
  with zero code change.
- **`internal/registry/loader_test.go`** — `thread: 9 → 8` in
  `TestAllDomainOperationCounts`. The total is summed from the map, so no
  other assertion change is needed.
- **`CLAUDE.md` / `README.md`** — `48 operations / 51 commands → 47/50`;
  the command-tree snippet in `CLAUDE.md` drops `delete` from the `thread`
  row.
- **`CHANGELOG.md`** — new `### Removed` entry under `[Unreleased]`;
  `[0.4.0]` history is left untouched (Keep a Changelog).
- **`docs/octo-cli-design.md`** — four independent count copies updated:
  domain heading (`Domain 4: thread (... 9 → 8 commands)`), the numbered
  command table (drop `#34 thread delete` and renumber `#35..#51 → #34..#50`
  for contiguity), the summary table (`thread 9→8`, `Total 51→50`,
  `App-blocked 13→12`), and the App/User availability lines
  (`38/51 → 38/50 (76%)`, `51/51 → 50/50`).
- **`skills/octo-messaging/SKILL.md`** — `9 commands → 8 commands` and the
  `octo thread delete` line removed.

Untracked draft docs in the working tree are intentionally excluded from
this PR.

## Tests

No code logic changed; only spec data and one assertion. CI commands
locally:

- `go build ./cmd/octo` — green
- `go vet ./...` — green
- `go test ./... -count=1` — all packages green, including the updated
  `TestAllDomainOperationCounts` (thread: 8, total: 47).

Manually verified after rebuild:

- `octo thread --help` lists 8 subcommands, no `delete`.
- `octo schema --list thread` no longer returns `thread.delete`.

## Breaking change

`octo thread delete` is no longer registered. Callers will receive
`unknown command`. Use the `octo api DELETE ...` passthrough as a fallback
if a thread genuinely needs deletion. This is intentional and aligned with
the "no destructive bot operations" convention.

## Notes

The count synchronisation across 6+ files in this PR highlights an existing
tech-debt pattern: the same number is duplicated by hand in many places,
guarded only on the code side (`loader_test.go`). A separate chore issue
is being filed to track de-duplication; this PR does not address it.
