### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main
+    with:
+      language: go
+    permissions:
+      actions: read
+      contents: read
+      security-events: write


### PR DESCRIPTION
## What

Add CodeQL static analysis for Go, using the org-level reusable workflow (`reusable-codeql.yml`).

## Why

octo-cli is the only Go repository in the org without CodeQL coverage. As a CLI tool that processes user input (CLI arguments, config files, API responses), it should have the same security scanning as peer repos.

## Details

- Language: `go`
- Reusable workflow: `Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main`
- Triggers: push to main, PRs (excluding drafts), daily schedule (`0 6 * * *`), manual dispatch
- Permissions: minimal (`actions: read`, `contents: read`, `security-events: write`)
- Top-level `permissions: {}` for least privilege
- Concurrency: cancel-in-progress for PRs
- Draft skip: `if: !github.event.pull_request.draft`

Follows the exact same caller pattern as octo-server, octo-lib, octo-matter, octo-im, octo-speech, and octo-smart-summary.

Ref: Workflow optimization task T09