### PR TITLE
Add spec-driven docs commands and octo-docs skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (7 domains, 47 operations / 50 commands incl. 3 matter transition aliases)
+## Command Structure (8 domains, 69 operations / 72 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -46,6 +46,11 @@ octo-cli thread    create | list | get | members
 octo-cli file      upload | download | credentials | presigned
 octo-cli bot       register | set-commands | user-info | space-members | typing | heartbeat
 octo-cli event     list | ack
+octo-cli docs      create | list | get | rename | delete | forward-grant
+               members  list|set|remove
+               comments list|add|edit|delete
+               versions list|create|state|rename|delete|restore
+               attachments presign|get|resolve
 
 octo-cli auth      login | status | logout | list
 octo-cli schema [--list [domain] | <operation-id>]
@@ -57,7 +62,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -151,11 +151,16 @@ func TestDocs_NoPagination(t *testing.T) {
 
 // TestDocsCreate_PostsBodyNoSpaceHeader checks docs.create hits POST /v1/bot/docs
 // with the promoted body field, carries the bearer token, and sends no
-// X-Space-Id (the bot mount server-resolves the space).
+// X-Space-Id even when the active credential carries a SpaceID — the docs bot
+// mount resolves the space server-side (x-octo-space-header:false), so the
+// header must be gated off rather than merely absent because the test bot has no
+// space. The companion assertion below proves the same spaced credential DOES
+// send X-Space-Id on a default/true operation, so the gating is real in both
+// directions and no existing service silently loses the header.
 func TestDocsCreate_PostsBodyNoSpaceHeader(t *testing.T) {
 	var gotMethod, gotPath, gotAuth, gotSpace string
 	var gotBody map[string]any
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath = r.Method, r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
 		gotSpace = r.Header.Get("X-Space-Id")
@@ -177,7 +182,29 @@ func TestDocsCreate_PostsBodyNoSpaceHeader(t *testing.T) {
 		t.Errorf("Authorization = %q, want Bearer app_test", gotAuth)
 	}
 	if gotSpace != "" {
-		t.Errorf("X-Space-Id must not be sent for docs; got %q", gotSpace)
+		t.Errorf("X-Space-Id must not be sent for docs even with a spaced credential; got %q", gotSpace)
+	}
+}
+
+// TestSpacedCredential_SendsSpaceHeaderOnDefaultOp is the companion to the docs
+// suppression test: with the SAME spaced credential, an operation whose spec
+// declares x-octo-space-header:true (matter, the canonical space-scoped domain)
+// still sends X-Space-Id. This guards against the gating over-reaching and
+// stripping the header from services that must keep it — only an explicit
+// x-octo-space-header:false suppresses it.
+func TestSpacedCredential_SendsSpaceHeaderOnDefaultOp(t *testing.T) {
+	var gotSpace string
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotSpace = r.Header.Get("X-Space-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"matter":{"id":"m1"}}`))
+	})
+	root.SetArgs([]string{"matter", "create", "--title", "Case"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotSpace != "space-1" {
+		t.Errorf("X-Space-Id = %q, want space-1 for a space-header:true op", gotSpace)
 	}
 }
 

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -33,6 +33,7 @@ func TestDocs_TreeShape(t *testing.T) {
 	}
 
 	groups := map[string][]string{
+		"content":     {"get", "edit"},
 		"members":     {"list", "set", "remove"},
 		"comments":    {"list", "add", "edit", "delete"},
 		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
@@ -66,6 +67,8 @@ func TestDocs_RegistryShape(t *testing.T) {
 		"docs.get":                 {"GET", "/v1/bot/docs/{docId}"},
 		"docs.rename":              {"PATCH", "/v1/bot/docs/{docId}"},
 		"docs.delete":              {"DELETE", "/v1/bot/docs/{docId}"},
+		"docs.content.get":         {"GET", "/v1/bot/docs/{docId}/content"},
+		"docs.content.edit":        {"PATCH", "/v1/bot/docs/{docId}/content"},
 		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
 		"docs.members.set":         {"PUT", "/v1/bot/docs/{docId}/members"},
 		"docs.members.remove":      {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
@@ -425,5 +428,94 @@ func TestDocsAttachmentsPresign_BodyTypes(t *testing.T) {
 	}
 	if sz, ok := gotBody["sizeBytes"].(float64); !ok || sz != 2048 {
 		t.Errorf("sizeBytes = %v (%T), want 2048", gotBody["sizeBytes"], gotBody["sizeBytes"])
+	}
+}
+
+// TestDocsContentGet_ReadsBodyAndBaseVersion checks docs.content.get hits
+// GET /v1/bot/docs/{docId}/content (reader), sends no body, and surfaces the
+// backend's {doc, baseVersion} response through the success envelope so the
+// caller can capture the base-version token for a follow-up edit.
+func TestDocsContentGet_ReadsBodyAndBaseVersion(t *testing.T) {
+	var gotMethod, gotPath string
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"d1","doc":{"type":"doc","content":[]},"schemaVersion":3,"baseVersion":"BV_ABC=="}`))
+	})
+	root.SetArgs([]string{"docs", "content", "get", "d1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/v1/bot/docs/d1/content" {
+		t.Errorf("got %s %s, want GET /v1/bot/docs/d1/content", gotMethod, gotPath)
+	}
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			BaseVersion string `json:"baseVersion"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v -- out=%s", err, tf.Out.String())
+	}
+	if !env.OK || env.Data.BaseVersion != "BV_ABC==" {
+		t.Errorf("expected baseVersion BV_ABC== in envelope, got %+v", env)
+	}
+}
+
+// TestDocsContentEdit_SendsOpsBatchAndIfMatch checks docs.content.edit hits
+// PATCH /v1/bot/docs/{docId}/content, carries the ops batch (passed via the
+// generic --data escape hatch) as a JSON array in the body, and sends the
+// base-version token as the If-Match header — the spec-declared header
+// capability wiring --base-version to If-Match, not a body/query field.
+func TestDocsContentEdit_SendsOpsBatchAndIfMatch(t *testing.T) {
+	var gotMethod, gotPath, gotIfMatch string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotIfMatch = r.Header.Get("If-Match")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","bytes":128,"baseVersion":"BV_NEXT==","newDocVersionSeq":9}`))
+	})
+	ops := `{"ops":[{"type":"insert","at":{"path":[],"position":"inside_end"},"content":[{"type":"paragraph","content":[{"type":"text","text":"hi"}]}]}]}`
+	root.SetArgs([]string{"docs", "content", "edit", "d1", "--base-version", "BV_ABC==", "--data", ops})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "PATCH" || gotPath != "/v1/bot/docs/d1/content" {
+		t.Errorf("got %s %s, want PATCH /v1/bot/docs/d1/content", gotMethod, gotPath)
+	}
+	if gotIfMatch != "BV_ABC==" {
+		t.Errorf("If-Match = %q, want BV_ABC== (base version must reach the wire as the If-Match header)", gotIfMatch)
+	}
+	opsArr, ok := gotBody["ops"].([]any)
+	if !ok || len(opsArr) != 1 {
+		t.Fatalf("ops = %v, want a 1-element array", gotBody["ops"])
+	}
+	op0, ok := opsArr[0].(map[string]any)
+	if !ok || op0["type"] != "insert" {
+		t.Errorf("ops[0] = %v, want an insert op", opsArr[0])
+	}
+	// The base version travels in the header, not the JSON body.
+	if _, present := gotBody["baseVersion"]; present {
+		t.Errorf("baseVersion must not be duplicated into the JSON body; got %v", gotBody["baseVersion"])
+	}
+}
+
+// TestDocsContentEdit_RequiresBaseVersion confirms --base-version is required:
+// the command fails before any request when the base-version token is missing,
+// mirroring the backend's mandatory optimistic-concurrency guard.
+func TestDocsContentEdit_RequiresBaseVersion(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	root.SetArgs([]string{"docs", "content", "edit", "d1", "--data", `{"ops":[]}`})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error when --base-version is omitted")
+	}
+	if called {
+		t.Error("server must not be called when required --base-version is missing")
 	}
 }

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -208,6 +208,33 @@ func TestSpacedCredential_SendsSpaceHeaderOnDefaultOp(t *testing.T) {
 	}
 }
 
