### PR TITLE
ci: bump Node.js version from 20 to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,6 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: node --test
         run: node --test scripts/install.test.js


### PR DESCRIPTION
## Summary

Bump Node.js version from 20 to 22 (current LTS) to align with the org-wide standard.

## Why

- Node 20 enters maintenance mode in October 2026
- `octo-adapters` already uses Node 22
- Standardizing on one version reduces cognitive overhead and ensures consistent behavior across repos

## Changes

- `.github/workflows/ci.yml`: `node-version: 20` → `node-version: 22`

## Validation

- [x] YAML syntax verified
- [x] actionlint passed