### PR TITLE
docs: add scene read/write operations (docs.scene.get/edit) + versions.state board schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (8 domains, 71 operations / 74 commands incl. 3 matter transition aliases)
+## Command Structure (8 domains, 75 operations / 78 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -47,6 +47,9 @@ octo-cli file      upload | download | credentials | presigned
 octo-cli bot       register | set-commands | user-info | space-members | typing | heartbeat
 octo-cli event     list | ack
 octo-cli docs      create | list | get | rename | delete | forward-grant
+               content  get|edit
+               sheet    get|edit
+               scene    get|edit
                members  list|set|remove
                comments list|add|edit|delete
                versions list|create|state|rename|delete|restore

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 73 operations
+octo-cli is **metadata-driven**. The entire command tree — 75 operations
 across 8 domains — is auto-registered at startup from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.
@@ -38,7 +38,7 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `docs`    | 26  | Documents & spreadsheets — lifecycle, body content, sheet cells (paged read), members, comments, versions, attachments |
+| `docs`    | 28  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
@@ -130,6 +130,11 @@ octo-cli docs sheet get sheet-9                      # whole sheet + base versio
 octo-cli docs sheet get sheet-9 --limit 500          # page a large sheet; follow --cursor <nextCursor>
 octo-cli docs sheet edit sheet-9 --base-version "<token>" \
   --data '{"cells":{"default!0:0":{"v":"hi"},"default!1:0":null}}'
+
+# Whiteboards — read the live scene + base version, then upsert/delete elements under If-Match.
+octo-cli docs scene get board-7                       # elements (z-order) + files + base version token
+octo-cli docs scene edit board-7 --base-version "<token>" \
+  --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
 
 # Discover the API — fully offline, specs are embedded.
 octo-cli schema --list              # all operations across all domains

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -36,6 +36,7 @@ func TestDocs_TreeShape(t *testing.T) {
 	groups := map[string][]string{
 		"content":     {"get", "edit"},
 		"sheet":       {"get", "edit"},
+		"scene":       {"get", "edit"},
 		"members":     {"list", "set", "remove"},
 		"comments":    {"list", "add", "edit", "delete"},
 		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
@@ -73,6 +74,8 @@ func TestDocs_RegistryShape(t *testing.T) {
 		"docs.content.edit":        {"PATCH", "/v1/bot/docs/{docId}/content"},
 		"docs.sheet.get":           {"GET", "/v1/bot/docs/{docId}/sheet"},
 		"docs.sheet.edit":          {"PATCH", "/v1/bot/docs/{docId}/sheet"},
+		"docs.scene.get":           {"GET", "/v1/bot/docs/{docId}/scene"},
+		"docs.scene.edit":          {"PATCH", "/v1/bot/docs/{docId}/scene"},
 		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
 		"docs.members.set":         {"PUT", "/v1/bot/docs/{docId}/members"},
 		"docs.members.remove":      {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
@@ -700,6 +703,100 @@ func TestDocsSheetEdit_RequiresBaseVersion(t *testing.T) {
 		called = true
 	})
 	root.SetArgs([]string{"docs", "sheet", "edit", "d1", "--data", `{"cells":{}}`})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error when --base-version is omitted")
+	}
+	if called {
+		t.Error("server must not be called when required --base-version is missing")
+	}
+}
+
+// TestDocsSceneGet_ReadsSceneAndBaseVersion checks docs.scene.get hits
+// GET /v1/bot/docs/{docId}/scene (reader), sends no body, and surfaces the
+// backend's {elements, files, baseVersion, schemaVersion} response through the
+// success envelope so the caller can capture the base-version token for a
+// follow-up edit.
+func TestDocsSceneGet_ReadsSceneAndBaseVersion(t *testing.T) {
+	var gotMethod, gotPath string
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"d1","elements":[{"id":"e1","type":"rectangle","version":3}],"files":{},"schemaVersion":1,"baseVersion":"BV_ABC=="}`))
+	})
+	root.SetArgs([]string{"docs", "scene", "get", "d1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/v1/bot/docs/d1/scene" {
+		t.Errorf("got %s %s, want GET /v1/bot/docs/d1/scene", gotMethod, gotPath)
+	}
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			BaseVersion string `json:"baseVersion"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v -- out=%s", err, tf.Out.String())
+	}
+	if !env.OK || env.Data.BaseVersion != "BV_ABC==" {
+		t.Errorf("expected baseVersion BV_ABC== in envelope, got %+v", env)
+	}
+}
+
+// TestDocsSceneEdit_SendsBatchAndIfMatch checks docs.scene.edit hits
+// PATCH /v1/bot/docs/{docId}/scene, carries the element upsert/delete batch
+// (passed via the generic --data escape hatch) in the body, and sends the
+// base-version token as the If-Match header — the spec-declared header
+// capability wiring --base-version to If-Match, not a body/query field.
+func TestDocsSceneEdit_SendsBatchAndIfMatch(t *testing.T) {
+	var gotMethod, gotPath, gotIfMatch string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotIfMatch = r.Header.Get("If-Match")
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","bytes":256,"baseVersion":"BV_NEXT==","newDocVersionSeq":7}`))
+	})
+	batch := `{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}`
+	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--base-version", "BV_ABC==", "--data", batch})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "PATCH" || gotPath != "/v1/bot/docs/d1/scene" {
+		t.Errorf("got %s %s, want PATCH /v1/bot/docs/d1/scene", gotMethod, gotPath)
+	}
+	if gotIfMatch != "BV_ABC==" {
+		t.Errorf("If-Match = %q, want BV_ABC== (base version must reach the wire as the If-Match header)", gotIfMatch)
+	}
+	elems, ok := gotBody["elements"].([]any)
+	if !ok || len(elems) != 1 {
+		t.Fatalf("elements = %v, want a 1-element array", gotBody["elements"])
+	}
+	e0, ok := elems[0].(map[string]any)
+	if !ok || e0["id"] != "e1" {
+		t.Errorf("elements[0] = %v, want the e1 upsert", elems[0])
+	}
+	del, ok := gotBody["deletedElementIds"].([]any)
+	if !ok || len(del) != 1 || del[0] != "e2" {
+		t.Errorf("deletedElementIds = %v, want [e2]", gotBody["deletedElementIds"])
+	}
+	// The base version travels in the header, not the JSON body.
+	if _, present := gotBody["baseVersion"]; present {
+		t.Errorf("baseVersion must not be duplicated into the JSON body; got %v", gotBody["baseVersion"])
+	}
+}
+
+// TestDocsSceneEdit_RequiresBaseVersion confirms --base-version is required:
+// the command fails before any request when the base-version token is missing,
+// mirroring the backend's mandatory optimistic-concurrency guard.
+func TestDocsSceneEdit_RequiresBaseVersion(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--data", `{"elements":[]}`})
 	if err := root.Execute(); err == nil {
 		t.Fatal("expected error when --base-version is omitted")
 	}

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -41,7 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
-		"docs":    26,
+		"docs":    28,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -390,6 +390,97 @@
         }
       }
     },
