### PR TITLE
chore(release): prepare 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,5 +110,5 @@ Factory-based DI throughout.
   and auto-registered from the spec.
 
 [Unreleased]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/Mininglamp-OSS/octo-cli/tree/v0.4.0
+[0.5.0]: https://github.com/Mininglamp-OSS/octo-cli/compare/555c959...v0.5.0
+[0.4.0]: https://github.com/Mininglamp-OSS/octo-cli/tree/555c959

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-- `octo thread delete` — withdrew the thread-deletion command. Threads expose no
-  bot-accessible archive or soft-close path, so a hard delete was inconsistent
-  with the convention that bots get no destructive operations. The backend route
-  is untouched; only the CLI command and its `thread.delete` spec entry are
-  removed. Command/operation totals drop 51/48 → 50/47.
+## [0.5.0] — 2026-05-28
+
+### Added
+- **`octo skills` command** for embedded skill discovery — lists or
+  extracts the Agent skills bundled in the binary (`octo-shared`,
+  `octo-messaging`, `octo-files`, `octo-matter`). Useful for agent
+  runtimes that load skills from `octo` at startup. (#16)
+- **Encrypted credential profiles** via `octo auth login | status |
+  logout | list` — bot tokens now live in `~/.octo-cli` (plaintext
+  `config.json` metadata + AES-256-GCM `credentials.enc` token store)
+  keyed by `--profile` / `--bot-id` (env `OCTO_BOT_ID`). `OCTO_BOT_TOKEN`
+  remains a fallback. Each success envelope echoes the active
+  `identity` (`{profile, robot_id, bot_kind, source}`) so agents can
+  detect credential misuse. (#17)
 
 ### Changed
-- Service-domain parent commands (`octo thread`, `octo group`, `octo file`, …)
-  now reject unknown subcommands with `unknown subcommand %q for %q` and exit 2
-  instead of silently printing help and exiting 0. Required by the `thread
-  delete` removal above so automation can detect a missing operation; also
-  catches typos like `octo group lisst`. Parent help (`octo thread`,
-  `octo thread --help`) is unchanged and still works without a token; only
-  leaf operations require authentication.
+- **Matter domain withheld** behind a new `x-octo-disabled` spec flag —
+  the spec stays embedded (`octo schema matter.*` still introspects it)
+  but the command subtree and the `octo-matter` skill are hidden until
+  the backend Matter API stabilises. Flip the spec flag and the skill
+  frontmatter to re-enable. (#19)
+- **Service-domain parent commands** (`octo thread`, `octo group`,
+  `octo file`, …) now reject unknown subcommands with
+  `unknown subcommand %q for %q` and exit 2 instead of silently printing
+  help and exiting 0. Required by the `thread delete` removal so
+  automation can detect a missing operation; also catches typos like
+  `octo group lisst`. Parent help (`octo thread`, `octo thread --help`)
+  still works without a token; only leaf operations require
+  authentication.
+
+### Removed
+- **`octo thread delete`** — withdrew the thread-deletion command.
+  Threads expose no bot-accessible archive or soft-close path, so a
+  hard delete was inconsistent with the convention that bots get no
+  destructive operations. The backend route is untouched; only the CLI
+  command and its `thread.delete` spec entry are removed.
+
+### Fixed
+- **`octo file presigned`** and other `bot_api` specs realigned with
+  octo-server — `file.presigned` now declares the required `fileSize`
+  query param (previous calls failed with `HTTP 400 fileSize 参数必填`).
+  Several other spec drifts also corrected. (#14)
+- **Auth gate on service parents** no longer fires for parent help or
+  unknown-subcommand handling — the `unknown subcommand` envelope and
+  `octo thread --help` now work without a bot token, restoring the
+  safety property of the `thread delete` removal.
 
 ## [0.4.0] — 2026-05
 
@@ -78,5 +109,6 @@ Factory-based DI throughout.
   subcommand trees. All equivalent functionality is now under `octo matter`
   and auto-registered from the spec.
 
-[Unreleased]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Mininglamp-OSS/octo-cli/releases/tag/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,4 +111,4 @@ Factory-based DI throughout.
 
 [Unreleased]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.5.0...HEAD
 [0.5.0]: https://github.com/Mininglamp-OSS/octo-cli/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/Mininglamp-OSS/octo-cli/releases/tag/v0.4.0
+[0.4.0]: https://github.com/Mininglamp-OSS/octo-cli/tree/v0.4.0

--- a/skills/octo-messaging/SKILL.md
+++ b/skills/octo-messaging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octo-messaging
-version: 0.4.0
+version: 0.4.1
 description: Messaging domain — send/edit/sync messages, read receipts, groups and threads (User Bot), and event polling. Covers App Bot DM-only constraints. Load after octo-shared.
 metadata:
   requires:


### PR DESCRIPTION
## Summary

Codebase-side preparation for **v0.5.0** — the first GitHub Release published from this repository.

## Changes

- `CHANGELOG.md` — promote the existing `[Unreleased]` entries (thread.delete removal, unknown-subcommand rejection — both carried by #20) and the four previously landed PRs (#14 / #16 / #17 / #19) into a new `[0.5.0] — 2026-05-28` section with Added / Changed / Removed / Fixed grouping. Update the bottom-of-file link refs.
- `skills/octo-messaging/SKILL.md` — bump `version` 0.4.0 → 0.4.1 because the skill text was updated to reflect the `thread.delete` removal carried by #20.

Other skill versions (`octo-shared` 0.5.0, `octo-matter` 0.4.0, `octo-files` 0.4.0) are left untouched because their contents did not change in this cycle.

## Motivation

`v0.5.0` will be the first GitHub Release published from this repo. The hand-written `[0.4.0]` CHANGELOG section documents an architectural baseline but has no corresponding git tag, and the `tag protection` ruleset blocks first-time `v*` tag creation — so an admin will need to unlock the ruleset (Settings → Rules → tag protection) once before the tag can be pushed.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 10 packages)
- [x] `go build ./...` passes

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [x] New commands added to README Command Reference table — _n/a, release-prep only_
- [x] CLAUDE.md command list updated if commands changed — _n/a, no command shape changes here_
- [x] New features include tests — _n/a, no new features_
- [x] No unrelated changes included — confirmed: diff is 2 files

## Notes for the release coordinator

- The `[0.4.0]` link in CHANGELOG.md intentionally points to `releases/tag/v0.4.0`; that tag does not exist and may not be created. The link will 404 until/unless someone backfills the tag.
- After merge, pushing `v0.5.0` needs the `tag protection` ruleset temporarily disabled (or — recommended — a permanent bypass added to `Repository admin` role / `@Mininglamp-OSS/cli-maintainers` team).
- Do **not** publish the auto-generated release body — without a prior `v0.4.0` tag GitHub will list the entire repo history. Replace the draft body with the `[0.5.0]` CHANGELOG section before publishing.
- Publish flow: push `v0.5.0` tag → run `release-publish.yml` workflow_dispatch with `tag=v0.5.0`, `validate_run_id=<merged commit's CI run id>`, `draft=true` → edit draft body → publish.