### PR TITLE
docs comments add: resolve anchors from --anchorText

### DIFF
--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -345,6 +345,73 @@ func TestDocsCommentsAdd_ReplyBody(t *testing.T) {
 	}
 }
 
+// TestDocsCommentsAdd_RootAnchorText checks a bot root comment carries the
+// anchorText resolution inputs {body, anchorText, blockPath, occurrence} in the
+// body, with occurrence promoted to a JSON number.
+func TestDocsCommentsAdd_RootAnchorText(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(201)
+		_, _ = w.Write([]byte(`{"id":7}`))
+	})
+	root.SetArgs([]string{
+		"docs", "comments", "add", "d1",
+		"--body", "please clarify",
+		"--anchorText", "the quoted span",
+		"--blockPath", "0,2",
+		"--occurrence", "2",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v1/bot/docs/d1/comments" {
+		t.Errorf("got %s %s, want POST /v1/bot/docs/d1/comments", gotMethod, gotPath)
+	}
+	if gotBody["body"] != "please clarify" {
+		t.Errorf("body = %v", gotBody["body"])
+	}
+	if gotBody["anchorText"] != "the quoted span" {
+		t.Errorf("anchorText = %v", gotBody["anchorText"])
+	}
+	if gotBody["blockPath"] != "0,2" {
+		t.Errorf("blockPath = %v", gotBody["blockPath"])
+	}
+	// Promoted integer flag must serialize as a JSON number.
+	if occ, ok := gotBody["occurrence"].(float64); !ok || occ != 2 {
+		t.Errorf("occurrence = %v (%T), want 2", gotBody["occurrence"], gotBody["occurrence"])
+	}
+	// No anchorStart/anchorEnd on the text-resolution path.
+	if _, ok := gotBody["anchorStart"]; ok {
+		t.Errorf("anchorStart should be absent, got %v", gotBody["anchorStart"])
+	}
+}
+
+// TestDocsCommentsAdd_RootLegacyAnchors checks the legacy explicit-anchor path
+// still carries {anchorStart, anchorEnd} unchanged.
+func TestDocsCommentsAdd_RootLegacyAnchors(t *testing.T) {
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(201)
+		_, _ = w.Write([]byte(`{"id":9}`))
+	})
+	root.SetArgs([]string{
+		"docs", "comments", "add", "d1",
+		"--body", "note",
+		"--anchorStart", "AA==",
+		"--anchorEnd", "Ag==",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotBody["anchorStart"] != "AA==" || gotBody["anchorEnd"] != "Ag==" {
+		t.Errorf("legacy anchors = start:%v end:%v", gotBody["anchorStart"], gotBody["anchorEnd"])
+	}
+}
+
 // TestDocsCommentsDelete_HardQuery checks the hard-delete query flag and the two
 // path args.
 func TestDocsCommentsDelete_HardQuery(t *testing.T) {

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -375,7 +375,7 @@
       "post": {
         "operationId": "docs.comments.add",
         "summary": "Add a root comment (anchored) or a reply (needs reader)",
-        "description": "Root comments require anchorStart and anchorEnd (opaque base64 Yjs positions). A reply sets parentId and omits anchors. Anchors are complex/base64 values — pass them via the flags below or --data.",
+        "description": "A reply sets parentId and omits anchors. A root comment needs an anchor: either the opaque base64 Yjs positions anchorStart/anchorEnd (from a live editor selection), or anchorText — the selected text — which the backend resolves against the document. When anchorText matches more than one place the request fails with 422 ambiguous_anchor; narrow it with blockPath (the block's child-index path, e.g. 0,2) and/or occurrence (1-based match index).",
         "x-octo-risk": "write",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
@@ -390,9 +390,11 @@
                 "properties": {
                   "body": { "type": "string", "description": "comment text" },
                   "parentId": { "type": "integer", "description": "thread root id to reply to (omit for a root comment)" },
-                  "anchorStart": { "type": "string", "description": "root only: base64-encoded Yjs start position" },
-                  "anchorEnd": { "type": "string", "description": "root only: base64-encoded Yjs end position" },
-                  "anchorText": { "type": "string", "description": "root only: the anchored text snippet (optional)" }
+                  "anchorStart": { "type": "string", "description": "root only: base64-encoded Yjs start position (from a live editor selection)" },
+                  "anchorEnd": { "type": "string", "description": "root only: base64-encoded Yjs end position (from a live editor selection)" },
+                  "anchorText": { "type": "string", "description": "root only: the exact selected text; the backend resolves it to an anchor. Use instead of anchorStart/anchorEnd when you have no live editor positions (e.g. a bot)" },
+                  "blockPath": { "type": "string", "description": "root only: disambiguate anchorText by block, as a comma-separated child-index path from the doc root (e.g. 0,2)" },
+                  "occurrence": { "type": "integer", "description": "root only: disambiguate anchorText by picking the Nth match (1-based) among the remaining candidates" }
                 }
               }
             }

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -129,10 +129,19 @@ Comments are anchored to a text range and live out-of-band from the body.
 # List thread roots + replies. --includeResolved 1 also returns resolved threads.
 octo-cli docs comments list <docId> [--includeResolved 1] [--cursor <id>] [--limit 50]
 
-# Root comment: requires both anchors (opaque base64 Yjs positions).
+# Root comment: needs an anchor. With a live editor selection, pass the opaque
+# base64 Yjs positions. Without one (a bot), pass --anchorText and the backend
+# resolves it to an anchor.
 octo-cli docs comments add <docId> \
   --body "Please clarify this" \
   --anchorStart <base64> --anchorEnd <base64> [--anchorText "the quoted span"]
+
+# Bot root comment (no live positions): anchor by text. Disambiguate a text that
+# appears more than once with --blockPath (comma-separated child-index path) and
+# --occurrence (1-based match index); an ambiguous match returns 422.
+octo-cli docs comments add <docId> \
+  --body "Please clarify this" --anchorText "the quoted span" \
+  [--blockPath "0,2"] [--occurrence 2]
 
 # Reply to a thread root: set --parentId, omit anchors.
 octo-cli docs comments add <docId> --body "Agreed" --parentId <rootId>
@@ -146,8 +155,12 @@ octo-cli docs comments delete <docId> <id> --hard 1 # hard delete (admin)
 ```
 
 Anchors are opaque base64-encoded Yjs positions produced by the editor — the
-backend never parses them. A bot that does not have live positions typically only
-posts replies (`--parentId`) or resolves threads.
+backend never parses base64 anchors. A bot that has no live editor selection can
+still start an anchored thread with `--anchorText`: the backend locates that text
+in the stored document and computes the anchor. When the text occurs more than
+once the request fails loudly with `422 ambiguous_anchor` (never a silent guess)
+— narrow it with `--blockPath` and/or `--occurrence`. Text that is not found
+returns `422 anchor_text_not_found`.
 
 ## 5. Versions (snapshots)
 


### PR DESCRIPTION
## Summary

Bots cannot currently create a **root** (anchored) comment: `docs comments add` needs `anchorStart` / `anchorEnd` (opaque base64 Yjs positions) that only a live editor selection produces. This promotes the existing descriptive `--anchorText` flag to a real request-body input and adds `--blockPath` / `--occurrence`, so a bot can anchor a comment by text and let the backend resolve the position (Option A from #70).

## What changed

`docs comments add` is metadata-driven, so this is a spec change in `internal/registry/specs/docs.json`:

- `anchorText` — promoted from a descriptive-only field to a real input the backend resolves against the stored document.
- `blockPath` (string, comma-separated child-index path, e.g. `0,2`) and `occurrence` (integer, 1-based) — new, to disambiguate when the text appears more than once.
- Refreshed the operation description and the `--anchorStart` / `--anchorEnd` help to distinguish the live-selection path from the text-resolution path.

```
octo-cli docs comments add d_xxx --body "please clarify" --anchorText "the quoted span"
# disambiguate a repeated span:
octo-cli docs comments add d_xxx --body "…" --anchorText "x" --blockPath "0,2" --occurrence 2
```

The legacy `--anchorStart` / `--anchorEnd` path is unchanged.

## Tests / docs

- `cmd/service/docs_test.go`: added coverage that the `anchorText` body (with `blockPath` string + `occurrence` as a JSON number) and the legacy explicit-anchor body reach the request body correctly.
- `skills/octo-docs/SKILL.md`: documented the bot text-anchor flow and the fail-loud `422 ambiguous_anchor` / `422 anchor_text_not_found` responses.
- `make ci` equivalent green: `gofmt`, `go vet`, `go build`, `go test ./... -count=1`.

## Notes

- Paired with the octo-docs-backend PR that implements the server-side `anchorText` resolver and the 422 ambiguity contract.
- Draft: opened to carry review before promotion.

Relates to #70
