### PR TITLE
fix(npm): harden bundled package publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -54,6 +54,8 @@ on:
         default: false
 
 concurrency:
+  # A package version is immutable on npm; never let two publish attempts for the
+  # same tag race each other.
   group: npm-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
@@ -110,6 +112,8 @@ jobs:
           TAG: ${{ steps.version.outputs.TAG }}
         run: |
           set -euo pipefail
+          # Gate: a repo writer can create a Release outside this workflow; npm
+          # publishing still requires the expected non-draft Release tag.
           if [ -z "$TAG" ]; then
             echo "::error::Empty TAG output from resolver step."
             exit 1
@@ -137,6 +141,7 @@ jobs:
           TAG: ${{ steps.version.outputs.TAG }}
         run: |
           set -euo pipefail
+          # Gate: only publish tags whose target commit has a successful CI run.
           ref_data=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG")
           ref_type=$(printf '%s' "$ref_data" | jq -r '.object.type')
           ref_sha=$(printf '%s' "$ref_data" | jq -r '.object.sha')
@@ -183,10 +188,26 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           cd dist
-          sha256sum --check --ignore-missing checksums.txt
+          # Verify exactly the archives we are about to package. Do not use
+          # --ignore-missing: a missing or only substring-matched archive must
+          # fail before npm packages are generated.
+          subset=$(mktemp)
+          trap 'rm -f "$subset"' EXIT
+          archive_count=0
           for f in *.tar.gz; do
-            grep -qF "  $f" checksums.txt || { echo "::error::$f not covered by checksums.txt"; exit 1; }
+            archive_count=$((archive_count + 1))
+            line=$(awk -v file="$f" '$2 == file { print }' checksums.txt)
+            if [ -z "$line" ]; then
+              echo "::error::$f not covered exactly by checksums.txt"
+              exit 1
+            fi
+            printf '%s\n' "$line" >> "$subset"
           done
+          if [ "$archive_count" -eq 0 ]; then
+            echo "::error::No release archives (*.tar.gz) found in dist/."
+            exit 1
+          fi
+          sha256sum --check "$subset"
 
       - name: Generate npm packages
         env:
@@ -203,8 +224,48 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
+          npm_view() {
+            local label="$1"
+            shift
+            local output=""
+            for attempt in 1 2 3; do
+              if output=$(npm view "$@" 2>&1); then
+                printf '%s\n' "$output"
+                return 0
+              fi
+              if printf '%s' "$output" | grep -Eiq '(^|[[:space:]])E404([[:space:]]|$)|404 Not Found|is not in this registry'; then
+                return 1
+              fi
+              if [ "$attempt" -eq 3 ]; then
+                echo "::error::npm view failed for $label after $attempt attempts." >&2
+                printf '%s\n' "$output" >&2
+                return 2
+              fi
+              echo "[npm-publish] npm view failed for $label (attempt $attempt/3); retrying" >&2
+              sleep $((attempt * 5))
+            done
+          }
+
+          version_exists() {
+            local name="$1"
+            if npm_view "$name@$VERSION" "$name@$VERSION" version >/dev/null; then
+              return 0
+            fi
+            local status=$?
+            if [ "$status" -eq 1 ]; then
+              return 1
+            fi
+            exit 1
+          }
+
           if [ "$DIST_TAG" = "latest" ]; then
-            reg_latest=$(npm view "@mininglamp-oss/octo-cli" dist-tags.latest 2>/dev/null || true)
+            reg_latest=""
+            if reg_latest=$(npm_view "@mininglamp-oss/octo-cli dist-tags.latest" "@mininglamp-oss/octo-cli" dist-tags.latest); then
+              :
+            else
+              status=$?
+              if [ "$status" -ne 1 ]; then exit 1; fi
+            fi
             if [ -n "$reg_latest" ] && [ "$reg_latest" != "$VERSION" ] && \
                [ "$(printf '%s\n%s\n' "$reg_latest" "$VERSION" | sort -V | tail -n1)" = "$reg_latest" ]; then
               DIST_TAG="release-$VERSION"
