### PR TITLE
ci: complete reusable caller coverage

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  dependency-review:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-dependency-review.yml@v1
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,18 @@
+name: PR Title Lint
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions: {}
+
+jobs:
+  pr-title-lint:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-title-lint.yml@v1
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_title: ${{ github.event.pull_request.title }}
+      repo_owner: ${{ github.event.repository.owner.login }}
+      repo_name: ${{ github.event.repository.name }}
+    permissions:
+      pull-requests: write

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,6 +1,9 @@
 name: PR Title Lint
 
 on:
+  # pull_request_target: metadata-only automation — the reusable checks out NO PR
+  # code and reads the PR title via env (never interpolated), so fork PRs cannot
+  # execute code or inject via the title. zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,15 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  secret-scan:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-secret-scan.yml@v1
+    permissions:
+      contents: read


### PR DESCRIPTION
Add missing reusable callers: secret-scan dependency-review pr-title-lint. Completes coverage of the org platform's applicable reusables. secret-scan + dependency-review are the security baseline; pr-title-lint enforces Conventional Commits on the squash-merge subject.