### PR TITLE
ci: add build-artifacts job to release-publish workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -29,3 +29,38 @@ jobs:
     permissions:
       contents: write
       actions: read
+
+  build-artifacts:
+    needs: publish
+    if: ${{ inputs.draft == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+          cache: true
+
+      - name: Build with GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean --skip=publish,announce
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List dist artifacts
+        run: ls -lh dist/
+
+      - name: Upload artifacts to release
+        run: gh release upload "${{ inputs.tag }}" dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -60,7 +60,14 @@ jobs:
       - name: List dist artifacts
         run: ls -lh dist/
 
-      - name: Upload artifacts to release
-        run: gh release upload "${{ inputs.tag }}" dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber
+      - name: Validate tag before upload
+        run: |
+          [[ "$TAG" =~ ^v[0-9]+\.[0-9]+(\.[0-9]+)?([-.][0-9A-Za-z.-]+)?$ ]] || { echo "Invalid tag: $TAG"; exit 1; }
         env:
+          TAG: ${{ inputs.tag }}
+
+      - name: Upload artifacts to release
+        run: gh release upload "$TAG" dist/*.tar.gz dist/*.zip dist/checksums.txt --clobber
+        env:
+          TAG: ${{ inputs.tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 背景

`release.yml` 靠 `push tag v*` 触发 goreleaser，但 tag protection ruleset 让 `GITHUB_TOKEN` 永远无法推 tag，该 workflow 事实上是死代码。

## 本次改动

在 `release-publish.yml` 的 `publish` job 之后追加 `build-artifacts` job：

| 项目 | 说明 |
|------|------|
| 触发条件 | `needs: publish` + `inputs.draft == false` |
| 构建 | goreleaser `--skip=publish,announce`（只构建打包，不操作 GitHub Release） |
| 产物 | linux/darwin/windows × amd64/arm64 的 .tar.gz / .zip + checksums.txt |
| 上传 | `gh release upload --clobber` 附加到已发布的 release |

## 使用前提

**tag 必须由授权用户（`cli-maintainers` team 成员）提前推送**，`GITHUB_TOKEN` 没有 tag protection bypass 权限。

## 发布流程（v0.5.0 起）

1. `lml2468` 或 `liuooo` 推 tag：`git tag v0.5.0 b5a4d6a3 && git push origin v0.5.0`
2. Actions → Release Publish → Run workflow，填入：
   - tag: `v0.5.0`
   - validate_run_id: `26559942509`
   - draft: `false`
3. `publish` job 发布 release，`build-artifacts` job 构建并上传二进制