@@ -216,9 +277,11 @@ jobs:
             local dir="$1"
             local name
             name=$(node -p "require('./$dir/package.json').name")
-            if [ -z "$DRY_RUN" ] && npm view "$name@$VERSION" version >/dev/null 2>&1; then
-              echo "[npm-publish] $name@$VERSION already on the registry — skipping"
-              return 0
+            if [ -z "$DRY_RUN" ]; then
+              if version_exists "$name"; then
+                echo "[npm-publish] $name@$VERSION already on the registry — skipping"
+                return 0
+              fi
             fi
             echo "[npm-publish] publishing $name@$VERSION"
             if [ -n "$DRY_RUN" ]; then
@@ -228,6 +291,8 @@ jobs:
             fi
           }
 
+          # Publish platform packages first; the main package pins them via
+          # optionalDependencies and must be last.
           for dir in build/octo-cli-*; do
             publish_one "$dir"
           done

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -248,10 +248,12 @@ jobs:
 
           version_exists() {
             local name="$1"
+            local status
             if npm_view "$name@$VERSION" "$name@$VERSION" version >/dev/null; then
               return 0
+            else
+              status=$?
             fi
-            local status=$?
             if [ "$status" -eq 1 ]; then
               return 1
             fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,15 +4,16 @@
 #
 # Job graph:
 #
-#   publish ── build ──┬─ release-upload: gh release upload
-#                      └─ publish-npm: npm packages
+#   publish ── build ── release-upload: gh release upload ── publish-npm: npm packages
 #
 # Why this shape:
 #   * publish is the CI-evidence gate. Build intentionally waits for it so an
 #     arbitrary tag cannot run build steps before the gate passes.
-#   * the binaries are built EXACTLY ONCE; release-upload and publish-npm both
-#     consume the same `goreleaser-dist` artifact (npm no longer re-downloads
-#     from the Release).
+#   * the binaries are built EXACTLY ONCE; release-upload and publish-npm consume
+#     the same `goreleaser-dist` artifact (npm no longer re-downloads from the
+#     Release).
+#   * npm publish waits for release-upload, so immutable npm versions do not
+#     appear before the matching GitHub Release assets/checksums are attached.
 name: Release Publish
 
 on:
@@ -117,11 +118,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$TAG" dist/*.tar.gz dist/checksums.txt --clobber
 
-  # Repack the SAME build artifact into npm packages and publish. Reuses
-  # npm-publish.yml via workflow_call (from_artifact: true) so there is no
-  # duplicate publish logic and no second download from the Release.
+  # Repack the SAME build artifact into npm packages after the Release assets
+  # are attached. Reuses npm-publish.yml via workflow_call (from_artifact: true)
+  # so there is no duplicate publish logic and no second download from the
+  # Release.
   publish-npm:
-    needs: [publish, build]
+    needs: [publish, build, release-upload]
     if: ${{ inputs.draft == false }}
     uses: ./.github/workflows/npm-publish.yml
     with:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ For Node-based agent runtimes (OpenClaw, etc.):
 npm install -g @mininglamp-oss/octo-cli
 ```
 
-A thin wrapper that downloads the matching prebuilt binary on install.
+The npm package resolves the matching platform sub-package, which already
+contains the prebuilt binary. Install does not download binaries from GitHub.
 
 ### Go install
 
@@ -76,12 +77,15 @@ Download the latest binary for your platform from
 [GitHub Releases](https://github.com/Mininglamp-OSS/octo-cli/releases):
 
 ```bash
-# Archives are named octo-cli_<version>_<os>_<arch>.{tar.gz,zip}; pick the one
-# for your platform and substitute <version> (e.g. 0.5.0):
+# Archives are named octo-cli_<version>_<os>_<arch>.tar.gz for every platform,
+# including Windows. Pick the one for your platform and substitute <version>
+# (e.g. 0.5.0):
 curl -LO https://github.com/Mininglamp-OSS/octo-cli/releases/download/v<version>/octo-cli_<version>_linux_amd64.tar.gz
 tar xzf octo-cli_<version>_linux_amd64.tar.gz
 sudo mv octo-cli /usr/local/bin/
 ```
+
+Windows release archives are `.tar.gz` as well; Windows 10+ includes `tar.exe`.
 
 ### install.sh
 

--- a/npm/bin/octo-cli.js
+++ b/npm/bin/octo-cli.js
@@ -16,47 +16,80 @@ const PLATFORM_PACKAGES = {
   "win32-x64": "@mininglamp-oss/octo-cli-win32-x64",
 };
 
-function resolveBinary() {
-  const key = `${process.platform}-${process.arch}`;
+function platformKey(platform, arch) {
+  return `${platform}-${arch}`;
+}
+
+function platformPackageFor(platform, arch) {
+  return PLATFORM_PACKAGES[platformKey(platform, arch)];
+}
+
+function binaryNameFor(platform) {
+  return platform === "win32" ? "octo-cli.exe" : "octo-cli";
+}
+
+function resolveBinary(platform = process.platform, arch = process.arch, resolver = require.resolve) {
+  const key = platformKey(platform, arch);
   const pkg = PLATFORM_PACKAGES[key];
   if (!pkg) {
-    console.error(`[octo-cli] no prebuilt binary for ${key}.`);
-    console.error(
+    const err = new Error(`[octo-cli] no prebuilt binary for ${key}.`);
+    err.detail =
       "[octo-cli] Prebuilt binaries cover darwin/linux/win32 on x64/arm64. " +
-        "Build from source instead: https://github.com/Mininglamp-OSS/octo-cli",
-    );
-    process.exit(1);
+      "Build from source instead: https://github.com/Mininglamp-OSS/octo-cli";
+    throw err;
   }
 
-  const binName = process.platform === "win32" ? "octo-cli.exe" : "octo-cli";
+  const binName = binaryNameFor(platform);
   try {
-    return require.resolve(`${pkg}/bin/${binName}`);
+    return resolver(`${pkg}/bin/${binName}`);
   } catch (_err) {
-    console.error(`[octo-cli] platform package ${pkg} is not installed.`);
-    console.error(
+    const err = new Error(`[octo-cli] platform package ${pkg} is not installed.`);
+    err.detail =
       "[octo-cli] npm skips optionalDependencies when installed with " +
-        "--no-optional / --omit=optional, and some package managers need a " +
-        "lockfile refresh after a platform change.\n" +
-        "[octo-cli] Try reinstalling: npm install -g @mininglamp-oss/octo-cli",
-    );
-    process.exit(1);
+      "--no-optional / --omit=optional, and some package managers need a " +
+      "lockfile refresh after a platform change.\n" +
+      "[octo-cli] Try reinstalling: npm install -g @mininglamp-oss/octo-cli";
+    throw err;
   }
 }
 
-const res = spawnSync(resolveBinary(), process.argv.slice(2), { stdio: "inherit" });
+function main() {
+  let bin;
+  try {
+    bin = resolveBinary();
+  } catch (err) {
+    console.error(err.message);
+    if (err.detail) console.error(err.detail);
+    process.exit(1);
+  }
 
-if (res.error) {
-  console.error(`[octo-cli] ${res.error.message}`);
-  process.exit(1);
+  const res = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+
+  if (res.error) {
+    console.error(`[octo-cli] ${res.error.message}`);
+    process.exit(1);
+  }
+
+  // Re-raise terminating signals so the shell observes the conventional
+  // 128+signum exit code; for default-ignored signals (SIGPIPE, ...) the
+  // explicit exit below sets the code instead.
+  if (res.signal) {
+    process.kill(process.pid, res.signal);
+    const signum = (os.constants && os.constants.signals && os.constants.signals[res.signal]) || 0;
+    process.exit(128 + signum);
+  }
+
+  process.exit(res.status === null ? 1 : res.status);
 }
 
-// Re-raise terminating signals so the shell observes the conventional
-// 128+signum exit code; for default-ignored signals (SIGPIPE, ...) the
-// explicit exit below sets the code instead.
-if (res.signal) {
-  process.kill(process.pid, res.signal);
-  const signum = (os.constants && os.constants.signals && os.constants.signals[res.signal]) || 0;
-  process.exit(128 + signum);
-}
+module.exports = {
+  PLATFORM_PACKAGES,
+  binaryNameFor,
+  platformKey,
+  platformPackageFor,
+  resolveBinary,
+};
 
-process.exit(res.status === null ? 1 : res.status);
+if (require.main === module) {
+  main();
+}

--- a/npm/scripts/prepare-packages.js
+++ b/npm/scripts/prepare-packages.js
@@ -33,6 +33,7 @@ const { execFileSync } = require("child_process");
 
 const SCOPE = "@mininglamp-oss";
 const PROJECT = "octo-cli";
+const ARG_KEYS = new Set(["version", "dist", "out"]);
 
 // goreleaser (os, arch) -> npm (os, cpu). Single source of truth for the
 // platform matrix on the npm side; the guard test asserts set-equality with
@@ -66,7 +67,10 @@ function parseArgs(argv) {
     const key = argv[i];
     const val = argv[i + 1];
     if (!key.startsWith("--") || val === undefined) fail(`bad argument: ${key}`);
-    args[key.slice(2)] = val;
+    const name = key.slice(2);
+    if (!ARG_KEYS.has(name)) fail(`unknown argument: ${key}`);
+    if (Object.prototype.hasOwnProperty.call(args, name)) fail(`duplicate argument: ${key}`);
+    args[name] = val;
   }
   for (const required of ["version", "dist", "out"]) {
     if (!args[required]) fail(`--${required} is required`);
@@ -80,6 +84,12 @@ function parseArgs(argv) {
 
 function writeJson(file, obj) {
   fs.writeFileSync(file, JSON.stringify(obj, null, 2) + "\n");
+}
+
+function copyProjectDoc(npmDir, destDir, doc) {
+  const src = path.join(npmDir, doc);
+  const fallback = path.join(npmDir, "..", doc);
+  fs.copyFileSync(fs.existsSync(src) ? src : fallback, path.join(destDir, doc));
 }
 
 function main() {
@@ -101,7 +111,7 @@ function main() {
     const binFile = binFileName(p.goOs);
     const workDir = path.join(outDir, `.extract-${p.goOs}-${p.goArch}`);
     fs.mkdirSync(workDir, { recursive: true });
-    execFileSync("tar", ["-xzf", archive, "-C", workDir]);
+    execFileSync("tar", ["-xzf", archive, "-C", workDir, binFile]);
     const extracted = path.join(workDir, binFile);
     if (!fs.existsSync(extracted)) fail(`archive ${archive} does not contain ${binFile}`);
     const extractedStat = fs.lstatSync(extracted);
@@ -114,6 +124,7 @@ function main() {
     fs.mkdirSync(path.join(pkgDir, "bin"), { recursive: true });
     fs.copyFileSync(extracted, path.join(pkgDir, "bin", binFile));
     fs.chmodSync(path.join(pkgDir, "bin", binFile), 0o755);
+    copyProjectDoc(npmDir, pkgDir, "LICENSE");
     fs.rmSync(workDir, { recursive: true, force: true });
 
     writeJson(path.join(pkgDir, "package.json"), {
@@ -122,7 +133,7 @@ function main() {
       description: `${PROJECT} prebuilt binary for ${p.npmOs}-${p.npmCpu}.`,
       os: [p.npmOs],
       cpu: [p.npmCpu],
-      files: [`bin/${binFile}`],
+      files: [`bin/${binFile}`, "LICENSE"],
       engines: { node: ">=18" },
       homepage: "https://github.com/Mininglamp-OSS/octo-cli#readme",
       repository: {
@@ -144,11 +155,7 @@ function main() {
     path.join(npmDir, "bin", "octo-cli.js"),
     path.join(mainDir, "bin", "octo-cli.js"),
   );
-  for (const doc of ["README.md", "LICENSE"]) {
-    const src = path.join(npmDir, doc);
-    const fallback = path.join(npmDir, "..", doc);
-    fs.copyFileSync(fs.existsSync(src) ? src : fallback, path.join(mainDir, doc));
-  }
+  for (const doc of ["README.md", "LICENSE"]) copyProjectDoc(npmDir, mainDir, doc);
 
   const manifest = JSON.parse(fs.readFileSync(path.join(npmDir, "package.json"), "utf8"));
   manifest.version = version;
@@ -159,7 +166,7 @@ function main() {
   console.log(`[prepare-packages] ${SCOPE}/${PROJECT}@${version} (main, ${PLATFORMS.length} platform deps)`);
 }
 
-module.exports = { PLATFORMS, binFileName };
+module.exports = { PLATFORMS, binFileName, parseArgs };
 
 if (require.main === module) {
   main();

--- a/npm/scripts/prepare-packages.test.js
+++ b/npm/scripts/prepare-packages.test.js
@@ -10,6 +10,7 @@ const { execFileSync, spawnSync } = require("child_process");
 const SCRIPT = path.join(__dirname, "prepare-packages.js");
 const SHIM = path.join(__dirname, "..", "bin", "octo-cli.js");
 const GORELEASER_YAML = path.join(__dirname, "..", "..", ".goreleaser.yaml");
+const NPM_PUBLISH_YAML = path.join(__dirname, "..", "..", ".github", "workflows", "npm-publish.yml");
 const { PLATFORMS, binFileName } = require(SCRIPT);
 const shim = require(SHIM);
 const VERSION = "9.9.9";
@@ -214,4 +215,78 @@ test("shim reports a missing platform package", (t) => {
   assert.strictEqual(res.status, 1);
   assert.match(res.stderr, new RegExp(`platform package ${scopedPkg} is not installed`));
   assert.match(res.stderr, /Try reinstalling: npm install -g @mininglamp-oss\/octo-cli/);
+});
+
+test("npm publish helper treats registry 404 as not published", () => {
+  if (process.platform === "win32") {
+    return;
+  }
+
+  const workflow = fs.readFileSync(NPM_PUBLISH_YAML, "utf8");
+  const start = workflow.indexOf("          npm_view() {\n");
+  const end = workflow.indexOf('\n          if [ "$DIST_TAG" = "latest" ]; then', start);
+  assert.notStrictEqual(start, -1, "cannot find npm_view helper in npm-publish.yml");
+  assert.notStrictEqual(end, -1, "cannot find helper terminator in npm-publish.yml");
+  const helpers = workflow.slice(start, end).replace(/^ {10}/gm, "");
+
+  const res = spawnSync(
+    "bash",
+    [
+      "-c",
+      `
+set -euo pipefail
+VERSION=9.9.9
+NPM_VIEW_MODE=exists
+
+npm() {
+  if [ "$1" != "view" ]; then
+    echo "unexpected npm command: $*" >&2
+    return 70
+  fi
+  case "$NPM_VIEW_MODE" in
+    exists)
+      printf '9.9.9\\n'
+      return 0
+      ;;
+    missing)
+      printf 'npm ERR! code E404\\n' >&2
+      printf 'npm ERR! 404 Not Found - GET https://registry.npmjs.org/%s - Not found\\n' "$2" >&2
+      return 1
+      ;;
+    hard)
+      printf 'npm ERR! network timeout\\n' >&2
+      return 1
+      ;;
+  esac
+}
+
+sleep() { :; }
+
+${helpers}
+
+NPM_VIEW_MODE=exists
+if ! version_exists "@mininglamp-oss/octo-cli-darwin-arm64"; then
+  echo "expected existing version to return 0" >&2
+  exit 1
+fi
+
+NPM_VIEW_MODE=missing
+if version_exists "@mininglamp-oss/octo-cli-darwin-arm64"; then
+  echo "expected missing version to return 1" >&2
+  exit 1
+fi
+
+NPM_VIEW_MODE=hard
+if (version_exists "@mininglamp-oss/octo-cli-darwin-arm64"); then
+  echo "expected hard npm view failure to exit non-zero" >&2
+  exit 1
+fi
+
+echo helper-ok
+`,
+    ],
+    { encoding: "utf8" },
+  );
+  assert.strictEqual(res.status, 0, res.stderr || res.stdout);
+  assert.match(res.stdout, /helper-ok/);
 });

--- a/npm/scripts/prepare-packages.test.js
+++ b/npm/scripts/prepare-packages.test.js
@@ -11,6 +11,7 @@ const SCRIPT = path.join(__dirname, "prepare-packages.js");
 const SHIM = path.join(__dirname, "..", "bin", "octo-cli.js");
 const GORELEASER_YAML = path.join(__dirname, "..", "..", ".goreleaser.yaml");
 const { PLATFORMS, binFileName } = require(SCRIPT);
+const shim = require(SHIM);
 const VERSION = "9.9.9";
 
 function makeDist(distDir) {
@@ -67,10 +68,11 @@ test("emits one package per platform and a pinned main package", (t) => {
     assert.strictEqual(manifest.version, VERSION);
     assert.deepStrictEqual(manifest.os, [npmOs]);
     assert.deepStrictEqual(manifest.cpu, [npmCpu]);
-    assert.deepStrictEqual(manifest.files, [`bin/${binFileName(goOs)}`]);
+    assert.deepStrictEqual(manifest.files, [`bin/${binFileName(goOs)}`, "LICENSE"]);
     const bin = path.join(pkgDir, "bin", binFileName(goOs));
     assert.ok(fs.existsSync(bin), `missing ${bin}`);
     assert.ok(fs.statSync(bin).mode & 0o100, `${bin} not executable`);
+    assert.ok(fs.existsSync(path.join(pkgDir, "LICENSE")), `missing ${pkgDir}/LICENSE`);
   }
 
   const main = JSON.parse(fs.readFileSync(path.join(outDir, "octo-cli", "package.json"), "utf8"));
@@ -101,6 +103,38 @@ test("rejects invalid versions and missing archives", (t) => {
   const missing = run(["--version", VERSION, "--dist", path.join(tmp, "dist"), "--out", path.join(tmp, "out")]);
   assert.notStrictEqual(missing.status, 0);
   assert.match(missing.stderr, /missing release archive/);
+});
+
+test("rejects unknown and duplicate arguments before touching output paths", (t) => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "octo-cli-prep-"));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(tmp, "dist"));
+
+  const unknown = run([
+    "--version",
+    VERSION,
+    "--dist",
+    path.join(tmp, "dist"),
+    "--out",
+    path.join(tmp, "out"),
+    "--cache",
+    path.join(tmp, "cache"),
+  ]);
+  assert.notStrictEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /unknown argument: --cache/);
+
+  const duplicate = run([
+    "--version",
+    VERSION,
+    "--dist",
+    path.join(tmp, "dist"),
+    "--out",
+    path.join(tmp, "out"),
+    "--out",
+    path.join(tmp, "other-out"),
+  ]);
+  assert.notStrictEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /duplicate argument: --out/);
 });
 
 test("rejects archive members that are not regular files", (t) => {
@@ -139,14 +173,9 @@ test("shim resolves the installed platform package and propagates output", (t) =
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "octo-cli-shim-"));
   t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
 
-  const key = `${process.platform}-${process.arch}`;
-  const pkg = {
-    "darwin-arm64": "octo-cli-darwin-arm64",
-    "darwin-x64": "octo-cli-darwin-x64",
-    "linux-arm64": "octo-cli-linux-arm64",
-    "linux-x64": "octo-cli-linux-x64",
-  }[key];
-  assert.ok(pkg, `test host ${key} must be part of the supported matrix`);
+  const scopedPkg = shim.platformPackageFor(process.platform, process.arch);
+  assert.ok(scopedPkg, `test host ${process.platform}-${process.arch} must be part of the supported matrix`);
+  const pkg = scopedPkg.replace("@mininglamp-oss/", "");
 
   const pkgDir = path.join(tmp, "node_modules", "@mininglamp-oss", pkg, "bin");
   fs.mkdirSync(pkgDir, { recursive: true });
@@ -160,4 +189,29 @@ test("shim resolves the installed platform package and propagates output", (t) =
   });
   assert.strictEqual(res.status, 0, res.stderr);
   assert.strictEqual(res.stdout.trim(), "shim-ok --ping");
+});
+
+test("shim resolver maps windows packages to the .exe binary", () => {
+  const resolved = shim.resolveBinary("win32", "x64", (specifier) => specifier);
+  assert.strictEqual(resolved, "@mininglamp-oss/octo-cli-win32-x64/bin/octo-cli.exe");
+  assert.strictEqual(shim.binaryNameFor("win32"), "octo-cli.exe");
+  assert.strictEqual(shim.binaryNameFor("linux"), "octo-cli");
+});
+
+test("shim reports a missing platform package", (t) => {
+  const scopedPkg = shim.platformPackageFor(process.platform, process.arch);
+  assert.ok(scopedPkg, `test host ${process.platform}-${process.arch} must be part of the supported matrix`);
+
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "octo-cli-shim-missing-"));
+  t.after(() => fs.rmSync(tmp, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(tmp, "node_modules"), { recursive: true });
+
+  const res = spawnSync(process.execPath, [SHIM, "--ping"], {
+    cwd: tmp,
+    env: { ...process.env, NODE_PATH: path.join(tmp, "node_modules") },
+    encoding: "utf8",
+  });
+  assert.strictEqual(res.status, 1);
+  assert.match(res.stderr, new RegExp(`platform package ${scopedPkg} is not installed`));
+  assert.match(res.stderr, /Try reinstalling: npm install -g @mininglamp-oss\/octo-cli/);
 });


### PR DESCRIPTION
## What
Follow-up to #56. The bundled npm package flow is merged, but reviewers called
out several hardening items around publish ordering, checksum validation,
archive extraction, platform-package metadata, and shim test coverage.

## How
- **release-publish.yml** — makes `publish-npm` wait for `release-upload`, so an
  immutable npm version is not published before the matching GitHub Release
  assets and checksums are attached.
- **npm-publish.yml** — verifies checksums using an exact per-archive subset,
  adds retry/error handling around `npm view`, and restores terse security
  comments for the release/CI gates and publish ordering.
- **prepare-packages.js** — rejects unknown or duplicate arguments before
  touching `--out`, extracts only the expected binary member from each archive,
  and ships `LICENSE` in every platform sub-package.
- **octo-cli.js / prepare-packages.test.js** — makes the shim resolver
  injectable for tests, adds Windows `.exe` path coverage, and locks in the
  missing-platform-package error path.
- **README.md** — documents that npm installs use platform sub-packages and that
  GitHub Release archives are `.tar.gz` for all platforms, Windows included.

## Tests
- `npm --prefix npm test`
- `actionlint .github/workflows/ci.yml .github/workflows/npm-publish.yml .github/workflows/release-publish.yml`
- `goreleaser check`
- `git diff --check`
- Local npm tarball smoke: generated fake release archives, packed the main
  package plus the current platform sub-package, installed them from local
  tarballs with `--offline --omit=optional`, and verified `.bin/octo-cli`
  executes with mode `755`.

Follow-up to #56.

Closes #59.
