### PR TITLE
feat: add .octospec/rules for AI agent architectural constraints

### DIFF
--- a/.octospec/index.md
+++ b/.octospec/index.md
@@ -1,0 +1,36 @@
+# .octospec — octo-cli architectural constraints
+
+`.octospec/` 存放 **octo-cli 仓库专属的架构约束（rules）**，供 AI 执行器（Claude Code 等）在改动
+对应代码时自动注入，使生成的改动符合本仓的真实模式与安全边界。结构与 octo-server 同构。
+
+## 什么是 rule
+
+每条 rule 是一段可注入的约束，落在 `rules/<id>.md`，frontmatter 携带可被工具解析的扩展字段：
+
+| 字段 | 含义 |
+|------|------|
+| `id` | 全局唯一标识 |
+| `tier` | `repo`（仓库级）/ 继承的全局级 |
+| `priority` | 预算受限时的排序权重（越大越先注入） |
+| `load_bearing` | 是否为「红线」：架构根基 / 安全边界 / wire 契约。预算受限时优先保留 |
+| `inject_when.paths` | 命中这些路径 glob 时注入 |
+| `inject_when.touches` | 命中这些主题标签时注入（与 paths 取并集） |
+| `source` | `self` 或继承来源（如 `octo-spec@1.1.0`） |
+
+## 消费方式
+
+- 工具读 `rules/_index.yaml`（镜像各 rule 的 frontmatter）来决定注入哪些 rule，无需逐文件解析。
+- 注入触发：`inject_when.paths` glob **或** `inject_when.touches` 标签命中（并集），每条注入一次。
+- 预算受限时：先保 `load_bearing: true`，再按 `priority` 降序；被截断的 rule 仅注入 summary 行。
+
+## 当前 rules（11 条 = 7 load-bearing + 4 约定级）
+
+详见 `rules/_index.yaml`。load-bearing 7 条：envelope-io-contract、credential-at-rest、
+metadata-driven-registry、credential-resolution、error-taxonomy、factory-di-no-globals、transport-client。
+
+## 维护约定
+
+- **改了真实代码模式，同步改 rule**——rule 描述的是代码里实际存在的模式，不是愿望。
+- **rule 正文引用 `CLAUDE.md` 对应段落（`> See CLAUDE.md § "…"`），不复制大段**，避免两份漂移。
+- rule 基于真实代码核实产出，不凭印象；未在代码中出现的模式（如服务端才有的 rate-limit /
+  space-isolation）不产出 rule。