+// TestMessageSend_SendsSpaceHeader is the regression guard for the fix: the
+// message spec declares x-octo-space-header:true, so a spaced credential MUST
+// send X-Space-Id on a message op. sendMessage for a multi-space bot uses the
+// header as the DM multi-space selection hint; dropping it silently
+// mis-attributes the message. This uses message (a real product service),
+// unlike the matter companion above, so a future flip of the message flag is
+// caught here rather than masked by the always-true matter domain.
+func TestMessageSend_SendsSpaceHeader(t *testing.T) {
+	var gotSpace, gotPath string
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotSpace = r.Header.Get("X-Space-Id")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message_id":1,"message_seq":1}`))
+	})
+	root.SetArgs([]string{"message", "send", "--data", `{"channel_id":"c1","channel_type":1,"payload":{"type":1,"content":"hi"}}`})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/v1/bot/sendMessage" {
+		t.Errorf("path = %q, want /v1/bot/sendMessage", gotPath)
+	}
+	if gotSpace != "space-1" {
+		t.Errorf("X-Space-Id = %q, want space-1 — message must keep sending the header for multi-space DM selection", gotSpace)
+	}
+}
+
 // TestDocsList_QueryParamsFromFlags checks the page-based list flags land in the
 // query string.
 func TestDocsList_QueryParamsFromFlags(t *testing.T) {

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -1,0 +1,375 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
+)
+
+// The docs service is spec-driven (internal/registry/specs/docs.json) — there is
+// no hand-written command code for it. These tests exercise the real embedded
+// registry through the same rootWithService harness the other services use, so
+// they assert what the generated command tree actually sends on the wire.
+
+// --- command-tree shape ---
+
+// TestDocs_TreeShape confirms the docs subtree and its nested resource groups
+// (members, comments, versions, attachments) generate from the dotted
+// operationIds without any Go registration code.
+func TestDocs_TreeShape(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	docs := findCmd(root, "docs")
+	if docs == nil {
+		t.Fatal("missing docs service command")
+	}
+	for _, leaf := range []string{"create", "list", "get", "rename", "delete", "forward-grant"} {
+		if !contains(childNames(docs), leaf) {
+			t.Errorf("docs: missing leaf %q; got %v", leaf, childNames(docs))
+		}
+	}
+
+	groups := map[string][]string{
+		"members":     {"list", "set", "remove"},
+		"comments":    {"list", "add", "edit", "delete"},
+		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
+		"attachments": {"presign", "get", "resolve"},
+	}
+	for group, leaves := range groups {
+		sub := findCmd(docs, group)
+		if sub == nil {
+			t.Errorf("docs: missing resource group %q", group)
+			continue
+		}
+		for _, leaf := range leaves {
+			if !contains(childNames(sub), leaf) {
+				t.Errorf("docs %s: missing leaf %q; got %v", group, leaf, childNames(sub))
+			}
+		}
+	}
+}
+
+// TestDocs_RegistryShape asserts every docs.* operationId parses into the
+// command path the tree generator will build from it (segments after the
+// service become nested resource commands, the last is the leaf verb) and that
+// the method/path match the verified octo-docs-backend bot routes.
+func TestDocs_RegistryShape(t *testing.T) {
+	reg := registry.MustNew()
+
+	type want struct{ method, path string }
+	cases := map[string]want{
+		"docs.create":              {"POST", "/v1/bot/docs"},
+		"docs.list":                {"GET", "/v1/bot/docs"},
+		"docs.get":                 {"GET", "/v1/bot/docs/{docId}"},
+		"docs.rename":              {"PATCH", "/v1/bot/docs/{docId}"},
+		"docs.delete":              {"DELETE", "/v1/bot/docs/{docId}"},
+		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
+		"docs.members.set":         {"PUT", "/v1/bot/docs/{docId}/members"},
+		"docs.members.remove":      {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
+		"docs.forward-grant":       {"POST", "/v1/bot/docs/{docId}/forward-grant"},
+		"docs.comments.list":       {"GET", "/v1/bot/docs/{docId}/comments"},
+		"docs.comments.add":        {"POST", "/v1/bot/docs/{docId}/comments"},
+		"docs.comments.edit":       {"PATCH", "/v1/bot/docs/{docId}/comments/{id}"},
+		"docs.comments.delete":     {"DELETE", "/v1/bot/docs/{docId}/comments/{id}"},
+		"docs.versions.list":       {"GET", "/v1/bot/docs/{docId}/versions"},
+		"docs.versions.create":     {"POST", "/v1/bot/docs/{docId}/versions"},
+		"docs.versions.state":      {"GET", "/v1/bot/docs/{docId}/versions/{versionId}/state"},
+		"docs.versions.rename":     {"PATCH", "/v1/bot/docs/{docId}/versions/{versionId}"},
+		"docs.versions.delete":     {"DELETE", "/v1/bot/docs/{docId}/versions/{versionId}"},
+		"docs.versions.restore":    {"POST", "/v1/bot/docs/{docId}/versions/{versionId}/restore"},
+		"docs.attachments.presign": {"POST", "/v1/bot/docs/{docId}/attachments/presign"},
+		"docs.attachments.get":     {"GET", "/v1/bot/docs/{docId}/attachments/{attachId}"},
+		"docs.attachments.resolve": {"POST", "/v1/bot/docs/{docId}/attachments/resolve"},
+	}
+
+	got := reg.ListOperations("docs")
+	if len(got) != len(cases) {
+		t.Errorf("docs operation count = %d, want %d", len(got), len(cases))
+	}
+	for id, w := range cases {
+		d, ok := reg.GetOperation(id)
+		if !ok {
+			t.Errorf("operation %q not found in registry", id)
+			continue
+		}
+		if d.Method != w.method || d.Path != w.path {
+			t.Errorf("%s: got %s %s, want %s %s", id, d.Method, d.Path, w.method, w.path)
+		}
+		// Dotted id must map to "<service> [<resource>...] <verb>".
+		segs := strings.Split(id, ".")
+		if segs[0] != "docs" {
+			t.Errorf("%s: first segment must be the service; got %q", id, segs[0])
+		}
+	}
+}
+
+// TestDocs_SpaceHeaderDeclaredFalse confirms the docs spec declares the bot
+// mount's server-resolved space (x-octo-space-header:false), matching bot.json.
+func TestDocs_SpaceHeaderDeclaredFalse(t *testing.T) {
+	reg := registry.MustNew()
+	d, ok := reg.GetOperation("docs.create")
+	if !ok {
+		t.Fatal("docs.create not in registry")
+	}
+	if d.SpaceHeader {
+		t.Error("docs spec must set x-octo-space-header:false (bot mount server-resolves the space)")
+	}
+	if d.BaseURLEnv != "OCTO_API_BASE_URL" {
+		t.Errorf("docs base-url env = %q, want OCTO_API_BASE_URL", d.BaseURLEnv)
+	}
+}
+
+// TestDocs_NoPagination confirms none of the docs list ops declare
+// x-octo-pagination: their envelopes ({total,items} / {items,nextCursor}) do
+// not match the engine's {data,pagination} walker, so --page-all is not offered.
+func TestDocs_NoPagination(t *testing.T) {
+	reg := registry.MustNew()
+	for _, id := range []string{"docs.list", "docs.comments.list", "docs.versions.list"} {
+		d, ok := reg.GetOperation(id)
+		if !ok {
+			t.Fatalf("%s not in registry", id)
+		}
+		if d.Pagination != nil {
+			t.Errorf("%s must not declare pagination (non-standard envelope)", id)
+		}
+	}
+	// And the generated command must not expose --page-all.
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+	list := findCmd(findCmd(root, "docs"), "list")
+	if list == nil {
+		t.Fatal("docs list command missing")
+	}
+	if list.Flags().Lookup("page-all") != nil {
+		t.Error("docs list must not have --page-all")
+	}
+}
+
+// --- operation execution ---
+
+// TestDocsCreate_PostsBodyNoSpaceHeader checks docs.create hits POST /v1/bot/docs
+// with the promoted body field, carries the bearer token, and sends no
+// X-Space-Id (the bot mount server-resolves the space).
+func TestDocsCreate_PostsBodyNoSpaceHeader(t *testing.T) {
+	var gotMethod, gotPath, gotAuth, gotSpace string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotSpace = r.Header.Get("X-Space-Id")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"d1","title":"Runbook"}`))
+	})
+	root.SetArgs([]string{"docs", "create", "--title", "Runbook", "--folderId", "f_1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v1/bot/docs" {
+		t.Errorf("got %s %s, want POST /v1/bot/docs", gotMethod, gotPath)
+	}
+	if gotBody["title"] != "Runbook" || gotBody["folderId"] != "f_1" {
+		t.Errorf("body = %v", gotBody)
+	}
+	if gotAuth != "Bearer app_test" {
+		t.Errorf("Authorization = %q, want Bearer app_test", gotAuth)
+	}
+	if gotSpace != "" {
+		t.Errorf("X-Space-Id must not be sent for docs; got %q", gotSpace)
+	}
+}
+
+// TestDocsList_QueryParamsFromFlags checks the page-based list flags land in the
+// query string.
+func TestDocsList_QueryParamsFromFlags(t *testing.T) {
+	var gotQuery, gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":0,"items":[]}`))
+	})
+	root.SetArgs([]string{"docs", "list", "--page", "2", "--pageSize", "50", "--sort", "updatedAt:asc"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/v1/bot/docs" {
+		t.Errorf("path = %s", gotPath)
+	}
+	for _, want := range []string{"page=2", "pageSize=50", "sort=updatedAt%3Aasc"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+}
+
+// TestDocsGet_PathArgInURL checks the single positional arg lands in the path.
+func TestDocsGet_PathArgInURL(t *testing.T) {
+	var gotMethod, gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"abc"}`))
+	})
+	root.SetArgs([]string{"docs", "get", "abc"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/v1/bot/docs/abc" {
+		t.Errorf("got %s %s, want GET /v1/bot/docs/abc", gotMethod, gotPath)
+	}
+}
+
+// TestDocsMembersSet_PutUpsertBody checks the PUT-upsert method, path, and
+// {uid, role} body.
+func TestDocsMembersSet_PutUpsertBody(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	root.SetArgs([]string{"docs", "members", "set", "d1", "--uid", "u9", "--role", "writer"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "PUT" || gotPath != "/v1/bot/docs/d1/members" {
+		t.Errorf("got %s %s, want PUT /v1/bot/docs/d1/members", gotMethod, gotPath)
+	}
+	if gotBody["uid"] != "u9" || gotBody["role"] != "writer" {
+		t.Errorf("body = %v", gotBody)
+	}
+}
+
+// TestDocsMembersRemove_TwoPathArgs checks both positional args land in the path.
+func TestDocsMembersRemove_TwoPathArgs(t *testing.T) {
+	var gotMethod, gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+	root.SetArgs([]string{"docs", "members", "remove", "d1", "u9"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "DELETE" || gotPath != "/v1/bot/docs/d1/members/u9" {
+		t.Errorf("got %s %s, want DELETE /v1/bot/docs/d1/members/u9", gotMethod, gotPath)
+	}
+}
+
+// TestDocsCommentsAdd_ReplyBody checks a reply carries {body, parentId}.
+func TestDocsCommentsAdd_ReplyBody(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(201)
+		_, _ = w.Write([]byte(`{"id":42}`))
+	})
+	root.SetArgs([]string{"docs", "comments", "add", "d1", "--body", "Agreed", "--parentId", "7"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/v1/bot/docs/d1/comments" {
+		t.Errorf("path = %s", gotPath)
+	}
+	if gotBody["body"] != "Agreed" {
+		t.Errorf("body field = %v", gotBody["body"])
+	}
+	// Promoted integer flag must serialize as a JSON number.
+	if pid, ok := gotBody["parentId"].(float64); !ok || pid != 7 {
+		t.Errorf("parentId = %v (%T), want 7", gotBody["parentId"], gotBody["parentId"])
+	}
+}
+
+// TestDocsCommentsDelete_HardQuery checks the hard-delete query flag and the two
+// path args.
+func TestDocsCommentsDelete_HardQuery(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"id":5}`))
+	})
+	root.SetArgs([]string{"docs", "comments", "delete", "d1", "5", "--hard", "1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "DELETE" || gotPath != "/v1/bot/docs/d1/comments/5" {
+		t.Errorf("got %s %s", gotMethod, gotPath)
+	}
+	if !strings.Contains(gotQuery, "hard=1") {
+		t.Errorf("query %q missing hard=1", gotQuery)
+	}
+}
+
+// TestDocsVersionsRestore_PostNestedPath checks a two-path-arg nested POST.
+func TestDocsVersionsRestore_PostNestedPath(t *testing.T) {
+	var gotMethod, gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"restoredFrom":3,"newDocVersionSeq":9}`))
+	})
+	root.SetArgs([]string{"docs", "versions", "restore", "d1", "3"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v1/bot/docs/d1/versions/3/restore" {
+		t.Errorf("got %s %s, want POST /v1/bot/docs/d1/versions/3/restore", gotMethod, gotPath)
+	}
+}
+
+// TestDocsAttachmentsResolve_ArrayBody checks the string-array body field
+// serializes as a JSON array.
+func TestDocsAttachmentsResolve_ArrayBody(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"items":[],"notFound":[]}`))
+	})
+	root.SetArgs([]string{"docs", "attachments", "resolve", "d1", "--attachIds", "a1", "--attachIds", "a2"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/v1/bot/docs/d1/attachments/resolve" {
+		t.Errorf("path = %s", gotPath)
+	}
+	arr, ok := gotBody["attachIds"].([]any)
+	if !ok || len(arr) != 2 || arr[0] != "a1" || arr[1] != "a2" {
+		t.Errorf("attachIds = %v", gotBody["attachIds"])
+	}
+}
+
+// TestDocsAttachmentsPresign_BodyTypes checks the presign body promotes fileName
+// and mime as strings and sizeBytes as a JSON number.
+func TestDocsAttachmentsPresign_BodyTypes(t *testing.T) {
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"attachId":"at1","uploadUrl":"https://x"}`))
+	})
+	root.SetArgs([]string{
+		"docs", "attachments", "presign", "d1",
+		"--fileName", "report.pdf", "--mime", "application/pdf", "--sizeBytes", "2048",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotBody["fileName"] != "report.pdf" || gotBody["mime"] != "application/pdf" {
+		t.Errorf("body = %v", gotBody)
+	}
+	if sz, ok := gotBody["sizeBytes"].(float64); !ok || sz != 2048 {
+		t.Errorf("sizeBytes = %v (%T), want 2048", gotBody["sizeBytes"], gotBody["sizeBytes"])
+	}
+}

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -61,7 +61,8 @@ const (
 )
 
 func registerQueryFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.OperationDetail) {
-	for _, p := range d.Parameters {
+	for i := range d.Parameters {
+		p := &d.Parameters[i]
 		if p.In != "query" {
 			continue
 		}
@@ -109,7 +110,7 @@ func registerQueryFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Op
 // turned into dashes (the historical derivation). The override lets a header
 // like `If-Match` surface as a clean first-class flag (`--base-version`)
 // without a hard-coded per-endpoint carve-out.
-func paramFlagName(p registry.ParamInfo) string {
+func paramFlagName(p *registry.ParamInfo) string {
 	if p.FlagName != "" {
 		return p.FlagName
 	}
@@ -124,7 +125,8 @@ func paramFlagName(p registry.ParamInfo) string {
 // Registered before body flags so a header flag never collides with a promoted
 // body field of the same name.
 func registerHeaderFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.OperationDetail) {
-	for _, p := range d.Parameters {
+	for i := range d.Parameters {
+		p := &d.Parameters[i]
 		if p.In != "header" {
 			continue
 		}

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -13,14 +13,15 @@ import (
 // operationRuntime holds everything the RunE closure needs to build the
 // outbound request from the user's flag values.
 type operationRuntime struct {
-	detail     *registry.OperationDetail
-	pathParams []string              // path param names in order
-	queryFlags map[string]*queryFlag // flag name → query param binding
-	bodyFlags  map[string]*bodyFlag  // flag name → body field binding
-	bodyData   *string               // --data (nil when command has no body)
-	pageAll    *bool                 // --page-all (nil when no pagination)
-	pageLimit  *int                  // --page-limit
-	filePath   *string               // --file (multipart operations only)
+	detail      *registry.OperationDetail
+	pathParams  []string               // path param names in order
+	queryFlags  map[string]*queryFlag  // flag name → query param binding
+	headerFlags map[string]*headerFlag // flag name → header param binding
+	bodyFlags   map[string]*bodyFlag   // flag name → body field binding
+	bodyData    *string                // --data (nil when command has no body)
+	pageAll     *bool                  // --page-all (nil when no pagination)
+	pageLimit   *int                   // --page-limit
+	filePath    *string                // --file (multipart operations only)
 }
 
 type queryFlag struct {
@@ -30,6 +31,15 @@ type queryFlag struct {
 	intVal  *int
 	boolVal *bool
 	strSlc  *[]string
+}
+
+// headerFlag binds a CLI flag to a request header declared in the spec
+// (`"in": "header"`). Header values are always strings on the wire, so a
+// header flag is string-valued; run.go sends it only when the user set the
+// flag, so an omitted optional header stays absent.
+type headerFlag struct {
+	apiName string // HTTP header name (e.g. "If-Match")
+	strVal  *string
 }
 
 type bodyFlag struct {
@@ -55,7 +65,7 @@ func registerQueryFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Op
 		if p.In != "query" {
 			continue
 		}
-		flagName := strings.ReplaceAll(p.Name, "_", "-")
+		flagName := paramFlagName(p)
 		qf := &queryFlag{apiName: p.Name, kind: schemaTypeKind(p.Type)}
 		desc := p.Description
 		if len(p.Enum) > 0 {
@@ -88,6 +98,40 @@ func registerQueryFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Op
 			cmd.Flags().StringVar(qf.strVal, flagName, dv, desc)
 		}
 		rt.queryFlags[flagName] = qf
+		if p.Required {
+			_ = cmd.MarkFlagRequired(flagName) //nolint:errcheck // static flag name, can't fail
+		}
+	}
+}
+
+// paramFlagName is the CLI flag name for a spec parameter: the explicit
+// x-octo-flag override when present, else the wire name with underscores
+// turned into dashes (the historical derivation). The override lets a header
+// like `If-Match` surface as a clean first-class flag (`--base-version`)
+// without a hard-coded per-endpoint carve-out.
+func paramFlagName(p registry.ParamInfo) string {
+	if p.FlagName != "" {
+		return p.FlagName
+	}
+	return strings.ReplaceAll(p.Name, "_", "-")
+}
+
+// registerHeaderFlags binds every `"in": "header"` parameter to a string flag.
+// This is the general spec-declared header capability: the request engine can
+// set any per-request header from a flag, so an endpoint needing (say) an
+// If-Match optimistic-concurrency token declares it in the spec rather than
+// requiring bespoke code. run.go emits the header only when the flag is set.
+// Registered before body flags so a header flag never collides with a promoted
+// body field of the same name.
+func registerHeaderFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.OperationDetail) {
+	for _, p := range d.Parameters {
+		if p.In != "header" {
+			continue
+		}
+		flagName := paramFlagName(p)
+		hf := &headerFlag{apiName: p.Name, strVal: new(string)}
+		cmd.Flags().StringVar(hf.strVal, flagName, "", p.Description)
+		rt.headerFlags[flagName] = hf
 		if p.Required {
 			_ = cmd.MarkFlagRequired(flagName) //nolint:errcheck // static flag name, can't fail
 		}
@@ -141,8 +185,10 @@ func registerBodyFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Ope
 			continue
 		}
 		flagName := strings.ReplaceAll(name, "_", "-")
-		// Avoid collisions with --data, --file or a query param of the same name.
-		if flagName == "data" || flagName == "file" || rt.queryFlags[flagName] != nil {
+		// Avoid collisions with --data, --file, a query param, or a spec-declared
+		// header flag of the same name (e.g. an If-Match header exposed as
+		// --base-version takes precedence over a body baseVersion mirror).
+		if flagName == "data" || flagName == "file" || rt.queryFlags[flagName] != nil || rt.headerFlags[flagName] != nil {
 			continue
 		}
 		desc := prop.Description

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -31,39 +31,13 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 
 	// Query parameters (only emit flags explicitly set by the user so defaults
 	// don't override backend defaults).
-	q := url.Values{}
-	for flagName, qf := range rt.queryFlags {
-		if !cobraCmd.Flags().Changed(flagName) {
-			continue
-		}
-		switch qf.kind {
-		case kindInt:
-			q.Set(qf.apiName, strconv.Itoa(*qf.intVal))
-		case kindBool:
-			q.Set(qf.apiName, strconv.FormatBool(*qf.boolVal))
-		case kindStringSlice:
-			for _, v := range *qf.strSlc {
-				q.Add(qf.apiName, v)
-			}
-		default:
-			q.Set(qf.apiName, *qf.strVal)
-		}
-	}
+	q := buildQuery(cobraCmd, rt)
 
 	// Header parameters (spec `"in": "header"`). Emit only headers the user
 	// explicitly set so an omitted optional header stays absent. This is how a
 	// spec-declared header such as If-Match (optimistic-concurrency base
 	// version) reaches the wire from a flag — no per-endpoint transport code.
-	var headers map[string]string
-	for flagName, hf := range rt.headerFlags {
-		if !cobraCmd.Flags().Changed(flagName) {
-			continue
-		}
-		if headers == nil {
-			headers = map[string]string{}
-		}
-		headers[hf.apiName] = *hf.strVal
-	}
+	headers := buildHeaders(cobraCmd, rt)
 
 	// Body: start from --data (if any), then merge explicit flags on top.
 	// Multipart ops take a separate path — they build a form body, not JSON.
@@ -102,6 +76,47 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 	}
 
 	return emitOnce(ctx, f, &req)
+}
+
+// buildQuery assembles the URL query from flags the user explicitly set, so
+// omitted flags don't override backend defaults.
+func buildQuery(cobraCmd *cobra.Command, rt *operationRuntime) url.Values {
+	q := url.Values{}
+	for flagName, qf := range rt.queryFlags {
+		if !cobraCmd.Flags().Changed(flagName) {
+			continue
+		}
+		switch qf.kind {
+		case kindInt:
+			q.Set(qf.apiName, strconv.Itoa(*qf.intVal))
+		case kindBool:
+			q.Set(qf.apiName, strconv.FormatBool(*qf.boolVal))
+		case kindStringSlice:
+			for _, v := range *qf.strSlc {
+				q.Add(qf.apiName, v)
+			}
+		default:
+			q.Set(qf.apiName, *qf.strVal)
+		}
+	}
+	return q
+}
+
+// buildHeaders assembles the per-request headers from spec-declared header
+// flags the user explicitly set. Returns nil when none were set, so an omitted
+// optional header stays absent from the wire.
+func buildHeaders(cobraCmd *cobra.Command, rt *operationRuntime) map[string]string {
+	var headers map[string]string
+	for flagName, hf := range rt.headerFlags {
+		if !cobraCmd.Flags().Changed(flagName) {
+			continue
+		}
+		if headers == nil {
+			headers = map[string]string{}
+		}
+		headers[hf.apiName] = *hf.strVal
+	}
+	return headers
 }
 
 // resolveBody constructs the JSON body. Empty when the op has neither --data

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -58,6 +58,10 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 		Path:           urlPath,
 		Query:          q,
 		BinaryResponse: d.BinaryResponse,
+		// Suppress X-Space-Id only when the spec explicitly declares
+		// x-octo-space-header:false. An omitted flag keeps the default
+		// behaviour of sending the header when the credential has a space.
+		SuppressSpaceHeader: d.SpaceHeaderSet && !d.SpaceHeader,
 	}
 	if d.Multipart {
 		raw, ct, err := buildMultipartBody(cobraCmd, rt)
@@ -189,12 +193,13 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 		}
 		nextQ.Set(cursorParam, nextCursor)
 		req = client.Request{
-			Service: req.Service,
-			Method:  req.Method,
-			Path:    req.Path,
-			Query:   nextQ,
-			Body:    req.Body,
-			Headers: req.Headers,
+			Service:             req.Service,
+			Method:              req.Method,
+			Path:                req.Path,
+			Query:               nextQ,
+			Body:                req.Body,
+			Headers:             req.Headers,
+			SuppressSpaceHeader: req.SuppressSpaceHeader,
 		}
 	}
 

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -50,6 +50,21 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 		}
 	}
 
+	// Header parameters (spec `"in": "header"`). Emit only headers the user
+	// explicitly set so an omitted optional header stays absent. This is how a
+	// spec-declared header such as If-Match (optimistic-concurrency base
+	// version) reaches the wire from a flag — no per-endpoint transport code.
+	var headers map[string]string
+	for flagName, hf := range rt.headerFlags {
+		if !cobraCmd.Flags().Changed(flagName) {
+			continue
+		}
+		if headers == nil {
+			headers = map[string]string{}
+		}
+		headers[hf.apiName] = *hf.strVal
+	}
+
 	// Body: start from --data (if any), then merge explicit flags on top.
 	// Multipart ops take a separate path — they build a form body, not JSON.
 	req := client.Request{
@@ -57,6 +72,7 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 		Method:         d.Method,
 		Path:           urlPath,
 		Query:          q,
+		Headers:        headers,
 		BinaryResponse: d.BinaryResponse,
 		// Suppress X-Space-Id only when the spec explicitly declares
 		// x-octo-space-header:false. An omitted flag keeps the default

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -113,9 +113,10 @@ func rejectUnknownSubcommand(cmd *cobra.Command, args []string) error {
 // Flag registration is delegated to flags.go; execution to run.go.
 func buildOperationCmd(f *cmdutil.Factory, d *registry.OperationDetail, verb string) *cobra.Command {
 	rt := &operationRuntime{
-		detail:     d,
-		queryFlags: map[string]*queryFlag{},
-		bodyFlags:  map[string]*bodyFlag{},
+		detail:      d,
+		queryFlags:  map[string]*queryFlag{},
+		headerFlags: map[string]*headerFlag{},
+		bodyFlags:   map[string]*bodyFlag{},
 	}
 
 	rt.pathParams = extractPathParams(d.Path)
@@ -133,6 +134,7 @@ func buildOperationCmd(f *cmdutil.Factory, d *registry.OperationDetail, verb str
 	}
 
 	registerQueryFlags(cmd, rt, d)
+	registerHeaderFlags(cmd, rt, d)
 	registerBodyFlags(cmd, rt, d)
 
 	if d.Pagination != nil {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -51,6 +51,35 @@ func rootWithService(t *testing.T, handler http.HandlerFunc) (*cobra.Command, *c
 	return root, tf, srv
 }
 
+// rootWithServiceSpaced is rootWithService with a credential that carries a
+// SpaceID, so tests can assert whether X-Space-Id reaches the wire. It is the
+// realistic shape for a platform-scoped bot (space supplied via --space /
+// OCTO_SPACE_ID), which is exactly the case the per-operation space-header
+// gating governs.
+func rootWithServiceSpaced(t *testing.T, spaceID string, handler http.HandlerFunc) (*cobra.Command, *cmdutil.TestFactory, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	tf := cmdutil.NewTestFactory()
+	cfg := &config.Config{
+		APIBaseURL: srv.URL,
+		BotToken:   "app_test",
+		Format:     "json",
+	}
+	tf.SetConfig(cfg)
+	cred := &credential.BotCredential{Token: "app_test", SpaceID: spaceID, Source: "test"}
+	tf.SetCredential(cred)
+	cli := client.New(cfg, cred, client.Options{ErrOut: io.Discard})
+	tf.SetClient(cli)
+	tf.RegistryFunc = registry.MustNew
+
+	root := &cobra.Command{Use: "octo-cli", SilenceUsage: true, SilenceErrors: true}
+	RegisterServiceCommands(root, tf.Factory)
+
+	return root, tf, srv
+}
+
 // --- command-tree assertions ---
 
 func TestRegisterServiceCommands_TreeShape(t *testing.T) {

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -58,6 +58,12 @@ type Request struct {
 	// BinaryResponse asks the client to treat 3xx/non-JSON responses as
 	// structured metadata envelopes rather than parsing JSON. See file.download.
 	BinaryResponse bool
+	// SuppressSpaceHeader omits the X-Space-Id header even when the active
+	// credential carries a SpaceID. It is set for operations whose spec declares
+	// x-octo-space-header:false (e.g. the docs bot mount resolves the space
+	// server-side). The default (false) preserves the historical behaviour of
+	// sending X-Space-Id whenever the credential has a space.
+	SuppressSpaceHeader bool
 }
 
 // Client is the REST client. Created via New; invoked by command layer via Do.
@@ -134,14 +140,14 @@ func (c *Client) Do(ctx context.Context, req *Request) ([]byte, error) {
 	}
 
 	if c.options.DryRun {
-		return c.renderDryRun(req.Method, u, req.Headers, bodyBytes)
+		return c.renderDryRun(req.Method, u, req.Headers, bodyBytes, req.SuppressSpaceHeader)
 	}
 
-	return c.doWithRetry(ctx, req.Method, u, req.Headers, bodyBytes, contentType, req.BinaryResponse)
+	return c.doWithRetry(ctx, req.Method, u, req.Headers, bodyBytes, contentType, req.BinaryResponse, req.SuppressSpaceHeader)
 }
 
 // doWithRetry runs the HTTP request, retrying transient errors with backoff.
-func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool) ([]byte, error) {
+func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp, suppressSpaceHeader bool) ([]byte, error) {
 	maxRetries := defaultMaxRetries
 	if c.options.NoRetry {
 		maxRetries = 0
@@ -165,7 +171,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 			}
 		}
 
-		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binaryResp)
+		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binaryResp, suppressSpaceHeader)
 		if err == nil {
 			return body, nil
 		}
@@ -179,7 +185,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 }
 
 // attempt executes one HTTP round-trip and interprets the response.
-func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
+func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp, suppressSpaceHeader bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
@@ -193,7 +199,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 	if c.cred != nil && c.cred.Token != "" {
 		httpReq.Header.Set("Authorization", "Bearer "+c.cred.Token)
 	}
-	if c.cred != nil && c.cred.SpaceID != "" {
+	if c.cred != nil && c.cred.SpaceID != "" && !suppressSpaceHeader {
 		httpReq.Header.Set("X-Space-Id", c.cred.SpaceID)
 	}
 	if body != nil && contentType != "" {
@@ -276,7 +282,7 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 
 // renderDryRun writes a human-readable request description and returns a
 // synthetic success body containing the same payload for envelope rendering.
-func (c *Client) renderDryRun(method, urlStr string, headers map[string]string, body []byte) ([]byte, error) {
+func (c *Client) renderDryRun(method, urlStr string, headers map[string]string, body []byte, suppressSpaceHeader bool) ([]byte, error) {
 	var bodyField any
 	if len(body) > 0 {
 		if err := json.Unmarshal(body, &bodyField); err != nil {
@@ -287,7 +293,7 @@ func (c *Client) renderDryRun(method, urlStr string, headers map[string]string, 
 	if c.cred != nil && c.cred.Token != "" {
 		hdr["Authorization"] = "Bearer " + credential.MaskToken(c.cred.Token)
 	}
-	if c.cred != nil && c.cred.SpaceID != "" {
+	if c.cred != nil && c.cred.SpaceID != "" && !suppressSpaceHeader {
 		hdr["X-Space-Id"] = c.cred.SpaceID
 	}
 	for k, v := range headers {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -47,6 +47,27 @@ func TestDo_SetsAuthAndSpaceHeaders(t *testing.T) {
 	}
 }
 
+func TestDo_SuppressSpaceHeader(t *testing.T) {
+	var sawSpaceHeader bool
+	var gotSpace string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, sawSpaceHeader = r.Header["X-Space-Id"]
+		gotSpace = r.Header.Get("X-Space-Id")
+		w.WriteHeader(200)
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	// Credential carries a space, but the request opts out of the header.
+	c := newTestClient(srv)
+	if _, err := c.Do(context.Background(), &Request{Method: "GET", Path: "/test", SuppressSpaceHeader: true}); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if sawSpaceHeader {
+		t.Errorf("X-Space-Id must be omitted when SuppressSpaceHeader is set; got %q", gotSpace)
+	}
+}
+
 func TestDo_SetsContentTypeForBody(t *testing.T) {
 	var gotCT string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -147,6 +147,13 @@ type ParamInfo struct {
 	Description string `json:"description,omitempty"`
 	Default     any    `json:"default,omitempty"`
 	Enum        []any  `json:"enum,omitempty"`
+	// FlagName is the optional CLI flag override from the x-octo-flag
+	// extension on the parameter. It lets a spec expose a header/query param
+	// whose wire name is awkward as a flag (e.g. the `If-Match` header) under a
+	// clean, first-class flag name (e.g. `base-version`) without a hard-coded
+	// carve-out in the engine. Empty when the spec does not set it, in which
+	// case the engine derives the flag from Name.
+	FlagName string `json:"flag_name,omitempty"`
 }
 
 // SchemaInfo is a trimmed projection of an OpenAPI schema — just enough for
@@ -318,6 +325,7 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 				In:          stringOf(pm["in"]),
 				Required:    boolOf(pm["required"]),
 				Description: stringOf(pm["description"]),
+				FlagName:    stringOf(pm["x-octo-flag"]),
 			}
 			if sch, ok := pm["schema"].(map[string]any); ok {
 				pi.Type = stringOf(sch["type"])

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -192,8 +192,13 @@ type OperationDetail struct {
 	Pagination     *PaginationInfo `json:"pagination,omitempty"`
 	BaseURLEnv     string          `json:"base_url_env,omitempty"`
 	SpaceHeader    bool            `json:"space_header,omitempty"`
-	Multipart      bool            `json:"multipart,omitempty"`
-	BinaryResponse bool            `json:"binary_response,omitempty"`
+	// SpaceHeaderSet records whether the spec declared x-octo-space-header at
+	// all. It lets the transport distinguish an explicit `false` (suppress the
+	// X-Space-Id header) from an omitted flag (keep the default behaviour of
+	// sending it when the credential carries a space).
+	SpaceHeaderSet bool `json:"space_header_set,omitempty"`
+	Multipart      bool `json:"multipart,omitempty"`
+	BinaryResponse bool `json:"binary_response,omitempty"`
 }
 
 // ListOperations returns every operation for a service, sorted by operationId.
@@ -297,6 +302,7 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 		BaseURLEnv:  stringOf(doc["x-octo-base-url"]),
 		SpaceHeader: boolOf(doc["x-octo-space-header"]),
 	}
+	_, d.SpaceHeaderSet = doc["x-octo-space-header"]
 
 	d.Multipart = boolOf(op["x-octo-multipart"])
 	d.BinaryResponse = boolOf(op["x-octo-binary-response"])

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -41,7 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
-		"docs":    22,
+		"docs":    24,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -184,6 +184,38 @@ func TestGetOperationNotFound(t *testing.T) {
 	r := MustNew()
 	if _, ok := r.GetOperation("does.not.exist"); ok {
 		t.Fatal("GetOperation: expected ok=false for unknown id")
+	}
+}
+
+// TestHeaderParamWithFlagAlias pins the general spec-declared header capability:
+// docs.content.edit declares an If-Match header parameter carrying the
+// x-octo-flag alias `base-version`, so the request engine can drive the
+// optimistic-concurrency base-version token from a first-class flag onto a
+// per-request header — no docs-specific carve-out in the transport.
+func TestHeaderParamWithFlagAlias(t *testing.T) {
+	r := MustNew()
+	op, ok := r.GetOperation("docs.content.edit")
+	if !ok {
+		t.Fatal("docs.content.edit not found")
+	}
+	var found *ParamInfo
+	for i := range op.Parameters {
+		if op.Parameters[i].In == "header" {
+			found = &op.Parameters[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("docs.content.edit: expected a header parameter (If-Match)")
+	}
+	if found.Name != "If-Match" {
+		t.Errorf("header param name = %q, want If-Match", found.Name)
+	}
+	if found.FlagName != "base-version" {
+		t.Errorf("header param flag alias = %q, want base-version (from x-octo-flag)", found.FlagName)
+	}
+	if !found.Required {
+		t.Error("If-Match header must be required (mandatory base-version guard)")
 	}
 }
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -10,7 +10,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "event", "file", "group", "matter", "message", "thread"}
+	want := []string{"bot", "docs", "event", "file", "group", "matter", "message", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -41,6 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
+		"docs":    22,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -131,8 +131,52 @@ func TestGetOperationMessageSend_DMWorkimBase(t *testing.T) {
 	if op.BaseURLEnv != "OCTO_API_BASE_URL" {
 		t.Errorf("base url env: got %q, want OCTO_API_BASE_URL", op.BaseURLEnv)
 	}
-	if op.SpaceHeader {
-		t.Error("space header: want false for dmworkim domain")
+	// message declares x-octo-space-header:true so the client keeps sending
+	// X-Space-Id: sendMessage for a multi-space bot uses the header as the DM
+	// multi-space selection hint, and dropping it silently mis-attributes the
+	// message.
+	if !op.SpaceHeader {
+		t.Error("space header: want true for message domain (sendMessage uses X-Space-Id for multi-space DM selection)")
+	}
+}
+
+// TestServiceSpaceHeaderContract pins the space-header declaration of every
+// service spec so an accidental flip is caught. The client suppresses
+// X-Space-Id only when a spec explicitly declares x-octo-space-header:false
+// (SpaceHeaderSet && !SpaceHeader); the values below are the intended,
+// server-verified per-service behaviour:
+//   - message / matter: true  — the server reads X-Space-Id (DM multi-space
+//     hint / space-scoped matters), so the client must keep sending it.
+//   - docs and the rest: false — those bot mounts server-resolve the space and
+//     ignore the header, so the client honestly suppresses it.
+func TestServiceSpaceHeaderContract(t *testing.T) {
+	r := MustNew()
+	cases := []struct {
+		service string
+		opID    string
+		want    bool
+	}{
+		{"message", "message.send", true},
+		{"matter", "matter.create", true},
+		{"docs", "docs.create", false},
+		{"bot", "bot.register", false},
+		{"thread", "thread.create", false},
+		{"group", "group.create", false},
+		{"file", "file.upload", false},
+		{"event", "event.list", false},
+	}
+	for _, c := range cases {
+		op, ok := r.GetOperation(c.opID)
+		if !ok {
+			t.Errorf("%s: operation %q not found", c.service, c.opID)
+			continue
+		}
+		if !op.SpaceHeaderSet {
+			t.Errorf("%s: x-octo-space-header must be declared explicitly (SpaceHeaderSet=false)", c.service)
+		}
+		if op.SpaceHeader != c.want {
+			t.Errorf("%s: space header = %v, want %v", c.service, op.SpaceHeader, c.want)
+		}
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -161,6 +161,88 @@
         "responses": { "200": { "description": "Deleted" } }
       }
     },
+    "/v1/bot/docs/{docId}/content": {
+      "get": {
+        "operationId": "docs.content.get",
+        "summary": "Read a document's live body + its base version (needs reader)",
+        "description": "Reads the LIVE ProseMirror body of a doc_type 'doc' plus the base-version token that pins the read. Pass that token to `docs content edit` as --base-version so the optimistic-concurrency guard can prove the body did not change between read and write. board / whiteboard bodies are a different Y.Doc shape and return 409 unsupported_doc_type here.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Live body + base version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "doc": { "type": "object", "description": "the live body as ProseMirror document JSON" },
+                    "schemaVersion": { "type": "integer", "description": "ProseMirror schema version the body was decoded with" },
+                    "baseVersion": { "type": "string", "description": "opaque base64 base-version token; pass to `docs content edit --base-version`" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "docs.content.edit",
+        "summary": "Apply an incremental block-op edit to a document body (needs writer)",
+        "description": "Applies a batch of incremental block ops to a doc_type 'doc' body under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs content get` via --base-version (sent as the If-Match header); the server rejects with 412 base_version_stale if the live body moved since that read. The ops batch is a structured array, so pass it as JSON through --data. Only doc_type 'doc' is accepted (board / whiteboard return 409 unsupported_doc_type). Gates: op count over the max → 413 too_many_ops, a single op's content too large → 413 op_content_too_large, block-path too deep → 400 path_too_deep, missing base version or malformed shape → 400 invalid_body, bad anchor / invalid ops → 422.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "x-octo-flag": "base-version",
+            "schema": { "type": "string" },
+            "description": "base-version token from 'docs content get' (sent as the If-Match header for optimistic concurrency; required)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["ops"],
+                "properties": {
+                  "ops": {
+                    "type": "array",
+                    "description": "ordered batch of incremental block edit ops. Each op is one of: insert {\"type\":\"insert\",\"at\":{\"path\":[i,...],\"position\":\"before|after|inside_start|inside_end\"},\"content\":[<ProseMirror block nodes>],\"expect\":{\"type\":\"<nodeType>\"}?}; replace {\"type\":\"replace\",\"range\":{\"from\":{\"path\":[...]},\"to\":{\"path\":[...]}},\"content\":[...],\"expect\":?}; delete {\"type\":\"delete\",\"range\":{\"from\":{\"path\":[...]},\"to\":{\"path\":[...]}},\"expect\":?}. `path` is child indices from the doc root; range endpoints must share a parent. Pass via --data.",
+                    "items": { "type": "object" }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Edit applied; carries the new base version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "bytes": { "type": "integer", "description": "encoded size of the doc after the edit" },
+                    "baseVersion": { "type": "string", "description": "new base-version token for the next edit" },
+                    "newDocVersionSeq": { "type": "integer", "description": "sequence of the auto safety snapshot taken before the edit" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}/members": {
       "get": {
         "operationId": "docs.members.list",

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -1,0 +1,620 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Octo Docs Bot API",
+    "version": "1.0.0",
+    "description": "Bot-facing document metadata surface under /v1/bot/docs: doc lifecycle, members, sharing, comments, versions, and attachment metadata. Live document body/outline editing is a Yjs websocket path and is NOT part of this REST surface."
+  },
+  "x-octo-service": "docs",
+  "x-octo-base-url": "OCTO_API_BASE_URL",
+  "x-octo-space-header": false,
+  "paths": {
+    "/v1/bot/docs": {
+      "post": {
+        "operationId": "docs.create",
+        "summary": "Create an (empty) document; the caller becomes owner/admin",
+        "description": "Create takes no body content — a new doc starts empty and its body is edited over the Yjs websocket, not REST.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": { "type": "string", "description": "initial title (optional; defaults to empty)" },
+                  "folderId": { "type": "string", "description": "target folder id (optional; defaults to the space default folder)" },
+                  "docType": { "type": "string", "description": "document type (optional; defaults to 'doc')" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created document metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "documentName": { "type": "string" },
+                    "title": { "type": "string" },
+                    "spaceId": { "type": "string" },
+                    "folderId": { "type": "string" },
+                    "ownerId": { "type": "string" },
+                    "role": { "type": "string" },
+                    "createdAt": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "docs.list",
+        "summary": "List documents the bot owns or is a member of (page-based)",
+        "description": "Page-based listing scoped to the bot's server-resolved space. Response is {total, items}; there is no cursor, so --page-all does not apply — walk pages with --page/--pageSize.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "folderId", "in": "query", "schema": { "type": "string" }, "description": "filter to a single folder" },
+          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1 }, "description": "1-based page number" },
+          { "name": "pageSize", "in": "query", "schema": { "type": "integer", "default": 20, "maximum": 100 }, "description": "items per page (1-100, default 20)" },
+          { "name": "sort", "in": "query", "schema": { "type": "string", "enum": ["updatedAt:desc", "updatedAt:asc"], "default": "updatedAt:desc" }, "description": "sort order by last update" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of documents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": { "type": "integer" },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "docId": { "type": "string" },
+                          "title": { "type": "string" },
+                          "ownerId": { "type": "string" },
+                          "docType": { "type": "string" },
+                          "role": { "type": "string" },
+                          "updatedAt": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/bot/docs/{docId}": {
+      "get": {
+        "operationId": "docs.get",
+        "summary": "Fetch one document's metadata (needs reader)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "documentName": { "type": "string" },
+                    "title": { "type": "string" },
+                    "ownerId": { "type": "string" },
+                    "spaceId": { "type": "string" },
+                    "folderId": { "type": "string" },
+                    "docType": { "type": "string" },
+                    "role": { "type": "string" },
+                    "createdAt": { "type": "string" },
+                    "updatedAt": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "docs.rename",
+        "summary": "Rename a document (needs admin)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["title"],
+                "properties": {
+                  "title": { "type": "string", "description": "new non-empty title" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Renamed" } }
+      },
+      "delete": {
+        "operationId": "docs.delete",
+        "summary": "Soft-delete a document (needs admin)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Deleted" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/members": {
+      "get": {
+        "operationId": "docs.members.list",
+        "summary": "List a document's members (needs admin)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Members",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "uid": { "type": "string" },
+                          "role": { "type": "string" },
+                          "source": { "type": "string" },
+                          "grantedBy": { "type": "string" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "docs.members.set",
+        "summary": "Add or change a member's role by uid (upsert; needs admin)",
+        "description": "PUT-upsert: adds the member if absent or changes the role if present. The target uid must be a real Octo user or the backend returns 404 user_not_found.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["uid", "role"],
+                "properties": {
+                  "uid": { "type": "string", "description": "target user uid" },
+                  "role": { "type": "string", "enum": ["reader", "writer", "admin"], "description": "role to grant" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Upserted" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/members/{uid}": {
+      "delete": {
+        "operationId": "docs.members.remove",
+        "summary": "Remove a member (needs admin; the owner cannot be removed)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "uid", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Removed" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/forward-grant": {
+      "post": {
+        "operationId": "docs.forward-grant",
+        "summary": "Grant (never downgrade) a single uid reader/writer access (needs admin)",
+        "description": "Max-merge grant used when forwarding a doc to a chat recipient. Only reader or writer is grantable here; admin is not forward-grantable.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["uid", "role"],
+                "properties": {
+                  "uid": { "type": "string", "description": "target user uid" },
+                  "role": { "type": "string", "enum": ["reader", "writer"], "description": "role to grant (grant-only, never downgrades)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Grant result (final role + changed flag)" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/comments": {
+      "get": {
+        "operationId": "docs.comments.list",
+        "summary": "List comment thread roots with their replies (needs reader)",
+        "description": "Returns {items, nextCursor}; there is no {data, pagination} envelope, so --page-all does not apply — pass --cursor with the returned nextCursor to walk pages.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "includeResolved", "in": "query", "schema": { "type": "string" }, "description": "set to 1 to include resolved threads" },
+          { "name": "cursor", "in": "query", "schema": { "type": "integer" }, "description": "id cursor from a previous page's nextCursor" },
+          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 50, "maximum": 100 }, "description": "page size (1-100, default 50)" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of comment threads",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": { "type": "array", "items": { "type": "object" } },
+                    "nextCursor": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "docs.comments.add",
+        "summary": "Add a root comment (anchored) or a reply (needs reader)",
+        "description": "Root comments require anchorStart and anchorEnd (opaque base64 Yjs positions). A reply sets parentId and omits anchors. Anchors are complex/base64 values — pass them via the flags below or --data.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["body"],
+                "properties": {
+                  "body": { "type": "string", "description": "comment text" },
+                  "parentId": { "type": "integer", "description": "thread root id to reply to (omit for a root comment)" },
+                  "anchorStart": { "type": "string", "description": "root only: base64-encoded Yjs start position" },
+                  "anchorEnd": { "type": "string", "description": "root only: base64-encoded Yjs end position" },
+                  "anchorText": { "type": "string", "description": "root only: the anchored text snippet (optional)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created (returns the new comment id)" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/comments/{id}": {
+      "patch": {
+        "operationId": "docs.comments.edit",
+        "summary": "Edit a comment body (author) or resolve/reopen a thread (writer)",
+        "description": "Pass --body to edit your own comment's text, or --resolved to resolve/reopen a thread root. Provide exactly one.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": { "type": "string", "description": "new comment text (author only)" },
+                  "resolved": { "type": "boolean", "description": "resolve (true) or reopen (false) a thread root (writer only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Updated" } }
+      },
+      "delete": {
+        "operationId": "docs.comments.delete",
+        "summary": "Soft-delete your own comment, or hard-delete as admin",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "hard", "in": "query", "schema": { "type": "string" }, "description": "set to 1 for an admin hard delete (default is a soft delete by the author)" }
+        ],
+        "responses": { "200": { "description": "Deleted" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/versions": {
+      "get": {
+        "operationId": "docs.versions.list",
+        "summary": "List saved versions/snapshots (needs reader)",
+        "description": "Returns {items, nextCursor, counts}; there is no {data, pagination} envelope, so --page-all does not apply — pass --cursor with the returned nextCursor to walk pages.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "cursor", "in": "query", "schema": { "type": "integer" }, "description": "id cursor from a previous page's nextCursor" },
+          { "name": "limit", "in": "query", "schema": { "type": "integer" }, "description": "page size" },
+          { "name": "kind", "in": "query", "schema": { "type": "string", "enum": ["manual", "auto", "all"] }, "description": "filter by snapshot kind" },
+          { "name": "includeAuto", "in": "query", "schema": { "type": "string" }, "description": "back-compat alias honoured only when kind is absent; set to 1 to include auto snapshots" }
+        ],
+        "responses": {
+          "200": {
+            "description": "A page of versions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": { "type": "array", "items": { "type": "object" } },
+                    "nextCursor": { "type": "integer" },
+                    "counts": { "type": "object" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "docs.versions.create",
+        "summary": "Take a named snapshot of the live document (needs writer)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": { "type": "string", "description": "human label for the snapshot (optional)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created (returns docVersionSeq)" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/versions/{versionId}/state": {
+      "get": {
+        "operationId": "docs.versions.state",
+        "summary": "Read a version's decoded content snapshot (read-only preview; needs reader)",
+        "description": "Returns the version decoded to ProseMirror JSON ({doc, sheetCells, sheetDims, schemaVersion, docVersionSeq}). This is a read-only preview of a past snapshot, not the live document, and cannot be written.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "versionId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Decoded snapshot content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "doc": { "type": "object" },
+                    "sheetCells": { "type": "object" },
+                    "sheetDims": { "type": "object" },
+                    "schemaVersion": { "type": "integer" },
+                    "docVersionSeq": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/bot/docs/{docId}/versions/{versionId}": {
+      "patch": {
+        "operationId": "docs.versions.rename",
+        "summary": "Rename a saved version (needs writer)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "versionId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["label"],
+                "properties": {
+                  "label": { "type": "string", "description": "new non-empty label" }
+                }
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Renamed" } }
+      },
+      "delete": {
+        "operationId": "docs.versions.delete",
+        "summary": "Delete a saved version (needs admin)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "versionId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Deleted" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/versions/{versionId}/restore": {
+      "post": {
+        "operationId": "docs.versions.restore",
+        "summary": "Restore the document to a saved version (needs admin)",
+        "description": "Non-destructive forward reconcile of the target version into the live state. A safety snapshot of the pre-restore state is recorded first, so a restore is itself undoable.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "versionId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "Restored (returns restoredFrom + newDocVersionSeq)" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/attachments/presign": {
+      "post": {
+        "operationId": "docs.attachments.presign",
+        "summary": "Register an attachment and get a presigned upload URL (needs writer)",
+        "description": "Metadata-only. Returns a presigned PUT URL + headers; the CLI does not upload the bytes. After presign, PUT the file directly to uploadUrl with the returned headers (see the octo-docs skill).",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["fileName", "mime", "sizeBytes"],
+                "properties": {
+                  "fileName": { "type": "string", "description": "original file name" },
+                  "mime": { "type": "string", "description": "MIME type (must pass the backend allow/deny list)" },
+                  "sizeBytes": { "type": "integer", "description": "file size in bytes (must be within the tier cap)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Presigned upload target",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "attachId": { "type": "string" },
+                    "objectKey": { "type": "string" },
+                    "bucket": { "type": "string" },
+                    "mime": { "type": "string" },
+                    "sizeBytes": { "type": "integer" },
+                    "uploadUrl": { "type": "string" },
+                    "headers": { "type": "object" },
+                    "expiresInSec": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/bot/docs/{docId}/attachments/{attachId}": {
+      "get": {
+        "operationId": "docs.attachments.get",
+        "summary": "Get a freshly signed, time-limited download URL for one attachment (needs reader)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "attachId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Signed download URL + metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "attachId": { "type": "string" },
+                    "objectKey": { "type": "string" },
+                    "mime": { "type": "string" },
+                    "sizeBytes": { "type": "integer" },
+                    "fileName": { "type": "string" },
+                    "url": { "type": "string" },
+                    "expiresInSec": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/bot/docs/{docId}/attachments/resolve": {
+      "post": {
+        "operationId": "docs.attachments.resolve",
+        "summary": "Batch-resolve attachIds to freshly signed download URLs (needs reader)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["attachIds"],
+                "properties": {
+                  "attachIds": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "attachment ids to resolve (non-empty; capped by the backend batch limit)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Signed URLs + not-found ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": { "type": "array", "items": { "type": "object" } },
+                    "notFound": { "type": "array", "items": { "type": "string" } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/registry/specs/message.json
+++ b/internal/registry/specs/message.json
@@ -7,7 +7,7 @@
   },
   "x-octo-service": "message",
   "x-octo-base-url": "OCTO_API_BASE_URL",
-  "x-octo-space-header": false,
+  "x-octo-space-header": true,
   "paths": {
     "/v1/bot/sendMessage": {
       "post": {

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -78,7 +78,7 @@ octo-cli docs comments add <docId> --body "Agreed" --parentId <rootId>
 
 # Edit your own comment's text, OR resolve/reopen a thread root (pass one).
 octo-cli docs comments edit   <docId> <id> --body "edited text"
-octo-cli docs comments edit   <docId> <id> --resolved true      # writer; false reopens
+octo-cli docs comments edit   <docId> <id> --resolved=true      # writer; false reopens
 
 octo-cli docs comments delete <docId> <id>          # soft delete (author)
 octo-cli docs comments delete <docId> <id> --hard 1 # hard delete (admin)

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: octo-docs
 version: 0.1.0
-description: Docs domain — create and govern documents, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Live body/outline editing is NOT available over the CLI. Load after octo-shared.
+description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
     skills: ["octo-shared"]
 ---
 
-# octo-docs — documents, members, comments, versions, attachments
+# octo-docs — documents, body content, members, comments, versions, attachments
 
-> **Live document content editing is NOT available from the CLI.** A document's
-> body and outline live in a Yjs (Hocuspocus) websocket session, not in any REST
-> endpoint. This skill drives everything *around* the content — metadata,
-> members, sharing, comments, versions, and attachment references — but it cannot
-> read or write the live body. Creating a doc makes an **empty** document; you
-> cannot seed or edit its text here. To inspect content, take a snapshot
-> (`docs versions create`) and read it back with `docs versions state`, which
-> returns a **read-only** decoded preview of that snapshot.
+> **Live body editing IS available for `doc_type: doc`.** You can read a
+> document's live body with `docs content get` and apply **incremental block-op
+> edits** with `docs content edit` under an `If-Match` base-version guard. These
+> are **not** a free-form "set the whole body" — each edit is a batch of insert /
+> replace / delete ops addressed by block path, and concurrency is controlled by
+> a base-version token: read to get the token, then edit with that token so the
+> server can prove the body did not change underneath you (a stale token is
+> rejected with `412 base_version_stale`). Only `doc_type: doc` bodies are
+> editable this way; **whiteboard and board bodies are a different Y.Doc shape
+> and are not editable here** (they return `409 unsupported_doc_type`). The
+> document *outline* still lives only in the Yjs session and is not a REST
+> surface. Creating a doc still makes an **empty** document; seed its text with
+> an initial `docs content edit`.
 
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 
@@ -34,7 +39,7 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 ## 1. Document lifecycle
 
 ```bash
-# Create an empty doc (caller becomes owner/admin). Body content is NOT set here.
+# Create an empty doc (caller becomes owner/admin). Seed the body with `docs content edit` (§2).
 octo-cli docs create [--title "Runbook"] [--folderId f_123] [--docType doc]
 
 # List docs you own or are a member of. Page-based (see the pagination note below).
@@ -45,7 +50,63 @@ octo-cli docs rename <docId> --title "New title"
 octo-cli docs delete <docId>                 # soft delete (admin)
 ```
 
-## 2. Members & sharing
+## 2. Document body (read + incremental edit)
+
+Available for `doc_type: doc` only. Read the live body and its base-version
+token, then apply a batch of incremental block ops guarded by that token.
+
+```bash
+# Read the LIVE body + baseVersion (reader). Response:
+#   { docId, doc: <ProseMirror JSON>, schemaVersion, baseVersion }
+octo-cli docs content get <docId>
+
+# Apply an incremental edit (writer). --base-version is REQUIRED and is sent as
+# the If-Match header; the ops batch goes through --data as a JSON array.
+octo-cli docs content edit <docId> --base-version "<token>" --data '<ops JSON>'
+```
+
+Ops are addressed by **block path** (child indices from the doc root) and come
+in three shapes — this is not a whole-body replace:
+
+- `insert` — `{"type":"insert","at":{"path":[i,...],"position":"before|after|inside_start|inside_end"},"content":[<block nodes>]}`. Use `path: []` with `inside_start`/`inside_end` to write the first block of an empty doc.
+- `replace` — `{"type":"replace","range":{"from":{"path":[...]},"to":{"path":[...]}},"content":[<block nodes>]}`
+- `delete` — `{"type":"delete","range":{"from":{"path":[...]},"to":{"path":[...]}}}`
+
+Range endpoints must share a parent. Each op may carry `"expect":{"type":"<nodeType>"}` to assert the addressed node type. On success the response returns a **new** `baseVersion` — use it for the next edit.
+
+### Worked example: read, then append a paragraph
+
+```bash
+# 1. Read the current body and capture the base version.
+BV=$(octo-cli docs content get d_123 --output json | jq -r '.data.baseVersion')
+
+# 2. Append a paragraph at the end of the doc, guarded by that base version.
+octo-cli docs content edit d_123 --base-version "$BV" --data '{
+  "ops": [
+    {
+      "type": "insert",
+      "at": { "path": [], "position": "inside_end" },
+      "content": [
+        { "type": "paragraph", "content": [ { "type": "text", "text": "Appended by the bot." } ] }
+      ]
+    }
+  ]
+}'
+```
+
+**Concurrency / errors.** The base version is optimistic-concurrency: if the
+live body changed since your `docs content get`, the edit is rejected with
+`412 base_version_stale` — re-read to get a fresh token and rebuild your ops.
+Other backend gates surface unchanged: `409 unsupported_doc_type` (target is a
+board/whiteboard), `413 too_many_ops` / `413 op_content_too_large` /
+`413 doc_too_large` (size caps), `400 path_too_deep` or `400 invalid_body`
+(missing base version or malformed shape), and `422` for a bad anchor
+(`anchor_not_found` / `anchor_mismatch`), invalid ops (`invalid_ops`), an
+attachment that is not this doc's (`attachment_not_found`), or content the
+schema rejects (`schema_incompatible`). Whiteboard and board bodies remain
+un-editable through this surface.
+
+## 3. Members & sharing
 
 ```bash
 octo-cli docs members list   <docId>                        # admin
@@ -60,7 +121,7 @@ octo-cli docs forward-grant  <docId> --uid <uid> --role reader
 role if already present. The target uid must be a real Octo user — a miss returns
 `404 user_not_found` and writes no ghost member.
 
-## 3. Comments
+## 4. Comments
 
 Comments are anchored to a text range and live out-of-band from the body.
 
@@ -88,7 +149,7 @@ Anchors are opaque base64-encoded Yjs positions produced by the editor — the
 backend never parses them. A bot that does not have live positions typically only
 posts replies (`--parentId`) or resolves threads.
 
-## 4. Versions (snapshots)
+## 5. Versions (snapshots)
 
 ```bash
 octo-cli docs versions list    <docId> [--kind manual|auto|all] [--cursor <id>] [--limit <n>]
@@ -99,12 +160,13 @@ octo-cli docs versions delete  <docId> <versionId>                       # admin
 octo-cli docs versions restore <docId> <versionId>                       # admin
 ```
 
-`versions state` is the sanctioned way to read historical content: it returns the
-snapshot decoded to ProseMirror JSON (`{doc, sheetCells, sheetDims, ...}`). It is a
-preview of a *past* version, not the live document, and is not writable. `restore`
-is non-destructive and records a safety snapshot first, so it is itself undoable.
+`versions state` reads *historical* content: it returns a past snapshot decoded
+to ProseMirror JSON (`{doc, sheetCells, sheetDims, ...}`), is a preview of that
+version rather than the live document, and is not writable. To read the **live**
+body instead, use `docs content get` (§2). `restore` is non-destructive and
+records a safety snapshot first, so it is itself undoable.
 
-## 5. Attachments (metadata only)
+## 6. Attachments (metadata only)
 
 The docs backend is **presign-only**: the CLI never streams the binary. Uploading
 is a two-step flow — presign to register the row and get a signed PUT URL, then PUT
@@ -147,13 +209,17 @@ so `--page-all` is intentionally not offered on them:
 
 ## Not in this version
 
-`docs attachments upload` (binary helper), invites, access-requests, link-card,
-and any live-content/body editing are out of scope here.
+`docs attachments upload` (binary helper), invites, access-requests, and
+link-card are out of scope here. Body editing is limited to `doc_type: doc`
+incremental block ops (§2) — whiteboard/board bodies and the document outline
+are not editable through the CLI.
 
 ## Schema lookup
 
 ```bash
 octo-cli schema docs.create
+octo-cli schema docs.content.get
+octo-cli schema docs.content.edit
 octo-cli schema docs.members.set
 octo-cli schema docs.comments.add
 octo-cli schema docs.attachments.presign

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: octo-docs
+version: 0.1.0
+description: Docs domain — create and govern documents, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Live body/outline editing is NOT available over the CLI. Load after octo-shared.
+metadata:
+  requires:
+    bins: ["octo-cli"]
+    skills: ["octo-shared"]
+---
+
+# octo-docs — documents, members, comments, versions, attachments
+
+> **Live document content editing is NOT available from the CLI.** A document's
+> body and outline live in a Yjs (Hocuspocus) websocket session, not in any REST
+> endpoint. This skill drives everything *around* the content — metadata,
+> members, sharing, comments, versions, and attachment references — but it cannot
+> read or write the live body. Creating a doc makes an **empty** document; you
+> cannot seed or edit its text here. To inspect content, take a snapshot
+> (`docs versions create`) and read it back with `docs versions state`, which
+> returns a **read-only** decoded preview of that snapshot.
+
+All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
+
+## Auth & space
+
+- Authenticate with a bot token via a stored profile (`--profile` / `--bot-id`)
+  or `OCTO_BOT_TOKEN`; both `app_*` and `bf_*` tokens work. Confirm with
+  `octo-cli config show`.
+- **Do not pass a space flag for docs.** The bot mount resolves the space
+  server-side from the token and deliberately ignores any client-supplied space
+  header (anti-spoof). Role enforcement (reader / writer / admin) also happens
+  server-side, so the CLI surfaces the backend's `403`/`404` envelopes unchanged.
+
+## 1. Document lifecycle
+
+```bash
+# Create an empty doc (caller becomes owner/admin). Body content is NOT set here.
+octo-cli docs create [--title "Runbook"] [--folderId f_123] [--docType doc]
+
+# List docs you own or are a member of. Page-based (see the pagination note below).
+octo-cli docs list [--folderId f_123] [--page 1] [--pageSize 20] [--sort updatedAt:desc]
+
+octo-cli docs get    <docId>                 # metadata + your role
+octo-cli docs rename <docId> --title "New title"
+octo-cli docs delete <docId>                 # soft delete (admin)
+```
+
+## 2. Members & sharing
+
+```bash
+octo-cli docs members list   <docId>                        # admin
+octo-cli docs members set    <docId> --uid <uid> --role writer   # add/upsert; role: reader|writer|admin
+octo-cli docs members remove <docId> <uid>                  # admin; owner cannot be removed
+
+# Grant-only forward access (never downgrades). Only reader|writer are grantable.
+octo-cli docs forward-grant  <docId> --uid <uid> --role reader
+```
+
+`docs members set` is a PUT-upsert: it adds the member if absent or changes the
+role if already present. The target uid must be a real Octo user — a miss returns
+`404 user_not_found` and writes no ghost member.
+
+## 3. Comments
+
+Comments are anchored to a text range and live out-of-band from the body.
+
+```bash
+# List thread roots + replies. --includeResolved 1 also returns resolved threads.
+octo-cli docs comments list <docId> [--includeResolved 1] [--cursor <id>] [--limit 50]
+
+# Root comment: requires both anchors (opaque base64 Yjs positions).
+octo-cli docs comments add <docId> \
+  --body "Please clarify this" \
+  --anchorStart <base64> --anchorEnd <base64> [--anchorText "the quoted span"]
+
+# Reply to a thread root: set --parentId, omit anchors.
+octo-cli docs comments add <docId> --body "Agreed" --parentId <rootId>
+
+# Edit your own comment's text, OR resolve/reopen a thread root (pass one).
+octo-cli docs comments edit   <docId> <id> --body "edited text"
+octo-cli docs comments edit   <docId> <id> --resolved true      # writer; false reopens
+
+octo-cli docs comments delete <docId> <id>          # soft delete (author)
+octo-cli docs comments delete <docId> <id> --hard 1 # hard delete (admin)
+```
+
+Anchors are opaque base64-encoded Yjs positions produced by the editor — the
+backend never parses them. A bot that does not have live positions typically only
+posts replies (`--parentId`) or resolves threads.
+
+## 4. Versions (snapshots)
+
+```bash
+octo-cli docs versions list    <docId> [--kind manual|auto|all] [--cursor <id>] [--limit <n>]
+octo-cli docs versions create  <docId> [--label "before restructure"]   # writer
+octo-cli docs versions state   <docId> <versionId>   # read-only decoded preview (reader)
+octo-cli docs versions rename  <docId> <versionId> --label "v2"          # writer
+octo-cli docs versions delete  <docId> <versionId>                       # admin
+octo-cli docs versions restore <docId> <versionId>                       # admin
+```
+
+`versions state` is the sanctioned way to read historical content: it returns the
+snapshot decoded to ProseMirror JSON (`{doc, sheetCells, sheetDims, ...}`). It is a
+preview of a *past* version, not the live document, and is not writable. `restore`
+is non-destructive and records a safety snapshot first, so it is itself undoable.
+
+## 5. Attachments (metadata only)
+
+The docs backend is **presign-only**: the CLI never streams the binary. Uploading
+is a two-step flow — presign to register the row and get a signed PUT URL, then PUT
+the bytes yourself directly to object storage.
+
+```bash
+# Step 1: register + get a presigned PUT target.
+octo-cli docs attachments presign <docId> \
+  --fileName report.pdf --mime application/pdf --sizeBytes 20481
+
+# The response contains: attachId, uploadUrl, headers{...}, expiresInSec, ...
+# Step 2: upload the bytes yourself (NOT through octo-cli — the URL is a
+# pre-authorized object-store URL that must not carry the bot Authorization header).
+curl -X PUT --upload-file report.pdf \
+  -H "Content-Type: application/pdf" \
+  "<uploadUrl>"
+# Add every header returned under "headers" to the PUT exactly as given.
+
+# Read back a single attachment's signed download URL, or resolve many at once.
+octo-cli docs attachments get     <docId> <attachId>
+octo-cli docs attachments resolve <docId> --attachIds a1 --attachIds a2
+```
+
+> There is no `docs attachments upload` command in this version — the raw PUT
+> cannot go through `octo-cli api` either, because that path always prepends
+> `OCTO_API_BASE_URL` and attaches the bot bearer token, both wrong for a
+> presigned object-store URL. Do the PUT with `curl` (or any HTTP client) as
+> shown above.
+
+## Pagination note
+
+The docs list endpoints do **not** use the shared `{data, pagination}` envelope,
+so `--page-all` is intentionally not offered on them:
+
+- `docs list` is **page-based** — response is `{total, items}`. Walk it with
+  `--page` / `--pageSize`.
+- `docs comments list` and `docs versions list` are **cursor-based** — response is
+  `{items, nextCursor}`. Pass the returned `nextCursor` back via `--cursor` to get
+  the next page; stop when `nextCursor` is null.
+
+## Not in this version
+
+`docs attachments upload` (binary helper), invites, access-requests, link-card,
+and any live-content/body editing are out of scope here.
+
+## Schema lookup
+
+```bash
+octo-cli schema docs.create
+octo-cli schema docs.members.set
+octo-cli schema docs.comments.add
+octo-cli schema docs.attachments.presign
+```

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -1,0 +1,41 @@
+package skills
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOctoDocsSkillEmbedded confirms the octo-docs SKILL.md is embedded and
+// discoverable: it must ship under the */SKILL.md glob, carry the expected
+// frontmatter name, stay enabled (no `disabled: true`, so `octo-cli skills`
+// lists it), and lead with the live-content-editing limitation.
+func TestOctoDocsSkillEmbedded(t *testing.T) {
+	b, err := FS.ReadFile("octo-docs/SKILL.md")
+	if err != nil {
+		t.Fatalf("octo-docs/SKILL.md not embedded: %v", err)
+	}
+	content := string(b)
+
+	if !strings.Contains(content, "name: octo-docs") {
+		t.Error("frontmatter missing `name: octo-docs`")
+	}
+
+	// Discoverability: the skills command withholds `disabled: true` skills, so
+	// the frontmatter must NOT disable this one.
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == "disabled: true" {
+			t.Error("octo-docs must stay enabled to be discoverable via `octo-cli skills`")
+		}
+	}
+
+	// The content-editing limitation must appear near the top (before the first
+	// command section) so a reader hits it first.
+	idx := strings.Index(content, "## 1.")
+	head := content
+	if idx > 0 {
+		head = content[:idx]
+	}
+	if !strings.Contains(head, "NOT available") {
+		t.Error("skill must lead with the 'live content editing is NOT available' limitation")
+	}
+}

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -8,7 +8,7 @@ import (
 // TestOctoDocsSkillEmbedded confirms the octo-docs SKILL.md is embedded and
 // discoverable: it must ship under the */SKILL.md glob, carry the expected
 // frontmatter name, stay enabled (no `disabled: true`, so `octo-cli skills`
-// lists it), and lead with the live-content-editing limitation.
+// lists it), and lead with the current body-editing capability + its limits.
 func TestOctoDocsSkillEmbedded(t *testing.T) {
 	b, err := FS.ReadFile("octo-docs/SKILL.md")
 	if err != nil {
@@ -28,14 +28,21 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 		}
 	}
 
-	// The content-editing limitation must appear near the top (before the first
-	// command section) so a reader hits it first.
+	// The body-editing state must appear near the top (before the first command
+	// section) so a reader hits it first: body editing is now available for
+	// doc_type doc, and the whiteboard/board caveat is stated up front.
 	idx := strings.Index(content, "## 1.")
 	head := content
 	if idx > 0 {
 		head = content[:idx]
 	}
-	if !strings.Contains(head, "NOT available") {
-		t.Error("skill must lead with the 'live content editing is NOT available' limitation")
+	if !strings.Contains(head, "docs content get") || !strings.Contains(head, "docs content edit") {
+		t.Error("skill must lead with the live-body read/edit commands (docs content get / edit)")
+	}
+	if !strings.Contains(head, "doc_type") {
+		t.Error("skill must state up front that body editing is limited to doc_type doc")
+	}
+	if !strings.Contains(strings.ToLower(head), "whiteboard") {
+		t.Error("skill must keep the up-front note that whiteboard/board bodies are not editable")
 	}
 }


### PR DESCRIPTION
## What

Adds a spec-driven `docs` service and an `octo-docs` skill so the merged bot docs API (the surface under `/v1/bot/docs`) is drivable from the CLI. No hand-written command code — the subtree auto-generates from the dotted operationIds in the embedded spec. This includes the doc-body content endpoints: reading a document's live body and applying incremental block-op edits.

## Scope

24 operations across:

- **lifecycle** — `create`, `list`, `get`, `rename`, `delete`
- **body content** — `content get` (read live body + base version), `content edit` (incremental block-op edit under an If-Match base-version guard)
- **members & sharing** — `members list|set|remove`, `forward-grant`
- **comments** — `comments list|add|edit|delete`
- **versions** — `versions list|create|state|rename|delete|restore`
- **attachments (metadata only)** — `attachments presign|get|resolve`

## Doc-body content editing

`docs.content.get` / `docs.content.edit` map to `GET` / `PATCH /v1/bot/docs/{docId}/content`, verified against `octo-docs-backend@main` (`src/api/routes/docContent.ts`, `src/collab/docBodyEdit.ts`, `src/api/services/editDocBody.ts`):

- `content get` (reader) returns `{ docId, doc, schemaVersion, baseVersion }` — the live ProseMirror body plus the base-version token that pins the read.
- `content edit` (writer) applies a batch of `insert`/`replace`/`delete` block ops (the `DocEditOp` union), addressed by block path, under a mandatory optimistic-concurrency guard. The ops batch is passed through the generic `--data` escape hatch; the base version is passed via `--base-version` and sent as the `If-Match` header. A stale token is rejected with `412 base_version_stale`. Only `doc_type: doc` is accepted (whiteboard/board return `409 unsupported_doc_type`).

### Spec-declared header parameters (general engine feature)

Rather than a docs-only `If-Match` carve-out, the request engine now binds any spec parameter declared with `"in": "header"` to a CLI flag and emits it as a per-request header (the transport already supported `Request.Headers`). An optional `x-octo-flag` alias on a parameter lets an awkward wire name like `If-Match` surface as a clean first-class flag (`--base-version`):

- `loader.go` reads `x-octo-flag` into `ParamInfo.FlagName`.
- `flags.go` `registerHeaderFlags` binds `"in":"header"` params; it runs before body-flag registration, and the body-flag collision guard now excludes header-flag names so an alias can't be shadowed by a same-named body field.
- `run.go` emits only the header flags the user set onto `req.Headers`.

`docs` keeps `x-octo-space-header: false`, so `X-Space-Id` stays suppressed on these endpoints too.

## Files

- `internal/registry/specs/docs.json` — the docs service spec (`x-octo-service: docs`, `x-octo-base-url: OCTO_API_BASE_URL`, `x-octo-space-header: false`), now including the two content ops and the `If-Match` header param.
- `internal/registry/loader.go` — parse `x-octo-flag` into `ParamInfo.FlagName`.
- `cmd/service/flags.go`, `service.go`, `run.go` — spec-declared header-flag support.
- `skills/octo-docs/SKILL.md` — agent-facing guide, now leading with the body read/incremental-edit capability + a worked read-then-edit example.
- `cmd/service/docs_test.go`, `skills/skills_test.go`, `internal/registry/loader_test.go` — tests (see below).
- `CLAUDE.md` — updated the domain count, command tree, and skill list.

## Verification against the backend

Every method + path was checked against `octo-docs-backend@main` (bot mount in `src/api/app.ts`, routers in `src/api/routes/*`). Corrections applied vs. the original design sketch:

- `docs list` is **page-based** (`page`/`pageSize`/`sort`/`folderId`, response `{total, items}`), not cursor-based.
- `versions create`/`rename` bodies use `label` (not `title`).
- `forward-grant` role is `reader|writer` only; `members set` is `reader|writer|admin`.
- `attachments resolve` body is `{attachIds}` (string array).

## Notes / deliberate omissions

- **No `--page-all` on the list ops.** None of the docs list endpoints use the shared `{data, pagination}` envelope the pagination engine walks (`docs list` → `{total, items}`; `comments`/`versions` lists → `{items, nextCursor}`), so no `x-octo-pagination` is declared and the engine is not hacked. Callers page with `--page`/`--pageSize` or `--cursor`. This is documented in the skill.
- **Attachments are presign-only.** The CLI exposes the metadata ops; the raw PUT to object storage is done by the client (the presigned URL must not carry the bot `Authorization` header). The skill documents the two-step flow. A binary upload helper is deliberately out of scope.
- **Body editing is `doc_type: doc` only.** Whiteboard/board bodies are a different Y.Doc shape and are not editable through this surface; the document *outline* still lives only in the Yjs session and is not a REST surface. The skill states both up front. `versions state` remains the read-only preview of a *past* snapshot.
- Invites, access-requests, and link-card are out of scope for this change.
- **Enable/withhold:** shipped enabled. If a target environment has not yet deployed docs-backend / routed `/v1/bot/docs`, the withhold levers are available (set `x-octo-disabled: true` on the spec and `disabled: true` in the skill frontmatter, same pattern as `matter`).

## Tests

`go build ./...`, `go vet ./...`, and `go test ./...` all pass locally. New tests assert representative ops hit the right method/path/body, path args land in the URL, query flags land in the query string, no `X-Space-Id` is sent for docs, and a registry-shape check maps every `docs.*` operationId to its expected command path. For the content ops specifically: `content get` surfaces the `baseVersion` through the envelope, `content edit` sends the ops batch as a JSON array and the base version as the `If-Match` header (not duplicated into the body), `--base-version` is required (fails before any HTTP call when omitted), and the `If-Match`/`x-octo-flag` spec→flag wiring is pinned at the loader level.
