### PR TITLE
chore(hooks): add lefthook git hooks (pre-commit, commit-msg, pre-push)

### DIFF
--- a/.lefthook/commit-msg-check.sh
+++ b/.lefthook/commit-msg-check.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Conventional Commits validator for the commit-msg hook (invoked by lefthook).
+#
+# Mirrors cc-channel-octo's loosened commitlint policy: enforce the
+# `type(scope)?!?: subject` shape, but stay permissive about the rest so the
+# repo's real style passes (uppercase technical scopes, long technical
+# subjects, `!` breaking markers).
+#
+# Usage: bash .lefthook/commit-msg-check.sh <path-to-commit-msg-file>
+set -euo pipefail
+
+msg_file="${1:?commit message file path required}"
+
+# First non-comment, non-blank line is the header.
+header=$(grep -vE '^\s*#' "$msg_file" | grep -vE '^\s*$' | head -n1 || true)
+
+# Skip machine-generated commits that don't follow the convention.
+case "$header" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"Reapply "*)
+    exit 0 ;;
+esac
+
+if [ -z "$header" ]; then
+  echo "✖ commit message is empty." >&2
+  exit 1
+fi
+
+types='feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert'
+# type, optional (scope) — scope is free-form, may contain spaces, optional ! then ": " then a non-empty subject.
+pattern="^(${types})(\([^)]+\))?!?: .+"
+
+if ! printf '%s' "$header" | grep -qE "$pattern"; then
+  cat >&2 <<EOF
+✖ Invalid commit message:
+
+    $header
+
+Expected Conventional Commits format:
+
+    <type>(<scope>)?(!)?: <subject>
+
+  type    one of: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+  scope   optional, free-form (e.g. cli, thread, ci)
+  !       optional, marks a breaking change
+  subject short imperative description
+
+Examples:
+    feat(cli): add octo skills command
+    fix(ci): pin golangci-lint-action to SHA
+    refactor!: rename binary from octo to octo-cli
+
+EOF
+  exit 1
+fi
+
+# Soft length guard (loosened — repo has long technical subjects).
+max=120
+len=${#header}
+if [ "$len" -gt "$max" ]; then
+  echo "✖ Commit header is ${len} chars (max ${max}). Shorten the subject or move detail to the body." >&2
+  exit 1
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,33 @@ need to know to get a change merged.
 git clone https://github.com/Mininglamp-OSS/octo-cli.git
 cd octo-cli
 
+make hooks            # install git hooks (lefthook) — do this once
 make build            # builds ./bin/octo-cli
 make test             # go test -race -count=1 ./...
 make lint             # golangci-lint run
 make ci               # fmt + vet + lint + test + build (what CI runs)
 ```
+
+## Git Hooks
+
+Hooks are managed by [lefthook](https://lefthook.dev) and mirror the CI checks
+so problems surface locally instead of on the remote. Activate them once after
+cloning with `make hooks` (installs into `.git/hooks/`); the config lives in
+[`lefthook.yml`](./lefthook.yml).
+
+| Hook | Runs | Notes |
+|------|------|-------|
+| `pre-commit` | `gofmt` (staged files) + `go vet` + `golangci-lint` | Fast. `golangci-lint` is skipped with a hint if not installed — CI still enforces it. |
+| `commit-msg` | Conventional Commits check | See [`.lefthook/commit-msg-check.sh`](./.lefthook/commit-msg-check.sh). |
+| `pre-push` | `go mod tidy` drift check + `go build ./...` + `go vet ./...` | Fast gate. The full `go test -race -shuffle` + coverage suite runs in CI, not on every push. |
+
+`lefthook` is the only extra tool required — install it with `brew install lefthook`
+or `go install github.com/evilmartians/lefthook@latest`. Optional linters used by
+the hooks and CI install via `make tools` (`golangci-lint`, `gci`).
+
+> Hooks can be bypassed with `--no-verify` (`git commit --no-verify`,
+> `git push --no-verify`) **in genuine emergencies only** — CI runs the same
+> checks, so a bypass just defers the failure.
 
 ## Architecture Overview
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint fmt vet clean ci help
+.PHONY: build test lint fmt vet clean ci hooks hooks-install tools help
 
 # Build metadata is injected at link time. Release builds override VERSION.
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -25,6 +25,21 @@ clean:
 
 ci: fmt vet lint test build
 
+# Install & activate git hooks (lefthook). Run once after cloning.
+hooks: hooks-install
+hooks-install:
+	@command -v lefthook >/dev/null 2>&1 || { \
+	  echo "lefthook not found. Install one of:"; \
+	  echo "  brew install lefthook"; \
+	  echo "  go install github.com/evilmartians/lefthook@latest"; \
+	  exit 1; }
+	lefthook install
+
+# Install optional dev tools the hooks/CI use (golangci-lint, gci).
+tools:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	go install github.com/daixiang0/gci@latest
+
 help:
 	@echo "Targets:"
 	@echo "  build   build ./bin/octo-cli with version from git"
@@ -33,6 +48,8 @@ help:
 	@echo "  fmt     fail if any Go file needs gofmt"
 	@echo "  vet     go vet ./..."
 	@echo "  ci      fmt + vet + lint + test + build (what CI runs)"
+	@echo "  hooks   install & activate git hooks (lefthook)"
+	@echo "  tools   install optional dev tools (golangci-lint, gci)"
 	@echo "  clean   remove ./bin"
 	@echo ""
 	@echo "Add a new service domain: write spec → embed → auto-register"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,58 @@
+# Git hooks managed by lefthook (https://lefthook.dev).
+# Activate after cloning: `make hooks` (or `lefthook install`).
+#
+# Hooks stay fast: pre-commit / pre-push run gofmt, go vet, go build, and the
+# go mod tidy drift check. The heavier suite (`go test -race -shuffle` +
+# coverage) runs in CI, not on every push — duplicating it locally is slow and
+# invites `--no-verify`.
+#
+# Heavy *optional* tools (golangci-lint) are skipped with a hint when not
+# installed — CI enforces them regardless. Go-native checks always run since
+# the Go toolchain guarantees them.
+min_version: 1.11.0
+
+pre-commit:
+  parallel: true
+  commands:
+    gofmt:
+      glob: "*.go"
+      run: |
+        unformatted=$(gofmt -l {staged_files})
+        if [ -n "$unformatted" ]; then
+          echo "gofmt needed on:"
+          echo "$unformatted"
+          echo "Fix: gofmt -w {staged_files}"
+          exit 1
+        fi
+    govet:
+      glob: "*.go"
+      run: go vet ./...
+    golangci-lint:
+      glob: "*.go"
+      run: |
+        if command -v golangci-lint >/dev/null 2>&1; then
+          golangci-lint run
+        else
+          echo "⚠ golangci-lint not installed — skipped (CI enforces it)."
+          echo "  Install: make tools   (or: brew install golangci-lint)"
+        fi
+
+commit-msg:
+  commands:
+    conventional:
+      run: bash .lefthook/commit-msg-check.sh {1}
+
+pre-push:
+  parallel: false
+  commands:
+    mod-tidy:
+      run: |
+        go mod tidy
+        if ! git diff --exit-code go.mod go.sum >/dev/null 2>&1; then
+          echo "go.mod / go.sum drift — run 'go mod tidy' and commit the result."
+          exit 1
+        fi
+    build:
+      run: go build ./...
+    vet:
+      run: go vet ./...


### PR DESCRIPTION
Closes #48

## What & why

octo-cli had a thorough CI pipeline but **no local git hooks** — every check only ran after pushing. This adopts **[lefthook](https://lefthook.dev)** (the Go-ecosystem husky equivalent: single Go binary, declarative YAML, parallel execution) to run fast gates locally. This repo is the **template** for the other Go repos in the workspace.

## Changes

| File | Change |
|------|--------|
| `lefthook.yml` | **new** — pre-commit / commit-msg / pre-push definitions |
| `.lefthook/commit-msg-check.sh` | **new** — pure-bash Conventional Commits validator (no Node) |
| `Makefile` | add `hooks` / `hooks-install` / `tools` targets |
| `CONTRIBUTING.md` | document hook setup + behaviour |

### Hooks

| Hook | Runs |
|------|------|
| `pre-commit` | `gofmt` (staged) + `go vet` + `golangci-lint` |
| `commit-msg` | Conventional Commits check |
| `pre-push` | `go mod tidy` drift check + `go build ./...` + `go vet ./...` |

**pre-push stays fast (~0.8s).** It catches compile errors and dependency drift — the cheap, high-value gates. The heavy suite (`go test -race -shuffle` + coverage) runs in CI, not on every push: duplicating it locally is slow and invites `--no-verify`.

### Two key design decisions

1. **Global install, not `go get -tool`.** The Go 1.24 `tool` directive would inject ~50 indirect deps + ~109 `go.sum` lines into the main module. Instead lefthook is installed globally (`brew` / `go install`), version-floored via `min_version` in `lefthook.yml`, activated through `make hooks`. **Main `go.mod` stays clean.**
2. **Graceful degradation.** Heavy optional tools (`golangci-lint`) are detected with `command -v` and **skipped with a hint** if absent — CI still enforces them. Go-native checks (gofmt/vet/build) always run, so clone-and-go is never blocked.

## Verification

- ✅ `make hooks` activates lefthook (pre-commit, commit-msg, pre-push)
- ✅ `commit-msg` rejects `bad message`; accepts real history (`refactor!: rename binary`, `feat(thread): remove ...`); skips merge/fixup
- ✅ `pre-commit` blocks an un-gofmt'd staged file; `golangci-lint` skips gracefully when not installed (CI enforces)
- ✅ `pre-push` runs `go mod tidy` check + build + vet in **~0.8s**
- ✅ Main `go.mod` unchanged — no dependency pollution