--- a/.octospec/rules/_index.yaml
+++ b/.octospec/rules/_index.yaml
@@ -1,0 +1,89 @@
+# Rule index for octo-cli .octospec/rules/
+# Mirrors each rule's frontmatter so tooling can resolve injection without
+# parsing every file.
+#
+# Resolution semantics:
+#   - id is globally unique (including inherited global rules).
+#   - a repo-tier rule with the same id overrides the global one.
+#   - inject_when = paths glob OR touches tag (union); injected once.
+#   - over budget: keep load_bearing first, then priority desc; truncated rules
+#     inject only their summary line.
+
+rules:
+  - id: envelope-io-contract
+    priority: 92
+    load_bearing: true
+    summary: "所有输出走 Factory→output 的 JSON 信封，禁止裸写 stdout/stderr"
+    inject_when:
+      paths: ["cmd/**/*.go", "internal/output/**/*.go", "internal/cmdutil/factory.go"]
+      touches: ["envelope", "output", "stdout", "stderr", "wire-contract", "exit-code"]
+  - id: credential-at-rest
+    priority: 92
+    load_bearing: true
+    summary: "token 仅以 AES-256-GCM 机器绑定密文落盘；元数据明文；权限 0600/0700；token 绝不入 argv"
+    inject_when:
+      paths: ["internal/authstore/**/*.go", "cmd/auth.go", "cmd/auth_test.go"]
+      touches: ["token", "secret", "encryption", "authstore", "file-permissions", "argv", "credential"]
+  - id: metadata-driven-registry
+    priority: 90
+    load_bearing: true
+    summary: "端点由内嵌 OpenAPI spec 驱动；改端点改 spec 不改代码；CLI 是 thin client"
+    inject_when:
+      paths: ["internal/registry/specs/**", "internal/registry/**/*.go", "cmd/service/**/*.go"]
+      touches: ["spec", "openapi", "registry", "command-registration", "x-octo", "endpoint", "business-logic"]
+  - id: credential-resolution
+    priority: 88
+    load_bearing: true
+    summary: "file→env 凭证链；多 profile 选择歧义是硬错误，绝不静默猜测"
+    inject_when:
+      paths: ["internal/credential/**/*.go", "internal/cmdutil/factory.go"]
+      touches: ["credential", "auth", "profile", "bot-id", "identity", "ambiguity"]
+  - id: error-taxonomy
+    priority: 85
+    load_bearing: true
+    summary: "错误统一收敛到 *output.ExitError；后端错误经 ParseBackendError 映射；退出码固定"
+    inject_when:
+      paths: ["internal/output/errors.go", "internal/client/client.go", "internal/cmdutil/factory.go", "cmd/**/*.go"]
+      touches: ["error", "exit-code", "taxonomy", "backend-error", "wire-contract"]
+  - id: factory-di-no-globals
+    priority: 82
+    load_bearing: true
+    summary: "状态只经 cmdutil.Factory 流动；禁止可变包级全局（仅三类豁免）"
+    inject_when:
+      paths: ["internal/**/*.go", "cmd/**/*.go"]
+      touches: ["factory", "di", "globals", "dependency-injection", "state"]
+  - id: transport-client
+    priority: 78
+    load_bearing: true
+    summary: "出站请求统一经 client.Client：注入鉴权头、重试退避、不自动跟随重定向"
+    inject_when:
+      paths: ["internal/client/**/*.go", "cmd/service/run.go"]
+      touches: ["http", "retry", "redirect", "auth-header", "backoff", "timeout"]
+  - id: output-leaf-package
+    priority: 75
+    load_bearing: false
+    summary: "internal/output 是叶子包，不得 import 其他 internal/*"
+    inject_when:
+      paths: ["internal/output/**/*.go"]
+      touches: ["output", "leaf", "imports", "architecture"]
+  - id: disabled-flag-parity
+    priority: 62
+    load_bearing: false
+    summary: "x-octo-disabled(spec) 与 disabled:(skill frontmatter) 必须同改同步；命令形态变更同步 skills/"
+    inject_when:
+      paths: ["internal/registry/specs/*.json", "skills/*/SKILL.md", "cmd/skills.go", "cmd/root.go", "internal/registry/loader.go", "cmd/service/**/*.go"]
+      touches: ["disabled", "withhold", "skill", "spec", "parity", "skills-sync"]
+  - id: code-style
+    priority: 55
+    load_bearing: false
+    summary: "gofmt/vet；%w 包裹；全英文非 i18n；依赖白名单；JSON 字段下划线"
+    inject_when:
+      paths: ["**/*.go", "go.mod"]
+      touches: ["style", "gofmt", "error-wrap", "dependency", "i18n-english"]
+  - id: commit-style
+    priority: 55
+    load_bearing: false
+    summary: "英文 Conventional Commits；lefthook 校验；禁用 --no-verify"
+    inject_when:
+      paths: ["**"]
+      touches: ["commit", "git", "pr"]

