### PR TITLE
ci: add concurrency group to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build & test


### PR DESCRIPTION
## Summary

Add concurrency group to CI workflow to cancel redundant runs when multiple pushes happen on the same PR.

## Changes

Added the org-standard concurrency block between `permissions` (or `on`) and `jobs`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

## Why

Without concurrency control, rapid successive pushes to the same PR trigger parallel CI runs that all run to completion, wasting CI minutes. This change cancels in-progress runs when a newer push arrives on the same PR, while preserving independent runs for different PRs and branches.

## Validation

- [x] YAML syntax verified (`yaml.safe_load`)
- [x] actionlint passed with no errors
- [x] Follows the same pattern used by octo-server, octo-matter, octo-web, octo-speech, and other org repos