+    "/v1/bot/docs/{docId}/scene": {
+      "get": {
+        "operationId": "docs.scene.get",
+        "summary": "Read a whiteboard's live scene + its base version (needs reader)",
+        "description": "Reads the LIVE Excalidraw scene of a doc_type 'board' — its `elements` in fractional-index (z-order), the `files` map of image/file refs, and the base-version token that pins the read. Pass that token to `docs scene edit` as --base-version so the optimistic-concurrency guard can prove the scene did not change between read and write. doc / sheet bodies are a different Y.Doc shape and return 409 unsupported_doc_type here; a live scene that decodes to a wrong-kind / corrupt blob returns 409 board_snapshot_invalid.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Live scene + base version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "elements": { "type": "array", "items": { "type": "object" }, "description": "the live Excalidraw elements in fractional-index (z-order); each element is a whiteboard-schema node" },
+                    "files": { "type": "object", "description": "map of fileId -> file ref (e.g. {attachId}) for images/files referenced by the scene" },
+                    "baseVersion": { "type": "string", "description": "opaque base64 base-version token; pass to `docs scene edit --base-version`" },
+                    "schemaVersion": { "type": "integer", "description": "whiteboard schema version the scene was decoded with" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "docs.scene.edit",
+        "summary": "Apply an element upsert/delete batch to a whiteboard scene (needs writer)",
+        "description": "Applies a batch of element upserts and soft-deletes to a doc_type 'board' scene under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs scene get` via --base-version (sent as the If-Match header); the server rejects with 412 base_version_stale if the live scene moved since that read. `elements` are full elements to upsert (CAS: the higher `version` wins), `deletedElementIds` are soft-delete tombstones, and `files` upserts file refs; the batch is a structured object, so pass it as JSON through --data. Only doc_type 'board' is accepted (doc / sheet return 409 unsupported_doc_type). Gates: element count over the max → 413 too_many_elements, a single element too large → 413 element_too_large, whole scene over the cap → 413 doc_too_large, an element failing the whitelist → 422 board_element_invalid, a file ref with no usable attachId → 422 board_file_invalid, missing base version or malformed shape → 400 invalid_body.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "x-octo-flag": "base-version",
+            "schema": { "type": "string" },
+            "description": "base-version token from 'docs scene get' (sent as the If-Match header for optimistic concurrency; required)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "elements": {
+                    "type": "array",
+                    "items": { "type": "object" },
+                    "description": "full Excalidraw elements to upsert; on a key collision the element with the higher `version` (then smaller `versionNonce`) wins the CAS. Pass via --data."
+                  },
+                  "deletedElementIds": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "element ids to soft-delete; each becomes a tombstone with a superseding version so it converges under CAS. Pass via --data."
+                  },
+                  "files": {
+                    "type": "object",
+                    "description": "map of fileId -> file ref (e.g. {\"attachId\":\"…\"}) to upsert for images/files referenced by the scene. Pass via --data."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Edit applied; carries the new base version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "bytes": { "type": "integer", "description": "encoded size of the scene after the edit" },
+                    "baseVersion": { "type": "string", "description": "new base-version token for the next edit" },
+                    "newDocVersionSeq": { "type": "integer", "description": "sequence of the auto safety snapshot taken before the edit" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}/members": {
       "get": {
         "operationId": "docs.members.list",
@@ -646,7 +737,7 @@
       "get": {
         "operationId": "docs.versions.state",
         "summary": "Read a version's decoded content snapshot (read-only preview; needs reader)",
-        "description": "Returns the version decoded to ProseMirror JSON ({doc, sheetCells, sheetDims, schemaVersion, docVersionSeq}). This is a read-only preview of a past snapshot, not the live document, and cannot be written.",
+        "description": "Returns the version decoded to structured content, kind-selected by the doc's doc_type. A document/sheet decodes to ProseMirror JSON ({kind:'document', doc, sheetCells, sheetDims, schemaVersion, docVersionSeq}); a board decodes to an Excalidraw scene ({kind:'board', scene, schemaVersion, docVersionSeq}). This is a read-only preview of a past snapshot, not the live document, and cannot be written.",
         "x-octo-risk": "read",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
@@ -654,15 +745,17 @@
         ],
         "responses": {
           "200": {
-            "description": "Decoded snapshot content",
+            "description": "Decoded snapshot content (document/sheet or board scene, selected by kind)",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "doc": { "type": "object" },
-                    "sheetCells": { "type": "object" },
-                    "sheetDims": { "type": "object" },
+                    "kind": { "type": "string", "enum": ["document", "board"], "description": "which content line was decoded: 'document' (doc/sheet -> doc + sheet maps) or 'board' (whiteboard -> scene)" },
+                    "doc": { "type": "object", "description": "document/sheet only: the snapshot body as ProseMirror document JSON" },
+                    "sheetCells": { "type": "object", "description": "document/sheet only: flat cell map keyed `sheetId!row:col` (empty {} for a text document)" },
+                    "sheetDims": { "type": "object", "description": "document/sheet only: column-width / row-height overrides (empty {} for a text document)" },
+                    "scene": { "type": "object", "description": "board only: the decoded Excalidraw scene ({elements in z-order, files})" },
                     "schemaVersion": { "type": "integer" },
                     "docVersionSeq": { "type": "integer" }
                   }

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: octo-docs
 version: 0.1.0
-description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheet cells (with paged reads for large sheets), members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
+description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheet cells (with paged reads for large sheets), read and batch-edit whiteboard scenes, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
     skills: ["octo-shared"]
 ---
 
-# octo-docs — documents, body content, members, comments, versions, attachments
+# octo-docs — documents, body content, sheet cells, board scenes, members, comments, versions, attachments
 
 > **Live body editing IS available for `doc_type: doc`.** You can read a
 > document's live body with `docs content get` and apply **incremental block-op
@@ -18,11 +18,12 @@ metadata:
 > a base-version token: read to get the token, then edit with that token so the
 > server can prove the body did not change underneath you (a stale token is
 > rejected with `412 base_version_stale`). Only `doc_type: doc` bodies are
-> editable this way; **whiteboard and board bodies are a different Y.Doc shape
-> and are not editable here** (they return `409 unsupported_doc_type`). The
-> document *outline* still lives only in the Yjs session and is not a REST
-> surface. Creating a doc still makes an **empty** document; seed its text with
-> an initial `docs content edit`.
+> editable this way; a **spreadsheet** (`doc_type: sheet`) has its own read/edit
+> surface (§3) and a **whiteboard / board** (`doc_type: board`) has its own scene
+> surface (§4) — both return `409 unsupported_doc_type` from the `content`
+> endpoints. The document *outline* still lives only in the Yjs session and is not
+> a REST surface. Creating a doc still makes an **empty** document; seed its text
+> with an initial `docs content edit`.
 
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 
@@ -157,7 +158,43 @@ Other gates: `409 unsupported_doc_type` (target is a doc/board/whiteboard),
 `422 sheet_snapshot_invalid` (a cell violates the `{v,f,s}` contract or the
 `sheetId!row:col` key shape).
 
-## 4. Members & sharing
+## 4. Whiteboard scenes (read + batch edit)
+
+Available for `doc_type: board` only. A whiteboard stores its Excalidraw scene on
+the Y.Doc — an ordered list of `elements` (in fractional-index / z-order) plus a
+`files` map of image/file refs. Same read-token-then-guarded-write discipline as
+the body and sheet surfaces.
+
+```bash
+# Read the LIVE scene + baseVersion (reader). Response:
+#   { docId, elements: [ <element> ], files: { <fileId>: {attachId} }, schemaVersion, baseVersion }
+octo-cli docs scene get <docId>
+
+# Batch-edit the scene (writer). --base-version is REQUIRED and is sent as the
+# If-Match header; the batch goes through --data as a JSON object.
+#   elements          — full elements to upsert (CAS: higher `version` wins)
+#   deletedElementIds — element ids to soft-delete (tombstone)
+#   files             — file refs to upsert
+octo-cli docs scene edit <docId> --base-version "<token>" \
+  --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
+```
+
+The upsert is element-level: only the ids named in `elements` / `deletedElementIds`
+are touched (the rest of the board is left as-is). On a key collision the element
+with the higher `version` (then smaller `versionNonce`) wins, and a delete is a
+soft-delete tombstone with a superseding version so it converges under CAS.
+
+**Concurrency / errors.** The base version is optimistic-concurrency: if the scene
+changed since your `docs scene get`, an edit is rejected with
+`412 base_version_stale` — re-read for a fresh token. Other gates:
+`409 unsupported_doc_type` (target is a doc/sheet), `409 board_snapshot_invalid`
+(the live scene decodes to a wrong-kind/corrupt blob, on read),
+`413 too_many_elements` / `413 element_too_large` / `413 doc_too_large` (size
+caps), `400 invalid_body` (missing base version or malformed shape),
+`422 board_element_invalid` (an element fails the whitelist), and
+`422 board_file_invalid` (a file ref carries no usable `attachId`).
+
+## 5. Members & sharing
 
 ```bash
 octo-cli docs members list   <docId>                        # admin
@@ -172,7 +209,7 @@ octo-cli docs forward-grant  <docId> --uid <uid> --role reader
 role if already present. The target uid must be a real Octo user — a miss returns
 `404 user_not_found` and writes no ghost member.
 
-## 5. Comments
+## 6. Comments
 
 Comments are anchored to a text range and live out-of-band from the body.
 
@@ -213,7 +250,7 @@ once the request fails loudly with `422 ambiguous_anchor` (never a silent guess)
 — narrow it with `--blockPath` and/or `--occurrence`. Text that is not found
 returns `422 anchor_text_not_found`.
 
-## 6. Versions (snapshots)
+## 7. Versions (snapshots)
 
 ```bash
 octo-cli docs versions list    <docId> [--kind manual|auto|all] [--cursor <id>] [--limit <n>]
@@ -225,12 +262,14 @@ octo-cli docs versions restore <docId> <versionId>                       # admin
 ```
 
 `versions state` reads *historical* content: it returns a past snapshot decoded
-to ProseMirror JSON (`{doc, sheetCells, sheetDims, ...}`), is a preview of that
+by the doc's kind — a document/sheet as `{kind:"document", doc, sheetCells,
+sheetDims, ...}`, a board as `{kind:"board", scene, ...}` — is a preview of that
 version rather than the live document, and is not writable. To read the **live**
-body instead, use `docs content get` (§2). `restore` is non-destructive and
-records a safety snapshot first, so it is itself undoable.
+body instead, use `docs content get` (§2), `docs sheet get` (§3), or
+`docs scene get` (§4). `restore` is non-destructive and records a safety snapshot
+first, so it is itself undoable.
 
-## 7. Attachments (metadata only)
+## 8. Attachments (metadata only)
 
 The docs backend is **presign-only**: the CLI never streams the binary. Uploading
 is a two-step flow — presign to register the row and get a signed PUT URL, then PUT
@@ -275,8 +314,9 @@ so `--page-all` is intentionally not offered on them:
 
 `docs attachments upload` (binary helper), invites, access-requests, and
 link-card are out of scope here. Body editing is limited to `doc_type: doc`
-incremental block ops (§2) — whiteboard/board bodies and the document outline
-are not editable through the CLI.
+incremental block ops (§2), `doc_type: sheet` cell batches (§3), and
+`doc_type: board` scene batches (§4); the document outline is not editable
+through the CLI.
 
 ## Schema lookup
 
@@ -284,6 +324,8 @@ are not editable through the CLI.
 octo-cli schema docs.create
 octo-cli schema docs.content.get
 octo-cli schema docs.content.edit
+octo-cli schema docs.scene.get
+octo-cli schema docs.scene.edit
 octo-cli schema docs.members.set
 octo-cli schema docs.comments.add
 octo-cli schema docs.attachments.presign


### PR DESCRIPTION
## What

Adds the two whiteboard **scene** operations to the docs domain so bots can read and batch-edit a board's Excalidraw scene, closing the gap where octo-docs-backend exposes `GET`/`PATCH /v1/bot/docs/{docId}/scene` but the CLI had no command for it.

- `docs.scene.get` — `GET /v1/bot/docs/{docId}/scene` → `octo-cli docs scene get <docId>`
- `docs.scene.edit` — `PATCH /v1/bot/docs/{docId}/scene` → `octo-cli docs scene edit <docId> --base-version <token> --data <json>`

This is **spec-only** — no Go changes. Both endpoints are standard JSON read/write, so the metadata-driven registry generates the command tree straight from `internal/registry/specs/docs.json`.

## How it mirrors the existing surfaces

`docs scene edit` reuses the exact optimistic-concurrency discipline of `docs.content.edit` / `docs.sheet.edit`:

- `--base-version` is declared as the `If-Match` header via `"x-octo-flag": "base-version"`, so the token reaches the wire as `If-Match`, not a body/query field.
- The `{elements, deletedElementIds, files}` batch is a structured object passed through `--data` (inline JSON / `@file` / `@-`).

```
octo-cli docs scene get board-7
octo-cli docs scene edit board-7 --base-version "<token>" \
  --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
```

Response contract matches the backend: `get` returns `{docId, elements (z-order), files, baseVersion, schemaVersion}`; `edit` returns `{docId, bytes, baseVersion, newDocVersionSeq}`.

## Also in this PR

`docs.versions.state` is kind-selected by the backend — a board version decodes to `{kind:"board", scene, ...}` while a document/sheet decodes to `{kind:"document", doc, sheetCells, sheetDims, ...}` — but the spec only documented the document/sheet shape. This adds the board `scene`/`kind` fields so `octo-cli schema docs.versions.state` introspects the full response. Documentation-only; the actual response is unchanged.

## Tests & docs

- `TestAllDomainOperationCounts`: docs `26 → 28`.
- `TestDocs_TreeShape` / `TestDocs_RegistryShape`: added the `scene` group and the two operation ids (method/path).
- New wire tests mirroring the sheet/content ones: `docs scene get` hits `GET /scene`; `docs scene edit` sends the batch with `If-Match` set and requires `--base-version`.
- Synced `README.md`, `CLAUDE.md`, and `skills/octo-docs/SKILL.md` command trees (the docs subtree in `CLAUDE.md` was also missing `content`/`sheet` — added for completeness).

`go build`, `go vet ./...`, `gofmt`, and `go test ./... -count=1` all clean.

Closes #75

---

_Draft: carries the full diff for review; not for merge until review + tests are confirmed and the PR is marked ready by the maintainer._