--- a/.octospec/rules/code-style.md
+++ b/.octospec/rules/code-style.md
@@ -1,0 +1,30 @@
+---
+type: Rule
+title: Code style
+description: gofmt/vet clean; wrap errors with %w; all user-facing text English (no i18n); dependency allowlist; underscore JSON fields.
+tags: ["style", "gofmt", "error-wrap", "dependency", "i18n-english"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: code-style
+tier: repo
+priority: 55
+load_bearing: false
+inject_when:
+  paths: ["**/*.go", "go.mod"]
+  touches: ["style", "gofmt", "error-wrap", "dependency", "i18n-english"]
+source: self
+supersedes: []
+---
+
+# Code style
+
+> See CLAUDE.md § "Code Style" & "Build & Test"。
+
+## Rules
+
+- `gofmt` + `go vet` 必过；golangci-lint 在 CI 强制（`.golangci.yml`、`Makefile ci`）。
+- 错误包裹 `fmt.Errorf("context: %w", err)`；CLI 错误用 `*output.ExitError` taxonomy（见 `error-taxonomy`）。
+- 外部依赖严格限定 cobra / gojq / `golang.org/x/term` + 标准库；**新增依赖需强理由**。
+- **全部用户可见文案 English；本仓不做 i18n**（与 octo-server 的 i18n 信封相反——别误把 i18n 约定搬过来）。
+- on-disk JSON 字段下划线命名（如 `api_base_url`、`robot_id`，`authstore.ProfileMeta`）。
+- 注：通用 CLAUDE.md 模板里的 JavaDoc `@author` 约定**不适用**本 Go 仓（无此约定，勿误植）。

--- a/.octospec/rules/commit-style.md
+++ b/.octospec/rules/commit-style.md
@@ -1,0 +1,31 @@
+---
+type: Rule
+title: Commit & PR style
+description: English Conventional Commits enforced by lefthook; read CONTRIBUTING.md before a PR; never bypass hooks with --no-verify.
+tags: ["commit", "git", "pr"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: commit-style
+tier: repo
+priority: 55
+load_bearing: false
+inject_when:
+  paths: ["**"]
+  touches: ["commit", "git", "pr"]
+source: octo-spec@1.1.0
+supersedes: []
+---
+
+# Commit & PR style
+
+继承全局 `commit` / `pr` 规则。仓库具体约定如下。
+
+> See CONTRIBUTING.md（Git Hooks）& CLAUDE.md § "Build & Test"。
+
+## Rules
+
+- 英文 **Conventional Commits**（`feat/fix/test/refactor/chore/docs`），由 lefthook `commit-msg` 钩子
+  `.lefthook/commit-msg-check.sh` 校验。
+- pre-commit：gofmt + go vet + golangci-lint(可选)；pre-push：mod-tidy 漂移检查 + build + vet（`lefthook.yml`）。
+- 开 PR 前读 `CONTRIBUTING.md`。
+- **禁用 `--no-verify` 绕过钩子。**

--- a/.octospec/rules/credential-at-rest.md
+++ b/.octospec/rules/credential-at-rest.md
@@ -1,0 +1,44 @@
+---
+type: Rule
+title: Credential at-rest security
+description: Tokens persist only as AES-256-GCM machine-bound ciphertext; metadata stays plaintext; tight file perms; tokens never touch argv.
+tags: ["security", "token", "secret", "encryption", "authstore", "trust-boundary"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: credential-at-rest
+tier: repo
+priority: 92
+load_bearing: true
+inject_when:
+  paths: ["internal/authstore/**/*.go", "cmd/auth.go", "cmd/auth_test.go"]
+  touches: ["token", "secret", "encryption", "authstore", "file-permissions", "argv", "credential"]
+source: self
+supersedes: []
+---
+
+# Credential at-rest security
+
+凭证落盘的安全不变量（`internal/authstore/`）。信任边界 = OS 用户账户：加密密钥机器绑定，
+密文抵抗离机泄露（误提交/备份/云同步），但不防同机同用户进程。
+
+> See CLAUDE.md § "Identity Model"（credential resolution & isolation boundary）。
+
+## Rules
+
+- token 只以 **AES-256-GCM** 写入 `credentials.enc`，密钥 `SHA256(machineID ‖ salt)`
+  （`crypto.go: deriveKey/seal/open`）。
+- 非密元数据（`ProfileMeta`）写明文 `config.json`；**token 绝不进明文**。
+- 文件权限：目录 `0700`、密文/盐 `0600`、元数据 `0644`；`ensureDir` 会收紧已存在的过宽目录
+  （防 restore-from-backup 的 0755 泄露 profile 名）。
+- 所有写入走 `atomicWrite`（temp + rename），杜绝半写文件。
+- `SaveProfile`/`RemoveProfile` 固定顺序（先 token 后元数据 / 先元数据后 token），
+  使崩溃只留「孤儿 token（不可见）」而非「列出但无 token 的 profile」。
+- 密钥/盐变化或盐长度异常**必须 fail loud**（提示删文件重 login），绝不静默重生成盐
+  （会让所有 token 不可解）。
+- `octo-cli auth login` 的 token 来源仅限：隐藏终端提示（`golang.org/x/term`）、`--with-token`（stdin）、
+  `--token-file`——**永不经 argv**（防 shell history / 进程列表泄露，`cmd/auth.go`）。
+- `status`/`list`/`--dry-run` 输出的 token 一律经 `credential.MaskToken` 掩码。
+
+## Why load-bearing
+
+这是 CLI 唯一的密钥静态存储面；任何权限放宽、明文落盘或 argv 泄露都是直接的凭证泄露。

--- a/.octospec/rules/credential-resolution.md
+++ b/.octospec/rules/credential-resolution.md
@@ -1,0 +1,43 @@
+---
+type: Rule
+title: Credential resolution & selector ambiguity
+description: Credentials resolve through a file→env chain; multi-profile selection ambiguity is a hard error, never a silent guess.
+tags: ["credential", "auth", "profile", "bot-id", "identity"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: credential-resolution
+tier: repo
+priority: 88
+load_bearing: true
+inject_when:
+  paths: ["internal/credential/**/*.go", "internal/cmdutil/factory.go"]
+  touches: ["credential", "auth", "profile", "bot-id", "identity", "ambiguity"]
+source: self
+supersedes: []
+---
+
+# Credential resolution & selector ambiguity
+
+运行期凭证解析走 `credential.Provider` 链：`FileProvider`(profile) → `EnvProvider`(env)。
+
+> See CLAUDE.md § "Identity Model"（selecting a credential at runtime）。
+
+## Rules
+
+- Source 约定：源**缺席**返回 `(nil, nil)` 让链继续；源**存在但损坏**返回 error 终止链
+  （`provider.go` 接口注释）。
+- 选择器优先级：`--bot-id`/`OCTO_BOT_ID`（robot id，agent 主选择器）与 `--profile`（友好名）
+  > 唯一/隐式 profile > `OCTO_BOT_TOKEN`。
+- **歧义即硬错误，绝不静默猜测**：
+  - ≥2 个 profile 且无选择器 → `StatusAmbiguous` → validation error（exit 2）；
+  - 选择器给了但不匹配 → `StatusMissing` → auth error（exit 3）；
+  - 0 个 profile → `StatusNone` → 落到 env（`file_provider.go` / `authstore.ActiveProfile`）。
+- env token 不携带可验证身份：从 env 解析的 credential 的 `Profile/RobotID/BotKind` 留空
+  （`provider.go: BotCredential` 注释）。
+- `buildConfig` 只吞 `ErrNoCredential`（让 `cfg.Validate` 报熟悉的 `OCTO_BOT_TOKEN` 提示）；
+  结构化解析错误与真实 IO 错误一律上浮，不得伪装成「缺 token」。
+- token 类型仅看前缀：`app_*`→app_bot，`bf_*`→user_bot（`token.go: TokenKind`）；其余路由在服务端。
+
+## Why load-bearing
+
+错误的凭证解析 = agent 以错误身份执行操作；静默选择某个 bot 是跨身份越权风险。

--- a/.octospec/rules/disabled-flag-parity.md
+++ b/.octospec/rules/disabled-flag-parity.md
@@ -1,0 +1,42 @@
+---
+type: Rule
+title: Disabled-flag parity & skills sync
+description: "x-octo-disabled (spec) and the skill frontmatter disabled flag must flip together; command-shape changes must sync the matching SKILL.md."
+tags: ["disabled", "withhold", "skill", "spec", "parity", "skills-sync"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: disabled-flag-parity
+tier: repo
+priority: 62
+load_bearing: false
+inject_when:
+  paths: ["internal/registry/specs/*.json", "skills/*/SKILL.md", "cmd/skills.go", "cmd/root.go", "internal/registry/loader.go", "cmd/service/**/*.go"]
+  touches: ["disabled", "withhold", "skill", "spec", "parity", "skills-sync"]
+source: self
+supersedes: []
+---
+
+# Disabled-flag parity & skills sync
+
+withhold 一个 domain（如 `matter`，后端 API 未稳）需**两处同步翻转**，否则两个面会漂移。
+
+> See CLAUDE.md § "Command Structure"（matter withheld via x-octo-disabled + skill disabled frontmatter）。
+
+## Rules
+
+- spec 侧 `x-octo-disabled: true`（`internal/registry/specs/matter.json`）——服务仍 load
+  （`schema` 与引擎仍可见），但从命令树与全局发现列表中移除
+  （`registry.ServiceDisabled/EnabledServices`，`cmd/root.go: withholdDisabledServices`）。
+- skill 侧 frontmatter `disabled: true`（`skills/octo-matter/SKILL.md`）——从 `octo-cli skills` 列表移除
+  （`cmd/skills.go: skillDisabled`）。
+- 两处共用同一 truthiness：JSON `true` 或字符串 `"true"`（`registry.truthy`），刻意一致以防漂移。
+
+## Skills documentation sync（附注）
+
+agent 面向用法在 `skills/`（`octo-shared`、`octo-messaging`、`octo-files`、`octo-matter`(withheld)）。
+**命令形态（新增 / 改名 / 参数变化）变更时，必须同步对应 SKILL.md**（CLAUDE.md 末「keep those in sync」）——
+否则 agent 会按过时形态调用。
+
+## Why
+
+仅改一处会导致命令隐藏但 skill 仍宣传（或反之），给 agent 矛盾信号。非安全级，故 load_bearing: false。

--- a/.octospec/rules/envelope-io-contract.md
+++ b/.octospec/rules/envelope-io-contract.md
@@ -1,0 +1,42 @@
+---
+type: Rule
+title: JSON envelope I/O contract
+description: All command output goes through the Factory→output JSON envelope; never write raw to stdout/stderr.
+tags: ["envelope", "output", "wire-contract", "exit-code"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: envelope-io-contract
+tier: repo
+priority: 92
+load_bearing: true
+inject_when:
+  paths: ["cmd/**/*.go", "internal/output/**/*.go", "internal/cmdutil/factory.go"]
+  touches: ["envelope", "output", "stdout", "stderr", "wire-contract", "exit-code"]
+source: self
+supersedes: []
+---
+
+# JSON envelope I/O contract
+
+命令产物只能通过统一 JSON 信封发出。agent runtime 把 stdout/stderr 当作唯一解析入口，
+任何裸输出都会破坏这个 wire contract。
+
+> See CLAUDE.md § "Architecture" → "JSON envelope I/O"。
+
+## Rules
+
+- 成功走 `Factory.EmitSuccess` / `EmitSuccessWithMeta` → `output.WriteSuccess`，stdout 形如
+  `{ok:true, identity, data, _pagination, _rate_limit, _notice}`（`internal/output/envelope.go`）。
+- 失败走 `Factory.EmitError` → `output.WriteError`，stderr 形如
+  `{ok:false, error:{type,code,message,hint,detail}}`。
+- `--jq` 在**信封成形之后**再过滤（`Factory.emit`：先 `WriteSuccess` 进 buffer 再 `ApplyJQ`），
+  保证 jq 作用于规范信封而非后端原始形状。
+- `identity` 永远是对象：默认 `{type:"bot"}`，认证过的命令补 `{profile,robot_id,bot_kind,source}`
+  （`Factory.identityValue`）——只读已缓存的 credential，从不强制解析。
+- `_pagination` 仅在后端返回 `{data:[], pagination:{}}` 形状时拆分平铺（`splitPagination`）。
+- `Factory.ErrorEmitted` 防止 RunE 与顶层 main 双重输出错误信封。
+- **禁止**在 handler/RunE 里直接 `fmt.Fprintln(os.Stdout, …)` 或手写 JSON 响应。
+
+## Why load-bearing
+
+stdout/stderr 的信封是 agent runtime 唯一解析入口；任何绕过信封的裸输出都会让上游误判命令成败。

--- a/.octospec/rules/error-taxonomy.md
+++ b/.octospec/rules/error-taxonomy.md
@@ -1,0 +1,39 @@
+---
+type: Rule
+title: Error taxonomy & exit codes
+description: Errors converge on *output.ExitError; backend errors map via ParseBackendError; exit codes are fixed and part of the wire contract.
+tags: ["error", "exit-code", "taxonomy", "backend-error", "wire-contract"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: error-taxonomy
+tier: repo
+priority: 85
+load_bearing: true
+inject_when:
+  paths: ["internal/output/errors.go", "internal/client/client.go", "internal/cmdutil/factory.go", "cmd/**/*.go"]
+  touches: ["error", "exit-code", "taxonomy", "backend-error", "wire-contract"]
+source: self
+supersedes: []
+---
+
+# Error taxonomy & exit codes
+
+所有到达顶层的错误必须是 `*output.ExitError`，使信封渲染器能输出结构化错误，agent 据
+`type`/`code` 决策。与 `envelope-io-contract` 分工：envelope 管「怎么发」，本 rule 管「错误如何分类」。
+
+> See CLAUDE.md § "Code Style"（ExitError taxonomy）& "Architecture"（exit codes）。
+
+## Rules
+
+- taxonomy：`auth_error | validation | api_error | network | rate_limited | permission | internal | config`（`errors.go`）。
+- 退出码固定：`auth_error`→3，`validation`/`config`→2，其余→1（`ExitError.ExitCode`）。
+- 构造器：`ErrAuth/ErrValidation/ErrAPI/ErrNetwork/ErrWithHint`；非 ExitError 经 `WrapCLIError`
+  （窄启发式：缺 token / 未知 flag / 参数错）分类后再渲染。
+- 后端错误经 `ParseBackendError` 三层解析：matters 信封 `{error:{code,message,details}}` →
+  dmworkim `{msg,status}` → 原始 body + status 推断；code→type/hint 经**不可变**映射表 `backendErrorMapping`。
+- HTTP status→type/code 的映射（`typeFromStatus`/`codeFromStatus`）是 wire 契约的一部分，改动需同步 agent 侧预期。
+- 用 `errors.As` 解包（`AsExitError`），使 retry 包装器 `retryableErr` 的结构化信息仍可穿透。
+
+## Why load-bearing
+
+退出码与 `error.type/code` 是 agent 的分支依据；裸 error 或错误码会让上游误判可重试性 / 是否换凭证。

--- a/.octospec/rules/factory-di-no-globals.md
+++ b/.octospec/rules/factory-di-no-globals.md
@@ -1,0 +1,38 @@
+---
+type: Rule
+title: Factory DI, no mutable globals
+description: State flows only through cmdutil.Factory; no mutable package-level globals (three documented exceptions only).
+tags: ["factory", "di", "dependency-injection", "globals", "architecture"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: factory-di-no-globals
+tier: repo
+priority: 82
+load_bearing: true
+inject_when:
+  paths: ["internal/**/*.go", "cmd/**/*.go"]
+  touches: ["factory", "di", "globals", "dependency-injection", "state"]
+source: self
+supersedes: []
+---
+
+# Factory DI, no mutable globals
+
+`cmdutil.Factory` 是唯一 DI 容器，命令只拿 `*Factory` 再按需解析其余依赖。
+
+> See CLAUDE.md § "Architecture" → "Factory DI" & "Code Style"（no mutable package-level globals）。
+
+## Rules
+
+- 所有 accessor 惰性 + 缓存（`ConfigFunc/CredentialFunc/ClientFunc/RegistryFunc`，`factory.go`）；命令只取自己需要的。
+- 测试经 hook 注入 stub（`TestFactory.SetClient/SetConfig/SetCredential`），不碰真实环境。
+- **禁止可变包级全局**；唯一豁免（CLAUDE.md 明列、代码可核对）：
+  - (a) ldflags 注入的构建元数据 `cmd/build.go`；
+  - (b) `//go:embed` 文件系统 `internal/registry`、`skills`；
+  - (c) 不可变查找表（`backendErrorMapping`、`httpMethods`）。
+  这些是 const 等价、运行期不改。
+- 新 leaf command 经 `NewXxxCmd(f *cmdutil.Factory)` 构造并在 `cmd/root.go` AddCommand。
+
+## Why load-bearing
+
+包级可变状态会破坏测试隔离与并发安全；Factory 边界是可测试性的根基。

--- a/.octospec/rules/metadata-driven-registry.md
+++ b/.octospec/rules/metadata-driven-registry.md
@@ -1,0 +1,54 @@
+---
+type: Rule
+title: Metadata-driven command registry
+description: The service command tree is auto-registered from embedded OpenAPI specs; change an endpoint by editing a spec, not code. The CLI is a thin client.
+tags: ["spec", "openapi", "registry", "command-registration", "architecture", "thin-client"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: metadata-driven-registry
+tier: repo
+priority: 90
+load_bearing: true
+inject_when:
+  paths: ["internal/registry/specs/**", "internal/registry/**/*.go", "cmd/service/**/*.go"]
+  touches: ["spec", "openapi", "registry", "command-registration", "x-octo", "endpoint", "business-logic"]
+source: self
+supersedes: []
+---
+
+# Metadata-driven command registry
+
+整棵 service 命令树在启动时由内嵌 OpenAPI 3.x spec 自动注册——**改端点 = 改 spec，不改代码**。
+
+> See CLAUDE.md § "Architecture" → "Metadata-driven" & "Thin client"。
+
+## Rules
+
+- spec 经 `//go:embed specs/*.json` 内嵌；运行期无文件访问（`registry/loader.go`）。
+- 新增 domain（`Makefile` help 亦载明）：写 `internal/registry/specs/<domain>.json` → 重新构建
+  （embed 自动拾取）→ 全部 operation 自动注册，无需写命令代码。
+- spec 保留为 `map[string]any`（非强类型 struct），以容忍 additive 变更和未知 `x-octo-*` 扩展。
+- operationId `domain.verb` / `domain.resource.verb` → `octo-cli <domain> [<resource>] <verb>`；
+  path 参数→位置参数；query 参数→typed flag；简单 body 顶层字段自动 promote 成 flag，
+  复杂 body 走 `--data` 逃生口（`cmd/service/service.go`、`flags.go`）。
+- 已用到的 `x-octo-*` 扩展契约（必须在 spec 侧表达）：`x-octo-service`、`x-octo-base-url`、
+  `x-octo-space-header`、`x-octo-risk`、`x-octo-multipart`、`x-octo-binary-response`、
+  `x-octo-pagination`、`x-octo-disabled`、`x-octo-status-values`。
+- query flag 只在用户**显式 set** 时下发（`cobraCmd.Flags().Changed`），避免默认值覆盖后端默认（`run.go`）。
+- 父命令对未知子命令必须 fail loud（`rejectUnknownSubcommand`）——否则 cobra 打印 help 并 exit 0，
+  会让自动化把「已删除命令」误当成功。
+- 注：`x-octo-risk` 目前仅作为元数据呈现在 `--help` / `schema`（`service.go: buildLongDesc`），
+  **不是**交互式确认门（CLI 面向非交互 agent）。
+
+## Thin-client positioning
+
+业务逻辑在后端服务（matters / dmworkim）；**CLI 只做传输 + 校验 + 格式化**，不内联业务规则。
+
+- 命令层只负责：从 flag/arg 构请求（`run.go: runOperation/resolveBody`）、发请求、把信封发出。
+- 分页 `--page-all` 是少数 CLI 侧编排（`runPaginated` 跟 `has_more`/`next_cursor` 走页），但仍只搬运后端数据。
+- 客户端校验限于本地可确定的（缺 base URL、path/query 非法、body 非 JSON 对象），其余交后端并经 `ParseBackendError` 透传。
+
+## Why load-bearing
+
+这是整个 CLI 的核心架构约束。绕过 registry 手写命令、或把业务规则写进 CLI = 双份真相源、
+spec/规则与后端漂移，破坏「spec 即契约」的根基。

--- a/.octospec/rules/output-leaf-package.md
+++ b/.octospec/rules/output-leaf-package.md
@@ -1,0 +1,33 @@
+---
+type: Rule
+title: output is a leaf package
+description: internal/output must not import any other internal/* package.
+tags: ["output", "leaf", "imports", "architecture"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: output-leaf-package
+tier: repo
+priority: 75
+load_bearing: false
+inject_when:
+  paths: ["internal/output/**/*.go"]
+  touches: ["output", "leaf", "imports", "architecture"]
+source: self
+supersedes: []
+---
+
+# output is a leaf package
+
+`internal/output` 是叶子包：**不得 import 任何其它 `internal/*` 包**（`internal/output/doc.go`，grep 核实无跨 internal 依赖）。
+
+> See CLAUDE.md § "Code Style"（the internal/output package is a leaf）。
+
+## Rules
+
+- 依赖单向流入：`ExitError` 是所有 CLI 路径收敛的结构化错误类型；`WriteSuccess`/`WriteError` 是唯一被认可的输出口。
+- 保持叶子可避免循环依赖，并把信封契约固定为单一、可审计的边界。
+
+## Why
+
+架构不变量。一旦 output 反向依赖上层包，信封契约就不再是可独立审计的边界，且易引入 import cycle。
+非安全 P0，故 load_bearing: false，但违反会破坏分层。

--- a/.octospec/rules/transport-client.md
+++ b/.octospec/rules/transport-client.md
@@ -1,0 +1,39 @@
+---
+type: Rule
+title: Transport client — auth, retry, redirects
+description: All outbound HTTP goes through client.Client — centralized auth headers, retry with backoff, and no auto-following redirects.
+tags: ["http", "retry", "redirect", "auth-header", "security", "transport"]
+timestamp: 2026-06-30T00:00:00Z
+# --- octospec extension fields (OKF-permitted; consumers must preserve) ---
+id: transport-client
+tier: repo
+priority: 78
+load_bearing: true
+inject_when:
+  paths: ["internal/client/**/*.go", "cmd/service/run.go"]
+  touches: ["http", "retry", "redirect", "auth-header", "backoff", "timeout"]
+source: self
+supersedes: []
+---
+
+# Transport client — auth, retry, redirects
+
+所有出站 HTTP 经 `client.Client.Do`，统一注入鉴权、重试、dry-run。
+
+> See CLAUDE.md § "Architecture"（multi-backend / unified API base URL）。
+
+## Rules
+
+- 鉴权头集中注入：`Authorization: Bearer <token>` 与 `X-Space-Id`（`attempt`）——**不要在命令层自己拼鉴权头**。
+- 重试：仅对 429/502/503/504（`isRetryableStatus`）做指数退避 + full jitter
+  （`backoffDelay`，jitter ∈ [0.5,1.0) 用 `crypto/rand`），尊重 `Retry-After`，`--no-retry` 关闭；默认 3 次（`defaultMaxRetries`）。
+- **不自动跟随 3xx**（`CheckRedirect: ErrUseLastResponse`）：`file.download` 返回 302 到 presigned URL，
+  需把该 URL 放进信封而非 fetch；其它端点的 3xx 视为错误。
+- `BinaryResponse`（`x-octo-binary-response`）时 2xx/3xx 不按 JSON 解析，返回描述性元数据信封。
+- 非 JSON payload（multipart 上传）经 `RawBody`+`ContentType`，文件用 `io.Copy` 流式
+  （`cmd/service/multipart.go`），内存与文件大小无关。
+- `--dry-run` 渲染请求描述（token 经 `MaskToken` 脱敏）且不实际发请求。
+
+## Why load-bearing
+
+鉴权头与重定向处理集中在此；命令层各自拼鉴权或误跟随 302 会泄露 token 到 presigned URL 主机或破坏下载语义。


### PR DESCRIPTION
## What

Adds `.octospec/rules/` to octo-cli — repo-tier architectural constraints (rules)
for AI agents/executors, auto-injected when touching the matching code. Structure
mirrors `octo-server/.octospec/`. Rules are grounded in the real codebase (verified
file-by-file), not impressions.

## Contents (13 files)

- `index.md` — what `.octospec` is + consumer guide
- `rules/_index.yaml` — frontmatter mirror for tooling (id / priority / load_bearing / inject_when)
- 11 rule files (7 load-bearing + 4 convention-tier)

### Load-bearing (7)

| id | priority | summary |
|----|----------|---------|
| envelope-io-contract     | 92 | All output goes through the Factory→output JSON envelope; never write raw stdout/stderr |
| credential-at-rest       | 92 | Tokens persist only as AES-256-GCM machine-bound ciphertext; metadata plaintext; 0600/0700 perms; tokens never on argv |
| metadata-driven-registry | 90 | Command tree auto-registered from embedded OpenAPI specs — change an endpoint by editing a spec; CLI is a thin client |
| credential-resolution    | 88 | file→env credential chain; multi-profile ambiguity is a hard error, never a silent guess |
| error-taxonomy           | 85 | Errors converge on `*output.ExitError`; backend errors map via `ParseBackendError`; exit codes fixed |
| factory-di-no-globals    | 82 | State flows only through `cmdutil.Factory`; no mutable package-level globals (3 documented exceptions) |
| transport-client         | 78 | All outbound HTTP through `client.Client`: centralized auth headers, retry+backoff, no auto-follow redirects |

### Convention-tier (4)

| id | priority | summary |
|----|----------|---------|
| output-leaf-package   | 75 | `internal/output` must not import other `internal/*` |
| disabled-flag-parity  | 62 | `x-octo-disabled` (spec) and skill `disabled` frontmatter flip together; sync SKILL.md on command-shape change |
| code-style            | 55 | gofmt/vet; wrap errors with `%w`; English (no i18n); dependency allowlist; underscore JSON fields |
| commit-style          | 55 | English Conventional Commits (lefthook-enforced); no `--no-verify` |

## Design decisions

- `thin-client` folded into `metadata-driven-registry` ("Thin-client positioning" section).
- `skills-sync` folded into `disabled-flag-parity` ("Skills documentation sync" note).
- `testing-conventions` intentionally NOT a rule (table-driven adoption uneven) — stays documentation-level.
- Rule bodies **reference** `CLAUDE.md` sections (`> See CLAUDE.md § "…"`) instead of duplicating, to avoid drift.
- No rule for rate-limit / space-isolation: those live server-side (CLI is a thin client) — no such pattern in CLI code.

## Scope

Only `.octospec/` added. No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
