### PR TITLE
fix: skip OSV-Scanner SARIF upload for Dependabot PRs

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -30,7 +30,8 @@ jobs:
       scan-args: |-
         -r
         ./
-      # Fork PRs have read-only GITHUB_TOKEN; skip SARIF upload to avoid
-      # security-events:write permission failure. Scan still runs and
-      # results are visible in the workflow output.
-      upload-sarif: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      # Skip SARIF upload when GITHUB_TOKEN is read-only:
+      # - Fork PRs: token is inherently read-only
+      # - Dependabot PRs: GitHub enforces read-only token for dependabot[bot]
+      # Scan still runs; results visible in workflow output.
+      upload-sarif: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}


### PR DESCRIPTION
## What
Add Dependabot exclusion to the OSV-Scanner SARIF upload condition.

## Why
Dependabot-triggered `pull_request` workflows get a read-only `GITHUB_TOKEN`. The existing fork guard (`head.repo.full_name == github.repository`) does not catch Dependabot PRs because they are same-repo branches. This causes `security-events:write` SARIF upload to fail on every Dependabot PR.

## Fix
```yaml
upload-sarif: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]' }}
```

Scan still runs for Dependabot PRs; results visible in workflow output. Only SARIF upload (which would fail anyway) is skipped.

Follow-up to the merged OSV-Scanner PR.