### PR TITLE
ci: replace paths-ignore with dorny/paths-filter preflight job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,11 @@ jobs:
           #   dotfiles:     all negations=true → every=true → CI runs ✅
           #   Dockerfile:   all negations=true → CI runs ✅
           #
-          # Do NOT add '**': picomatch('**') doesn't match dotfiles (e.g. .golangci.yml)
-          # causing them to incorrectly skip CI with the 'every' quantifier.
+          # Do NOT add '**' as an inclusion pattern: with the 'every' quantifier
+          # the bare '**' pattern adds no useful constraint and risks regressing
+          # the negation logic on future picomatch upgrades. Stick to negation-only.
+          # (dorny/paths-filter v3 already sets picomatch dot:true so dotfiles like
+          # .golangci.yml ARE matched by '**' under v3 — earlier versions did not.)
           # Do NOT use 'some' + negation: every changed file matches at least one
           # negation pattern (e.g. main.go matches !**/*.md), so some=true always
           # and the skip logic becomes a no-op.
@@ -77,16 +80,12 @@ jobs:
       needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ["1.24.x"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.24.x"
           check-latest: true
 
       - name: gofmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     branches: [main]
+    # paths-ignore is intentionally NOT set here — workflow-level path filtering
+    # prevents GitHub from creating any check run, which deadlocks required-status
+    # checks on docs-only PRs. Path-based skipping is handled by the `changes`
+    # preflight job below instead (dorny/paths-filter produces "skipped" statuses
+    # that GitHub counts as passing for required checks).
 
 permissions:
   contents: read
@@ -14,8 +24,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            code:
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.github/ISSUE_TEMPLATE/**'
+
   build:
     name: build & test
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -66,6 +105,10 @@ jobs:
 
   npm-test:
     name: npm test
+    needs: [changes]
+    if: |
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
-          predicate-quantifier: 'every'
           filters: |
             code:
               - '!**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,9 @@ jobs:
       # are docs/templates. Push events default to 'true'.
       code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: github.event_name == 'pull_request'
-        with:
-          persist-credentials: false
+      # No checkout: on pull_request events dorny/paths-filter lists changed
+      # files via the GitHub API (needs only pull-requests: read, granted
+      # above), so a working tree is unnecessary here.
       - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
         if: github.event_name == 'pull_request'
@@ -154,6 +153,13 @@ jobs:
   npm-test:
     name: npm test
     needs: [changes]
+    # Job-level skip is intentional here and asymmetric with `build` above.
+    # `npm test` is NOT a required status check (ruleset 16222449 pins only
+    # "build & test (1.24.x)" and "code-review"), so skipping the whole job on
+    # docs-only PRs is safe — there is no required check to keep alive. `build`
+    # must use per-step gating instead because skipping it job-level would drop
+    # its required matrix child check and re-create the deadlock. Do not "align"
+    # these two jobs onto the same strategy.
     if: |
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
       needs.changes.outputs.code == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      # code=true when at least one changed file matches the code filter.
+      # predicate-quantifier:every + negation patterns (no bare '**'):
+      # a file matches 'code' iff ALL negation patterns are satisfied
+      # (file is not a doc/template). code=false only when all changed files
+      # are docs/templates. Push events default to 'true'.
       code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -42,6 +47,22 @@ jobs:
         id: filter
         if: github.event_name == 'pull_request'
         with:
+          # predicate-quantifier: every — a file matches 'code' only when ALL
+          # negation patterns are satisfied (file is NOT a doc/template file).
+          #
+          # Validated by picomatch v4 unit test (same library used internally):
+          #   README.md:    !**/*.md=false → every=false → not match → code=false ✅
+          #   main file:    all negations=true → every=true → match → code=true ✅
+          #   mixed PR:     code file matches → code=true (some over changed files) ✅
+          #   dotfiles:     all negations=true → every=true → CI runs ✅
+          #   Dockerfile:   all negations=true → CI runs ✅
+          #
+          # Do NOT add '**': picomatch('**') doesn't match dotfiles (e.g. .golangci.yml)
+          # causing them to incorrectly skip CI with the 'every' quantifier.
+          # Do NOT use 'some' + negation: every changed file matches at least one
+          # negation pattern (e.g. main.go matches !**/*.md), so some=true always
+          # and the skip logic becomes a no-op.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '!**/*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,20 +75,43 @@ jobs:
   build:
     name: build & test
     needs: [changes]
-    if: |
-      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
-      needs.changes.outputs.code == 'true'
+    # Draft guard stays at the job level. The code-vs-docs skip is enforced
+    # per-step (below) instead, so the matrix child check
+    # `build & test (1.24.x)` is always emitted (success on docs-only PRs,
+    # real run on code PRs). Job-level `if: code == 'true'` would skip the
+    # whole job BEFORE matrix expansion, so the parenthesised child check
+    # required by the repository ruleset (id 16222449) would never be
+    # created — recreating the very deadlock this workflow is meant to fix,
+    # just on docs-only PRs instead of all PRs.
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single-value matrix intentionally retained. The repository ruleset
+        # (id 16222449, "main branch protection") pins the exact check name
+        # "build & test (1.24.x)" — the parenthesised form GitHub emits only
+        # for matrix jobs. Dropping the matrix renames the check to
+        # "build & test" and breaks the required-status gate on every PR.
+        # Add new Go versions here instead of removing the matrix.
+        go-version: ["1.24.x"]
     steps:
+      - name: skip notice (docs-only PR)
+        if: needs.changes.outputs.code != 'true'
+        run: echo "docs-only PR — skipping build & test (matrix=${{ matrix.go-version }})"
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        if: needs.changes.outputs.code == 'true'
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        if: needs.changes.outputs.code == 'true'
         with:
-          go-version: "1.24.x"
+          go-version: ${{ matrix.go-version }}
           check-latest: true
 
       - name: gofmt
+        if: needs.changes.outputs.code == 'true'
         run: |
           out=$(gofmt -l . | grep -v '^vendor/' || true)
           if [ -n "$out" ]; then
@@ -98,9 +121,11 @@ jobs:
           fi
 
       - name: go vet
+        if: needs.changes.outputs.code == 'true'
         run: go vet ./...
 
       - name: go mod tidy check
+        if: needs.changes.outputs.code == 'true'
         run: |
           go mod tidy
           if ! git diff --exit-code go.mod go.sum; then
@@ -109,17 +134,21 @@ jobs:
           fi
 
       - name: golangci-lint
+        if: needs.changes.outputs.code == 'true'
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           version: v2.12.2
 
       - name: test (race, coverage)
+        if: needs.changes.outputs.code == 'true'
         run: go test -race -shuffle=on -count=1 -covermode=atomic -coverprofile=coverage.out ./...
 
       - name: coverage summary
+        if: needs.changes.outputs.code == 'true'
         run: go tool cover -func=coverage.out | tail -n 20
 
       - name: build
+        if: needs.changes.outputs.code == 'true'
         run: go build -o octo-cli ./cmd/octo-cli
 
   npm-test:


### PR DESCRIPTION
## What

Replace workflow-level `paths-ignore` on `pull_request` trigger with a `changes` preflight job using `dorny/paths-filter`.

## Why

When `paths-ignore` is set at the workflow level, GitHub will not create any check run for docs-only PRs. If CI is a required status check, those PRs can never merge. The preflight job produces a "skipped" status instead, which GitHub counts as passing.

## Changes

- Removed `paths-ignore` from `pull_request` trigger (kept on `push`)
- Added `changes` preflight job with `dorny/paths-filter`
- Added `needs: [changes]` condition to build/test jobs
- Added draft PR skip (`converted_to_draft` type + draft condition)

## Reference

Follows the same pattern as octo-server's CI workflow.

Refs: Mininglamp-OSS workflow optimization T13

Closes #50
