### PR TITLE
feat(mail): add mail service commands over octo-mail REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (7 domains, 47 operations / 50 commands incl. 3 matter transition aliases)
+## Command Structure (8 domains, 65 operations / 68 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -46,6 +46,11 @@ octo-cli thread    create | list | get | members
 octo-cli file      upload | download | credentials | presigned
 octo-cli bot       register | set-commands | user-info | space-members | typing | heartbeat
 octo-cli event     list | ack
+octo-cli mail      list | get | send | reply | reply-all | forward | flag | delete
+               thread get
+               draft  create|list|send|delete
+               mailboxes
+               suppression list|check|add|remove
 
 octo-cli auth      login | status | logout | list
 octo-cli schema [--list [domain] | <operation-id>]
@@ -57,7 +62,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-mail`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -60,6 +60,7 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 		"matter":  {"archive", "assignee", "channel", "close", "create", "delete", "extract", "get", "list", "reopen", "timeline", "transition", "update"},
 		"message": {"edit", "read-receipt", "send", "sync"},
 		"event":   {"ack", "list"},
+		"mail":    {"delete", "draft", "flag", "forward", "get", "list", "mailboxes", "reply", "reply-all", "send", "suppression", "thread"},
 	}
 	for svc, wantCmds := range want {
 		svcCmd := findCmd(root, svc)
@@ -83,6 +84,90 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 	timeline := findCmd(matter, "timeline")
 	if timeline == nil || !contains(childNames(timeline), "add") || !contains(childNames(timeline), "list") || !contains(childNames(timeline), "delete") {
 		t.Errorf("matter timeline should nest add/list/delete; got %v", childNames(timeline))
+	}
+
+	// mail sub-resource nesting: draft, thread, suppression.
+	mail := findCmd(root, "mail")
+	draft := findCmd(mail, "draft")
+	if draft == nil || !contains(childNames(draft), "create") || !contains(childNames(draft), "list") || !contains(childNames(draft), "send") || !contains(childNames(draft), "delete") {
+		t.Errorf("mail draft should nest create/list/send/delete; got %v", childNames(draft))
+	}
+	thread := findCmd(mail, "thread")
+	if thread == nil || !contains(childNames(thread), "get") {
+		t.Errorf("mail thread should nest get; got %v", childNames(thread))
+	}
+	supp := findCmd(mail, "suppression")
+	if supp == nil || !contains(childNames(supp), "add") || !contains(childNames(supp), "remove") || !contains(childNames(supp), "list") || !contains(childNames(supp), "check") {
+		t.Errorf("mail suppression should nest add/remove/list/check; got %v", childNames(supp))
+	}
+}
+
+// --- mail operation execution ---
+
+// TestMailSend_BodyFlagsToJSON proves mail.send promotes to/cc/subject/text to
+// JSON body fields and POSTs to /webapi/v0/messages.
+func TestMailSend_BodyFlagsToJSON(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(202)
+		_, _ = w.Write([]byte(`{"submissionIds":["s1"]}`))
+	})
+	root.SetArgs([]string{
+		"mail", "send",
+		"--to", "a@x.test,b@y.test",
+		"--subject", "hi",
+		"--text", "hello there",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/webapi/v0/messages" {
+		t.Fatalf("got %s %s, want POST /webapi/v0/messages", gotMethod, gotPath)
+	}
+	to, ok := gotBody["to"].([]any)
+	if !ok || len(to) != 2 {
+		t.Fatalf("to = %v, want 2 recipients", gotBody["to"])
+	}
+	if gotBody["subject"] != "hi" || gotBody["text"] != "hello there" {
+		t.Fatalf("body = %v", gotBody)
+	}
+}
+
+// TestMailGet_PathParam proves mail.get maps the positional id into the path.
+func TestMailGet_PathParam(t *testing.T) {
+	var gotPath, gotMethod string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"E7","subject":"x"}`))
+	})
+	root.SetArgs([]string{"mail", "get", "E7"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/webapi/v0/messages/E7" {
+		t.Fatalf("got %s %s, want GET /webapi/v0/messages/E7", gotMethod, gotPath)
+	}
+}
+
+// TestMailList_QueryFlags proves mail.list turns mailbox/limit into query params.
+func TestMailList_QueryFlags(t *testing.T) {
+	var gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"messages":[],"total":0}`))
+	})
+	root.SetArgs([]string{"mail", "list", "--mailbox", "Inbox", "--limit", "10"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(gotQuery, "mailbox=Inbox") || !strings.Contains(gotQuery, "limit=10") {
+		t.Fatalf("query = %q, want mailbox=Inbox&limit=10", gotQuery)
 	}
 }
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -10,7 +10,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "event", "file", "group", "matter", "message", "thread"}
+	want := []string{"bot", "event", "file", "group", "mail", "matter", "message", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -41,6 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
+		"mail":    18,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/specs/mail.json
+++ b/internal/registry/specs/mail.json
@@ -1,0 +1,423 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "octo-mail REST API",
+    "version": "0.0.0",
+    "description": "Programmatic mail for agents, backed by octo-mail's resource-oriented REST surface under /webapi/v0. Account-scoped: an API key reaches only its own mailbox. Field names are camelCase to match the octo-mail wire contract. Provisioning is intentionally not exposed here — it lives on octo-mail's admin surface, not in the agent CLI."
+  },
+  "x-octo-service": "mail",
+  "x-octo-base-url": "OCTO_API_BASE_URL",
+  "x-octo-space-header": false,
+  "paths": {
+    "/webapi/v0/messages": {
+      "get": {
+        "operationId": "mail.list",
+        "summary": "List messages (newest first, deduplicated by email)",
+        "description": "Lists messages in the account. Filter by mailbox and/or full-text search; page with limit/offset.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "mailbox", "in": "query", "schema": { "type": "string" }, "description": "restrict to a mailbox by name (e.g. Inbox, Sent, Drafts)" },
+          { "name": "search", "in": "query", "schema": { "type": "string" }, "description": "full-text search query" },
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 50 }, "description": "max messages to return" },
+          { "name": "offset", "in": "query", "schema": { "type": "integer", "default": 0 }, "description": "number of messages to skip" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Messages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "messages": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string", "description": "opaque message id (E<n>), shared with JMAP" },
+                          "threadId": { "type": "string" },
+                          "mailbox": { "type": "string" },
+                          "subject": { "type": "string" },
+                          "from": { "type": "string" },
+                          "to": { "type": "array", "items": { "type": "string" } },
+                          "preview": { "type": "string" },
+                          "receivedAt": { "type": "string" },
+                          "size": { "type": "integer", "format": "int64" },
+                          "keywords": { "type": "array", "items": { "type": "string" } },
+                          "unread": { "type": "boolean" }
+                        }
+                      }
+                    },
+                    "total": { "type": "integer" },
+                    "offset": { "type": "integer" },
+                    "limit": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "mail.send",
+        "summary": "Send a message",
+        "description": "Composes an RFC 5322 message server-side and submits it to the outbound queue. Attachments are objects ({filename, contentType, content(base64)}) — pass them via --data.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["to"],
+                "properties": {
+                  "to": { "type": "array", "items": { "type": "string" }, "description": "recipient addresses (required)" },
+                  "cc": { "type": "array", "items": { "type": "string" } },
+                  "bcc": { "type": "array", "items": { "type": "string" } },
+                  "subject": { "type": "string" },
+                  "text": { "type": "string", "description": "plain-text body" },
+                  "html": { "type": "string", "description": "HTML body (sent as multipart/alternative with text)" },
+                  "attachments": { "type": "array", "description": "base64 attachments; pass via --data", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted for delivery",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "submissionIds": { "type": "array", "items": { "type": "string" } } } } } }
+          }
+        }
+      }
+    },
+    "/webapi/v0/messages/{id}": {
+      "get": {
+        "operationId": "mail.get",
+        "summary": "Get one message with parsed bodies",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "message id (E<n>)" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Message detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "threadId": { "type": "string" },
+                    "mailbox": { "type": "string" },
+                    "subject": { "type": "string" },
+                    "from": { "type": "string" },
+                    "to": { "type": "array", "items": { "type": "string" } },
+                    "cc": { "type": "array", "items": { "type": "string" } },
+                    "preview": { "type": "string" },
+                    "receivedAt": { "type": "string" },
+                    "size": { "type": "integer", "format": "int64" },
+                    "keywords": { "type": "array", "items": { "type": "string" } },
+                    "unread": { "type": "boolean" },
+                    "bodyText": { "type": "string" },
+                    "bodyHtml": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": { "description": "No such message" }
+        }
+      },
+      "patch": {
+        "operationId": "mail.flag",
+        "summary": "Add or remove keywords/flags on a message",
+        "description": "Adds and/or removes IMAP flags (e.g. \\\\Seen, \\\\Flagged) or free-form keywords. Provide addKeywords and/or removeKeywords.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "addKeywords": { "type": "array", "items": { "type": "string" }, "description": "flags/keywords to set" },
+                  "removeKeywords": { "type": "array", "items": { "type": "string" }, "description": "flags/keywords to clear" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Updated" } }
+      },
+      "delete": {
+        "operationId": "mail.delete",
+        "summary": "Delete (expunge) a message",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "204": { "description": "Deleted" } }
+      }
+    },
+    "/webapi/v0/messages/{id}/reply": {
+      "post": {
+        "operationId": "mail.reply",
+        "summary": "Reply to a message (sender only)",
+        "description": "Derives the recipient and In-Reply-To/References from the original; you supply the body.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" },
+                  "html": { "type": "string" },
+                  "attachments": { "type": "array", "description": "pass via --data", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "202": { "description": "Accepted for delivery", "content": { "application/json": { "schema": { "type": "object", "properties": { "submissionIds": { "type": "array", "items": { "type": "string" } } } } } } } }
+      }
+    },
+    "/webapi/v0/messages/{id}/reply-all": {
+      "post": {
+        "operationId": "mail.reply-all",
+        "summary": "Reply to all recipients of a message",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "text": { "type": "string" },
+                  "html": { "type": "string" },
+                  "attachments": { "type": "array", "description": "pass via --data", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "202": { "description": "Accepted for delivery", "content": { "application/json": { "schema": { "type": "object", "properties": { "submissionIds": { "type": "array", "items": { "type": "string" } } } } } } } }
+      }
+    },
+    "/webapi/v0/messages/{id}/forward": {
+      "post": {
+        "operationId": "mail.forward",
+        "summary": "Forward a message",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["to"],
+                "properties": {
+                  "to": { "type": "array", "items": { "type": "string" }, "description": "recipient addresses (required)" },
+                  "text": { "type": "string", "description": "optional note prepended to the quoted original" },
+                  "attachments": { "type": "array", "description": "pass via --data", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "202": { "description": "Accepted for delivery", "content": { "application/json": { "schema": { "type": "object", "properties": { "submissionIds": { "type": "array", "items": { "type": "string" } } } } } } } }
+      }
+    },
+    "/webapi/v0/threads/{id}": {
+      "get": {
+        "operationId": "mail.thread.get",
+        "summary": "Get a thread and its messages",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "thread id (T<n>)" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Thread",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "string" },
+                    "messages": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          },
+          "404": { "description": "No such thread" }
+        }
+      }
+    },
+    "/webapi/v0/drafts": {
+      "get": {
+        "operationId": "mail.draft.list",
+        "summary": "List drafts",
+        "x-octo-risk": "read",
+        "responses": {
+          "200": {
+            "description": "Drafts",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "drafts": { "type": "array", "items": { "type": "object" } } } } } }
+          }
+        }
+      },
+      "post": {
+        "operationId": "mail.draft.create",
+        "summary": "Create a draft (compose without sending)",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "to": { "type": "array", "items": { "type": "string" } },
+                  "cc": { "type": "array", "items": { "type": "string" } },
+                  "bcc": { "type": "array", "items": { "type": "string" } },
+                  "subject": { "type": "string" },
+                  "text": { "type": "string" },
+                  "html": { "type": "string" },
+                  "attachments": { "type": "array", "description": "pass via --data", "items": { "type": "object" } }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Draft created", "content": { "application/json": { "schema": { "type": "object", "properties": { "id": { "type": "string" } } } } } } }
+      }
+    },
+    "/webapi/v0/drafts/{id}/send": {
+      "post": {
+        "operationId": "mail.draft.send",
+        "summary": "Send an existing draft",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "202": { "description": "Accepted for delivery", "content": { "application/json": { "schema": { "type": "object", "properties": { "submissionIds": { "type": "array", "items": { "type": "string" } } } } } } } }
+      }
+    },
+    "/webapi/v0/drafts/{id}": {
+      "delete": {
+        "operationId": "mail.draft.delete",
+        "summary": "Delete a draft",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "204": { "description": "Deleted" } }
+      }
+    },
+    "/webapi/v0/mailboxes": {
+      "get": {
+        "operationId": "mail.mailboxes",
+        "summary": "List mailboxes with counts",
+        "x-octo-risk": "read",
+        "responses": {
+          "200": {
+            "description": "Mailboxes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "mailboxes": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "string" },
+                          "name": { "type": "string" },
+                          "total": { "type": "integer", "format": "int64" },
+                          "unread": { "type": "integer", "format": "int64" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webapi/v0/suppressions": {
+      "get": {
+        "operationId": "mail.suppression.list",
+        "summary": "List suppressed recipient addresses",
+        "x-octo-risk": "read",
+        "responses": {
+          "200": {
+            "description": "Suppressions",
+            "content": { "application/json": { "schema": { "type": "object", "properties": { "suppressions": { "type": "array", "items": { "type": "string" } } } } } }
+          }
+        }
+      }
+    },
+    "/webapi/v0/suppressions/{address}": {
+      "get": {
+        "operationId": "mail.suppression.check",
+        "summary": "Check whether an address is suppressed",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Suppressed" },
+          "404": { "description": "Not suppressed" }
+        }
+      },
+      "put": {
+        "operationId": "mail.suppression.add",
+        "summary": "Suppress an address (idempotent)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": { "reason": { "type": "string" } }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Suppressed" } }
+      },
+      "delete": {
+        "operationId": "mail.suppression.remove",
+        "summary": "Remove an address from the suppression list",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "204": { "description": "Removed" } }
+      }
+    }
+  }
+}

--- a/skills/octo-mail/SKILL.md
+++ b/skills/octo-mail/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: octo-mail
+version: 0.1.0
+description: Mail domain — send/list/get/reply/forward/flag/delete messages, threads, drafts, mailboxes, and the suppression list, over octo-mail's REST API. Account-scoped by API key. Load after octo-shared.
+metadata:
+  requires:
+    bins: ["octo-cli"]
+    skills: ["octo-shared"]
+---
+
+# octo-mail — programmatic email for agents
+
+The `mail` domain is a thin CLI over [octo-mail](https://github.com/Mininglamp-OSS/octo-mail)'s
+REST surface at `$OCTO_API_BASE_URL/webapi/v0/*`. Every command is **account-scoped**:
+the API key you authenticate with reaches only its own mailbox — there is no
+cross-account access and no admin/provisioning surface here (accounts, domains, and
+keys are created out-of-band by an operator).
+
+Message ids are opaque `E<n>` strings (shared with the JMAP surface); thread ids are
+`T<n>`. Sends are asynchronous — a successful send returns `202` with
+`submissionIds`, meaning the message was accepted into the outbound queue.
+
+## Authentication
+
+Mail uses an octo-mail account API key (an `omk_<prefix>_<secret>` token) as the bot
+token. It travels as `Authorization: Bearer <token>`, exactly like any other octo-cli
+credential:
+
+```bash
+export OCTO_API_BASE_URL=https://mail.example.com     # octo-mail origin (or gateway)
+export OCTO_BOT_TOKEN=omk_ab12cd34ef_9x8y7z…          # account API key
+octo-cli mail mailboxes                               # smoke test
+```
+
+(An operator mints the key with `octo-mail apikey create <login>` on the server; the
+secret is shown once.)
+
+## 1. Messages — 8 commands
+
+```bash
+# List (newest first, deduplicated by email). All filters optional.
+octo-cli mail list [--mailbox Inbox] [--search "invoice"] [--limit 50] [--offset 0]
+
+# Read one message (includes parsed bodyText/bodyHtml).
+octo-cli mail get <id>
+
+# Send. --to/--cc/--bcc are repeatable (or comma-separated). Returns 202 + submissionIds.
+octo-cli mail send --to a@x.test --to b@y.test --subject "Hi" --text "hello"
+octo-cli mail send --to a@x.test --subject "Report" --html "<h1>Q3</h1>" --text "Q3 (plain)"
+
+# Reply / reply-all — recipients + In-Reply-To/References derived from the original.
+octo-cli mail reply     <id> --text "thanks!"
+octo-cli mail reply-all <id> --text "thanks all"
+
+# Forward — you supply new recipients; the original is quoted below your note.
+octo-cli mail forward <id> --to c@z.test --text "fyi"
+
+# Flag: add/remove IMAP flags or free-form keywords (repeatable).
+octo-cli mail flag <id> --addKeywords '\Seen'
+octo-cli mail flag <id> --addKeywords '\Flagged' --removeKeywords '\Seen'
+
+# Delete (expunge). Returns 204.
+octo-cli mail delete <id>
+```
+
+### Raw RFC 822
+
+`mail get` returns parsed `bodyText`/`bodyHtml` and headers, which covers almost
+every need. There is no `mail raw` command — the CLI speaks JSON envelopes, not
+raw byte streams. For the rare case where you need the exact `.eml`, GET the
+endpoint directly with your key:
+
+```bash
+curl -H "Authorization: Bearer $OCTO_BOT_TOKEN" \
+  "$OCTO_API_BASE_URL/webapi/v0/messages/<id>/raw" > message.eml
+```
+
+
+### Attachments
+
+Attachments are objects, not flags — pass them inside `--data`. Each is
+`{filename, contentType, content}` where `content` is **base64**:
+
+```bash
+octo-cli mail send --to a@x.test --subject "Invoice" --text "attached" \
+  --data '{"attachments":[{"filename":"inv.pdf","contentType":"application/pdf","content":"'"$(base64 -w0 inv.pdf)"'"}]}'
+```
+
+Individual flags (`--to`, `--subject`, …) override same-named fields in `--data`, so you
+can mix: put the attachment array in `--data` and keep recipients/subject as flags.
+
+## 2. Threads — 1 command
+
+```bash
+octo-cli mail thread get <thread_id>     # e.g. T5 — returns the thread + its messages
+```
+
+Get a message first (`mail get <id>`) to read its `threadId`.
+
+## 3. Drafts — 4 commands
+
+```bash
+octo-cli mail draft list
+octo-cli mail draft create --to a@x.test --subject "WIP" --text "draft body"   # 201 + {id}
+octo-cli mail draft send <id>                                                   # 202
+octo-cli mail draft delete <id>                                                 # 204
+```
+
+`draft create` takes the same body shape as `send` (including `--data` attachments) but
+stores the message in Drafts instead of submitting it.
+
+## 4. Mailboxes — 1 command
+
+```bash
+octo-cli mail mailboxes     # [{id, name, total, unread}, …]
+```
+
+Use a mailbox `name` (e.g. `Inbox`, `Sent`, `Drafts`) with `mail list --mailbox`.
+
+## 5. Suppressions — 4 commands
+
+The suppression list holds recipient addresses that should not be mailed (bounces,
+complaints). It is per-account.
+
+```bash
+octo-cli mail suppression list
+octo-cli mail suppression check  <address>     # 200 if suppressed, 404 if not
+octo-cli mail suppression add    <address> [--reason bounce]   # idempotent
+octo-cli mail suppression remove <address>     # 204
+```
+
+## 6. Status codes & error recovery
+
+| Code | Meaning                                          |
+|------|--------------------------------------------------|
+| 200  | OK (get/list/flag/thread/suppression check)      |
+| 201  | Draft created                                    |
+| 202  | Send/reply/forward/draft-send accepted (queued)  |
+| 204  | Deleted / suppression removed                    |
+| 400  | Bad message id or malformed body                 |
+| 401  | Missing/invalid API key                          |
+| 404  | No such message/thread/draft, or not suppressed  |
+| 422  | Nothing to send to (e.g. reply with no recipient)|
+
+Errors return `{"error":{"code","message"}}`.
+
+| Symptom                                   | Likely cause / fix                                          |
+|-------------------------------------------|-------------------------------------------------------------|
+| `401 unauthorized`                        | `OCTO_BOT_TOKEN` is not a valid `omk_` key, or unset.       |
+| `400 invalid_id` on `get`/`reply`         | Message id must be the `E<n>` form from `mail list`.        |
+| `404 not_found` on another account's id   | Account isolation — you can only see your own mail.         |
+| `422 no_recipients` on `reply`            | The original had no reply address; use `send` explicitly.   |
+| send "succeeds" but never arrives         | `202` means queued, not delivered — check the recipient isn't suppressed (`mail suppression check`). |
+
+## 7. Schema lookup
+
+```bash
+octo-cli schema --list mail
+octo-cli schema mail.send
+octo-cli schema mail.flag
+octo-cli schema mail.draft.create
+```


### PR DESCRIPTION
## Summary

Adds a spec-driven `mail` domain to octo-cli (**zero Go**): the OpenAPI spec at `internal/registry/specs/mail.json` auto-registers under `octo mail …`, targeting octo-mail's account-scoped REST surface at `$OCTO_API_BASE_URL/webapi/v0/*`. An octo-mail account API key (`omk_…` token) works verbatim as the Bearer credential.

**18 operations across five resources:**
- **messages**: `list · get · send · reply · reply-all · forward · flag · delete`
- **threads**: `thread get`
- **drafts**: `draft list · create · send · delete`
- **mailboxes**: `mailboxes`
- **suppressions**: `suppression list · check · add · remove`

Path params (`{id}`/`{address}`) → positional args; query params and string-array body fields → flags (`--to`/`--cc`/`--addKeywords`, …); attachments (array of object) go through `--data`. Fields are camelCase to match the octo-mail wire contract. Admin/provisioning is deliberately **not** exposed — the CLI only ever touches its own account's mail.

Raw RFC 822 is intentionally not a CLI command: octo-cli emits JSON envelopes, not raw byte streams, so `mail get` (parsed bodies/headers) covers the common case and the skill documents a direct `curl` to `/webapi/v0/messages/{id}/raw` for the rare `.eml` need.

Adds the `octo-mail` agent skill and updates `CLAUDE.md` (8 domains, 65 ops).

## Tests
- Tree-shape + `mail.send`/`get`/`list` execution against `httptest`; loader counts updated (7→8 services, +18 ops).
- Verified end-to-end against a locally deployed octo-mail: mailboxes/list/get/flag/thread/reply/send/drafts/suppressions all pass, plus account isolation and error-code mapping (400/401/404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)