### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: build & test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -62,6 +63,7 @@ jobs:
   npm-test:
     name: npm test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: build & test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

Add `timeout-minutes` to every CI job that is missing one.

**Timeout values:**
- `changes` (path detection): **5 min**
- `build` / `vet` / `lint` / custom lint jobs: **15 min**
- `test` / `build-and-test` / `npm-test`: **30 min**

## Why

Without explicit timeouts, a stuck test or build will run until GitHub's
6-hour default kills it — wasting runner capacity and delaying feedback.

Ref: Mininglamp-OSS workflow optimization T04.
