### PR TITLE
feat(docs): add docs.scene.export CLI operation (whiteboard PNG/SVG)

### DIFF
--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -93,6 +93,7 @@ func TestDocs_RegistryShape(t *testing.T) {
 		"docs.attachments.presign": {"POST", "/v1/bot/docs/{docId}/attachments/presign"},
 		"docs.attachments.get":     {"GET", "/v1/bot/docs/{docId}/attachments/{attachId}"},
 		"docs.attachments.resolve": {"POST", "/v1/bot/docs/{docId}/attachments/resolve"},
+		"docs.scene.export":        {"GET", "/v1/bot/docs/{docId}/export"},
 	}
 
 	got := reg.ListOperations("docs")

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -36,7 +36,7 @@ func TestDocs_TreeShape(t *testing.T) {
 	groups := map[string][]string{
 		"content":     {"get", "edit"},
 		"sheet":       {"get", "edit"},
-		"scene":       {"get", "edit"},
+		"scene":       {"get", "edit", "export"},
 		"members":     {"list", "set", "remove"},
 		"comments":    {"list", "add", "edit", "delete"},
 		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
@@ -114,6 +114,52 @@ func TestDocs_RegistryShape(t *testing.T) {
 		if segs[0] != "docs" {
 			t.Errorf("%s: first segment must be the service; got %q", id, segs[0])
 		}
+	}
+}
+
+// TestDocsSceneExport_ImageFormatFlagNoGlobalShadow pins the fix for the
+// `--format` collision: docs.scene.export's `format` query param carries
+// x-octo-flag "image-format", so its CLI flag is --image-format (leaving the
+// global persistent output --format reachable) while the wire param stays
+// ?format=. The leaf must NOT declare a local --format flag.
+func TestDocsSceneExport_ImageFormatFlagNoGlobalShadow(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	docs := findCmd(root, "docs")
+	scene := findCmd(docs, "scene")
+	if scene == nil {
+		t.Fatal("missing docs scene resource group")
+	}
+	export := findCmd(scene, "export")
+	if export == nil {
+		t.Fatal("missing docs scene export leaf")
+	}
+	if export.LocalFlags().Lookup("image-format") == nil {
+		t.Error("docs scene export: expected local --image-format flag")
+	}
+	if export.LocalFlags().Lookup("format") != nil {
+		t.Error("docs scene export: --format must NOT be a local flag (it would shadow the global output --format)")
+	}
+}
+
+// TestDocsSceneExport_ImageFormatMapsToWireFormat drives the command and asserts
+// --image-format lands on the wire as ?format= (the api name is preserved).
+func TestDocsSceneExport_ImageFormatMapsToWireFormat(t *testing.T) {
+	var gotPath, gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		w.Header().Set("Content-Type", "image/svg+xml")
+		_, _ = w.Write([]byte("<svg/>"))
+	})
+	root.SetArgs([]string{"docs", "scene", "export", "abc", "--image-format", "svg"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/v1/bot/docs/abc/export" {
+		t.Errorf("path = %s, want /v1/bot/docs/abc/export", gotPath)
+	}
+	if !strings.Contains(gotQuery, "format=svg") {
+		t.Errorf("query %q missing format=svg", gotQuery)
 	}
 }
 

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -22,6 +22,7 @@ type operationRuntime struct {
 	pageAll     *bool                  // --page-all (nil when no pagination)
 	pageLimit   *int                   // --page-limit
 	filePath    *string                // --file (multipart operations only)
+	outputPath  *string                // --output/-o (binary-response operations only)
 }
 
 type queryFlag struct {

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -222,21 +222,17 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 		if !hasMore || nextCursor == "" {
 			break
 		}
-		// Prepare next request. Clone Query so we don't mutate the previous.
+		// Prepare next request. Copy the whole struct so no field is silently
+		// dropped (RawBody/ContentType/BinaryResponse/OutputPath), then clone
+		// Query and set the next cursor so we don't mutate the previous page's.
 		nextQ := url.Values{}
 		for k, vs := range req.Query {
 			nextQ[k] = append([]string(nil), vs...)
 		}
 		nextQ.Set(cursorParam, nextCursor)
-		req = client.Request{
-			Service:             req.Service,
-			Method:              req.Method,
-			Path:                req.Path,
-			Query:               nextQ,
-			Body:                req.Body,
-			Headers:             req.Headers,
-			SuppressSpaceHeader: req.SuppressSpaceHeader,
-		}
+		next := req
+		next.Query = nextQ
+		req = next
 	}
 
 	out, err := json.Marshal(merged)

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -53,6 +53,11 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 		// behaviour of sending the header when the credential has a space.
 		SuppressSpaceHeader: d.SpaceHeaderSet && !d.SpaceHeader,
 	}
+	// Binary-response ops may carry an --output/-o destination; when set, the
+	// client writes the 2xx body to that path instead of only describing it.
+	if rt.outputPath != nil {
+		req.OutputPath = *rt.outputPath
+	}
 	if d.Multipart {
 		raw, ct, err := buildMultipartBody(cobraCmd, rt)
 		if err != nil {

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -190,6 +190,23 @@ func emitOnce(ctx context.Context, f *cmdutil.Factory, req *client.Request) erro
 // items — the caller gets a single envelope with no _pagination block
 // (architecture §4.4).
 func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime, firstReq *client.Request) error {
+	// Pagination and binary output-to-disk are mutually exclusive. The loop
+	// reuses OutputPath for every page, so an operation that was both paginated
+	// AND declared an inline binary body would write each page to the same file,
+	// leaving only the last page's bytes. No spec op declares both today, so this
+	// never fires in practice; it is a fail-loud guard against a future spec that
+	// wires the two together and would otherwise silently corrupt --output.
+	if firstReq.OutputPath != "" {
+		err := output.ErrWithHint(
+			"internal",
+			"PAGINATION_OUTPUT_CONFLICT",
+			"operation is paginated and also writes a binary body to --output; these are mutually exclusive",
+			"operation-spec bug: an op with x-octo-pagination must not also declare an inline 2xx binary body",
+		)
+		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+		return err
+	}
+
 	cli, err := f.Client()
 	if err != nil {
 		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -147,7 +147,7 @@ func buildOperationCmd(f *cmdutil.Factory, d *registry.OperationDetail, verb str
 	}
 
 	// Binary-response operations accept --output/-o to WRITE a 2xx binary body
-	// to disk (e.g. docs.scene.export --format png -o board.png). Without it the
+	// to disk (e.g. docs.scene.export --image-format png -o board.png). Without it the
 	// command only describes the body (status/content_type/size), preserving the
 	// historical behaviour of redirect-style binary ops such as file.download.
 	if d.BinaryResponse {

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -146,6 +146,16 @@ func buildOperationCmd(f *cmdutil.Factory, d *registry.OperationDetail, verb str
 		rt.pageLimit = &pageLimit
 	}
 
+	// Binary-response operations accept --output/-o to WRITE a 2xx binary body
+	// to disk (e.g. docs.scene.export --format png -o board.png). Without it the
+	// command only describes the body (status/content_type/size), preserving the
+	// historical behaviour of redirect-style binary ops such as file.download.
+	if d.BinaryResponse {
+		var outputPath string
+		cmd.Flags().StringVarP(&outputPath, "output", "o", "", "write the binary response body to this file path")
+		rt.outputPath = &outputPath
+	}
+
 	cmd.RunE = func(cobraCmd *cobra.Command, args []string) error {
 		return runOperation(cobraCmd, f, rt, args)
 	}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -146,11 +146,14 @@ func buildOperationCmd(f *cmdutil.Factory, d *registry.OperationDetail, verb str
 		rt.pageLimit = &pageLimit
 	}
 
-	// Binary-response operations accept --output/-o to WRITE a 2xx binary body
-	// to disk (e.g. docs.scene.export --image-format png -o board.png). Without it the
-	// command only describes the body (status/content_type/size), preserving the
-	// historical behaviour of redirect-style binary ops such as file.download.
-	if d.BinaryResponse {
+	// Operations that return a binary body inline on a 2xx success accept
+	// --output/-o to WRITE those bytes to disk (e.g. docs.scene.export
+	// --image-format png -o board.png). Without it the command only describes
+	// the body (status/content_type/size). Redirect-style binary ops such as
+	// file.download (302-only, no consumable body) are deliberately excluded:
+	// registering -o there accepts the flag but never writes a file, a silent
+	// footgun. See registry.OperationDetail.BinaryBody.
+	if d.BinaryBody {
 		var outputPath string
 		cmd.Flags().StringVarP(&outputPath, "output", "o", "", "write the binary response body to this file path")
 		rt.outputPath = &outputPath

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -551,7 +551,59 @@ func TestBuildMultipartBody_MissingFile(t *testing.T) {
 	}
 }
 
-// TestParentCommand_RejectsUnknownSubcommand guards against cobra's default
+// TestFileDownload_NoOutputFlag pins the -o footgun fix: file.download is a
+// 302-only redirect (x-octo-binary-response for Location surfacing, but no
+// consumable body), so the leaf must NOT register --output/-o. Registering it
+// would accept the flag and silently write nothing.
+func TestFileDownload_NoOutputFlag(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+
+	download := findCmd(findCmd(root, "file"), "download")
+	if download == nil {
+		t.Fatal("file download command not registered")
+	}
+	if download.Flags().Lookup("output") != nil {
+		t.Error("file download: --output must NOT be registered (302-only redirect, -o would silently no-op)")
+	}
+	if download.Flags().ShorthandLookup("o") != nil {
+		t.Error("file download: -o must NOT be registered (302-only redirect, -o would silently no-op)")
+	}
+}
+
+// TestDocsSceneExport_OutputFlagWritesFileToDisk confirms the fix does not harm
+// the W3 export main use case: docs.scene.export delivers a 2xx image body, so
+// it keeps --output/-o and the bytes land on disk.
+func TestDocsSceneExport_OutputFlagWritesFileToDisk(t *testing.T) {
+	wantBytes := []byte("\x89PNG\r\n\x1a\nfake-board")
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(wantBytes)
+	})
+
+	export := findCmd(findCmd(root, "docs"), "scene")
+	export = findCmd(export, "export")
+	if export == nil {
+		t.Fatal("docs scene export command not registered")
+	}
+	if export.Flags().Lookup("output") == nil || export.Flags().ShorthandLookup("o") == nil {
+		t.Fatal("docs scene export: expected --output/-o flag (2xx binary body op)")
+	}
+
+	dst := filepath.Join(t.TempDir(), "board.png")
+	root.SetArgs([]string{"docs", "scene", "export", "abc", "--image-format", "png", "-o", dst})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("read output file: %v", err)
+	}
+	if !bytes.Equal(got, wantBytes) {
+		t.Errorf("written bytes = %q, want %q", got, wantBytes)
+	}
+}
+
 // fallback: a parent command with no RunE silently prints help and exits 0
 // when given an unknown token, which can let automation treat a removed or
 // mistyped command as a success. Regression test for the removal of

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"mime"
@@ -340,6 +341,76 @@ func TestPagination_PageLimitStops(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Errorf("expected 2 calls bounded by --page-limit, got %d", calls)
+	}
+}
+
+// TestRunPaginated_RejectsOutputPathConflict pins the item-2 guard: pagination
+// and binary output-to-disk are mutually exclusive (the page loop reuses the
+// single OutputPath, so it would write every page over the same file). No spec
+// op declares both today, so this cannot be reached through the command tree —
+// it is a fail-loud guard called directly here to prove a future spec wiring
+// the two together is rejected up front rather than silently corrupting output.
+func TestRunPaginated_RejectsOutputPathConflict(t *testing.T) {
+	tf := cmdutil.NewTestFactory()
+	tf.SetConfig(&config.Config{APIBaseURL: "http://example.invalid", Format: "json"})
+
+	dst := filepath.Join(t.TempDir(), "must-not-write.bin")
+	err := runPaginated(context.Background(), tf.Factory, &operationRuntime{}, &client.Request{
+		Method: "GET", Path: "/x", OutputPath: dst,
+	})
+	if err == nil {
+		t.Fatal("expected an error for a paginated op carrying OutputPath, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should explain the conflict, got %q", err.Error())
+	}
+	if _, statErr := os.Stat(dst); statErr == nil {
+		t.Error("guard must reject before any write; output file must not exist")
+	}
+}
+
+// TestDocsSceneExport_DescribeOnlyEnvelope covers the no-`-o` path: without a
+// destination, docs.scene.export must not write anything and the envelope
+// reports the binary body's status / content_type / size (describe-only). This
+// path was only covered indirectly before.
+func TestDocsSceneExport_DescribeOnlyEnvelope(t *testing.T) {
+	payload := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><circle r="5"/></svg>`)
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		_, _ = w.Write(payload)
+	})
+
+	root.SetArgs([]string{"docs", "scene", "export", "abc", "--image-format", "svg"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Status      int    `json:"status"`
+			ContentType string `json:"content_type"`
+			Size        int    `json:"size"`
+			Output      string `json:"output"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v -- out=%s", err, tf.Out.String())
+	}
+	if !env.OK {
+		t.Fatalf("expected ok envelope, got %s", tf.Out.String())
+	}
+	if env.Data.Status != 200 {
+		t.Errorf("status = %d, want 200", env.Data.Status)
+	}
+	if env.Data.ContentType != "image/svg+xml" {
+		t.Errorf("content_type = %q, want image/svg+xml", env.Data.ContentType)
+	}
+	if env.Data.Size != len(payload) {
+		t.Errorf("size = %d, want %d", env.Data.Size, len(payload))
+	}
+	if env.Data.Output != "" {
+		t.Errorf("describe-only envelope must not carry an output path, got %q", env.Data.Output)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,12 @@ type Request struct {
 	// BinaryResponse asks the client to treat 3xx/non-JSON responses as
 	// structured metadata envelopes rather than parsing JSON. See file.download.
 	BinaryResponse bool
+	// OutputPath, when set together with BinaryResponse, makes the client WRITE
+	// a 2xx binary body to that file path (instead of only describing it) and
+	// return an envelope carrying the saved path + size. Empty preserves the
+	// historical describe-only behaviour. A 3xx (redirect-to-URL) response is
+	// never written — its URL is surfaced in the envelope as before.
+	OutputPath string
 	// SuppressSpaceHeader omits the X-Space-Id header even when the active
 	// credential carries a SpaceID. It is set for operations whose spec declares
 	// x-octo-space-header:false (e.g. the docs bot mount resolves the space
@@ -143,11 +150,11 @@ func (c *Client) Do(ctx context.Context, req *Request) ([]byte, error) {
 		return c.renderDryRun(req.Method, u, req.Headers, bodyBytes, req.SuppressSpaceHeader)
 	}
 
-	return c.doWithRetry(ctx, req.Method, u, req.Headers, bodyBytes, contentType, req.BinaryResponse, req.SuppressSpaceHeader)
+	return c.doWithRetry(ctx, req.Method, u, req.Headers, bodyBytes, contentType, req.BinaryResponse, req.OutputPath, req.SuppressSpaceHeader)
 }
 
 // doWithRetry runs the HTTP request, retrying transient errors with backoff.
-func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp, suppressSpaceHeader bool) ([]byte, error) {
+func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool, outputPath string, suppressSpaceHeader bool) ([]byte, error) {
 	maxRetries := defaultMaxRetries
 	if c.options.NoRetry {
 		maxRetries = 0
@@ -171,7 +178,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 			}
 		}
 
-		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binaryResp, suppressSpaceHeader)
+		body, err := c.attempt(ctx, method, urlStr, headers, body, contentType, binaryResp, outputPath, suppressSpaceHeader)
 		if err == nil {
 			return body, nil
 		}
@@ -185,7 +192,7 @@ func (c *Client) doWithRetry(ctx context.Context, method, urlStr string, headers
 }
 
 // attempt executes one HTTP round-trip and interprets the response.
-func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp, suppressSpaceHeader bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
+func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map[string]string, body []byte, contentType string, binaryResp bool, outputPath string, suppressSpaceHeader bool) ([]byte, error) { //nolint:gocyclo // HTTP attempt handles auth, headers, dry-run, binary, retries in one flow
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
@@ -262,6 +269,19 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 				"status":       resp.StatusCode,
 				"content_type": resp.Header.Get("Content-Type"),
 				"size":         len(respBody),
+			}
+			// When the caller asked for a destination, WRITE the bytes to disk
+			// (docs.scene.export --output). A write failure is a hard, non-
+			// retryable error — the request succeeded, so retrying would only
+			// re-download; the problem is local (bad path/permissions).
+			if outputPath != "" {
+				if err := os.WriteFile(outputPath, respBody, 0o644); err != nil {
+					return nil, output.ErrValidation(
+						fmt.Sprintf("write output %q: %v", outputPath, err),
+						"check the path is writable and the directory exists",
+					)
+				}
+				env["output"] = outputPath
 			}
 			return json.Marshal(env)
 		}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -232,6 +233,12 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 	}
 	defer resp.Body.Close() //nolint:errcheck // best-effort close on HTTP response body
 
+	// The whole response body is buffered here. Every downstream branch needs
+	// it fully in memory anyway — JSON parsing, backend-error parsing, and the
+	// binary describe envelope (which reports size = len(body)) all consume the
+	// complete payload. Board PNG/SVG exports are bounded and small, so a size
+	// cap / streaming-to-temp path would add complexity without a real payoff
+	// today; deferred until an operation returns genuinely large bodies.
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, output.ErrNetwork(fmt.Sprintf("read response: %v", err), "")
@@ -274,8 +281,14 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 			// (docs.scene.export --output). A write failure is a hard, non-
 			// retryable error — the request succeeded, so retrying would only
 			// re-download; the problem is local (bad path/permissions).
+			//
+			// The write is atomic: bytes go to a temp file in the destination
+			// directory and are renamed into place only after a fully successful
+			// write. A mid-write failure (disk full, I/O error, cancellation)
+			// therefore never leaves a truncated/empty file, and never clobbers
+			// an existing good copy at outputPath — the rename is all-or-nothing.
 			if outputPath != "" {
-				if err := os.WriteFile(outputPath, respBody, 0o644); err != nil {
+				if err := writeFileAtomic(outputPath, respBody, 0o644); err != nil {
 					return nil, output.ErrValidation(
 						fmt.Sprintf("write output %q: %v", outputPath, err),
 						"check the path is writable and the directory exists",
@@ -298,6 +311,44 @@ func (c *Client) attempt(ctx context.Context, method, urlStr string, headers map
 		return nil, re
 	}
 	return nil, ee
+}
+
+// writeFileAtomic writes data to path atomically: it streams the bytes into a
+// temp file in the same directory, then renames it over path. Because rename
+// within a directory is atomic, path is only ever the old file (untouched) or
+// the fully-written new file — never a partial/truncated result, and an
+// existing good copy is never clobbered when the write fails midway. On any
+// error the temp file is removed so no stray temp files accumulate.
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Remove the temp file unless the rename below hands it off successfully.
+	renamed := false
+	defer func() {
+		if !renamed {
+			_ = os.Remove(tmpName) //nolint:errcheck // best-effort cleanup
+		}
+	}()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close() //nolint:errcheck // already returning the write error
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close() //nolint:errcheck // already returning the chmod error
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	renamed = true
+	return nil
 }
 
 // renderDryRun writes a human-readable request description and returns a

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -447,6 +447,104 @@ func TestDo_BinaryResponse_OutputPathUnwritableIsError(t *testing.T) {
 	}
 }
 
+// TestDo_BinaryResponse_OutputPathWritesSVG covers the SVG branch of
+// docs.scene.export end-to-end: an image/svg+xml body lands on disk verbatim
+// and the envelope echoes the saved path. Only the PNG path was exercised
+// before, so the SVG content-type was covered only indirectly.
+func TestDo_BinaryResponse_OutputPathWritesSVG(t *testing.T) {
+	payload := []byte(`<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.WriteHeader(200)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "board.svg")
+	c := newBinaryClient(srv)
+	body, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/export", BinaryResponse: true, OutputPath: dest,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("written bytes differ: got %q, want %q", got, payload)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal: %v -- %s", err, body)
+	}
+	if env["output"] != dest {
+		t.Errorf("output = %v, want %s", env["output"], dest)
+	}
+	if env["content_type"] != "image/svg+xml" {
+		t.Errorf("content_type = %v, want image/svg+xml", env["content_type"])
+	}
+}
+
+// TestDo_BinaryResponse_OutputWriteFailurePreservesExistingFile pins the
+// atomicity fix: a mid-write failure (here, the destination directory is not
+// writable so the atomic temp file cannot be created) must leave an existing
+// good copy at the destination untouched rather than clobbering/truncating it,
+// and must not leave a stray temp file behind.
+func TestDo_BinaryResponse_OutputWriteFailurePreservesExistingFile(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: directory write permissions are not enforced")
+	}
+	newBytes := bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47}, 16) // the download that must NOT land
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write(newBytes)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "board.png")
+	existing := []byte("previous good copy")
+	if err := os.WriteFile(dest, existing, 0o644); err != nil {
+		t.Fatalf("seed existing file: %v", err)
+	}
+	// Read-only directory: the atomic write cannot create its temp file, so the
+	// write fails after the good copy already exists.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	defer func() { _ = os.Chmod(dir, 0o700) }() // restore so t.TempDir cleanup works
+
+	c := newBinaryClient(srv)
+	if _, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/export", BinaryResponse: true, OutputPath: dest,
+	}); err == nil {
+		t.Fatalf("expected a write error, got nil")
+	}
+
+	// The pre-existing good copy must survive the failed write verbatim.
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read existing file after failed write: %v", err)
+	}
+	if !bytes.Equal(got, existing) {
+		t.Errorf("existing file was clobbered: got %q, want %q", got, existing)
+	}
+
+	// No stray temp file should be left in the directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "board.png" {
+			t.Errorf("unexpected leftover file in dir: %q", e.Name())
+		}
+	}
+}
+
 func TestBackoffDelay_Grows(t *testing.T) {
 	d1 := backoffDelay(1)
 	d3 := backoffDelay(3)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -386,6 +388,62 @@ func TestDo_BinaryResponse_InlineBodyReturnsMetadata(t *testing.T) {
 	}
 	if n, _ := env["size"].(float64); int(n) != len(payload) {
 		t.Errorf("size = %v, want %d", env["size"], len(payload))
+	}
+}
+
+func TestDo_BinaryResponse_OutputPathWritesFile(t *testing.T) {
+	payload := bytes.Repeat([]byte{0x89, 0x50, 0x4e, 0x47}, 32)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "board.png")
+	c := newBinaryClient(srv)
+	body, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/export", BinaryResponse: true, OutputPath: dest,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	// The bytes are written verbatim to the destination.
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("written bytes differ: got %d bytes, want %d", len(got), len(payload))
+	}
+	// The envelope reports the saved path + size.
+	var env map[string]any
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal: %v -- %s", err, body)
+	}
+	if env["output"] != dest {
+		t.Errorf("output = %v, want %s", env["output"], dest)
+	}
+	if n, _ := env["size"].(float64); int(n) != len(payload) {
+		t.Errorf("size = %v, want %d", env["size"], len(payload))
+	}
+}
+
+func TestDo_BinaryResponse_OutputPathUnwritableIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte{1, 2, 3})
+	}))
+	defer srv.Close()
+
+	// A path under a non-existent directory cannot be created → validation error.
+	dest := filepath.Join(t.TempDir(), "no-such-dir", "board.png")
+	c := newBinaryClient(srv)
+	if _, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/export", BinaryResponse: true, OutputPath: dest,
+	}); err == nil {
+		t.Fatalf("expected an error writing to an unwritable path")
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -542,6 +543,75 @@ func TestDo_BinaryResponse_OutputWriteFailurePreservesExistingFile(t *testing.T)
 		if e.Name() != "board.png" {
 			t.Errorf("unexpected leftover file in dir: %q", e.Name())
 		}
+	}
+}
+
+// TestDo_BinaryResponse_OutputWriteFailureIsNonRetryable pins the PR's central
+// invariant: a local write failure is a non-retryable validation error, so a
+// successful server request is never re-downloaded just because the disk write
+// failed. Asserts the error taxonomy and that the server handler is hit exactly
+// once (no retry loop).
+func TestDo_BinaryResponse_OutputWriteFailureIsNonRetryable(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte{1, 2, 3})
+	}))
+	defer srv.Close()
+
+	// Unwritable destination: parent directory does not exist.
+	dest := filepath.Join(t.TempDir(), "no-such-dir", "board.png")
+	c := newBinaryClient(srv)
+	_, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/export", BinaryResponse: true, OutputPath: dest,
+	})
+	if err == nil {
+		t.Fatal("expected a write error, got nil")
+	}
+	var ee *output.ExitError
+	if !errors.As(err, &ee) || ee.Type != "validation" {
+		t.Errorf("expected a validation ExitError, got %T: %v", err, err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("server hit %d times; a local write failure must not trigger a retry (want 1)", got)
+	}
+}
+
+// TestDo_BinaryResponse_RedirectWithOutputPathWritesNothing pins the documented
+// promise on the OutputPath field: a 3xx (redirect-to-URL) response is never
+// written to disk even when OutputPath is set — its Location is surfaced in the
+// envelope instead.
+func TestDo_BinaryResponse_RedirectWithOutputPathWritesNothing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "https://cdn.example.com/board.png")
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(302)
+		_, _ = w.Write([]byte("this body must never reach disk"))
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "board.png")
+	c := newBinaryClient(srv)
+	body, err := c.Do(context.Background(), &Request{
+		Method: "GET", Path: "/dl", BinaryResponse: true, OutputPath: dest,
+	})
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Errorf("a redirect response must not write a file; os.Stat err = %v", statErr)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal: %v -- %s", err, body)
+	}
+	if env["url"] != "https://cdn.example.com/board.png" {
+		t.Errorf("url = %v, want the Location header", env["url"])
+	}
+	if _, ok := env["output"]; ok {
+		t.Errorf("redirect envelope must not carry an output key, got %v", env["output"])
 	}
 }
 

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -321,7 +321,7 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 	d.BinaryResponse = boolOf(op["x-octo-binary-response"])
 	if d.BinaryResponse {
 		if resps, ok := op["responses"].(map[string]any); ok {
-			d.BinaryBody = hasSuccessBody(resps)
+			d.BinaryBody = hasSuccessBody(doc, resps)
 		}
 	}
 
@@ -399,7 +399,14 @@ func extractJSONSchema(body map[string]any) map[string]any {
 // i.e. the operation returns bytes inline on success (docs.scene.export) rather
 // than a bodyless redirect (file.download's 302-only). It gates the --output/-o
 // flag so -o is offered only where it can actually write something.
-func hasSuccessBody(resps map[string]any) bool {
+//
+// A 2xx entry may either inline the response object or factor it out via
+// {"$ref": "#/components/responses/..."}. Both are handled: a response-level
+// $ref is resolved through components.responses before the content check, so a
+// spec that shares its success response does not fail-closed and silently drop
+// -o. Only one hop is followed (OpenAPI response objects do not chain refs); an
+// unresolvable ref is treated as "no body".
+func hasSuccessBody(doc, resps map[string]any) bool {
 	for code, r := range resps {
 		if !strings.HasPrefix(code, "2") {
 			continue
@@ -408,11 +415,38 @@ func hasSuccessBody(resps map[string]any) bool {
 		if !ok {
 			continue
 		}
+		if ref, ok := rm["$ref"].(string); ok && ref != "" {
+			resolved := followResponseRef(doc, ref)
+			if resolved == nil {
+				continue
+			}
+			rm = resolved
+		}
 		if content, ok := rm["content"].(map[string]any); ok && len(content) > 0 {
 			return true
 		}
 	}
 	return false
+}
+
+// followResponseRef resolves a `#/components/responses/<name>` pointer to its
+// response object. It returns nil for any other ref shape or an unknown name.
+func followResponseRef(doc map[string]any, ref string) map[string]any {
+	const prefix = "#/components/responses/"
+	if !strings.HasPrefix(ref, prefix) {
+		return nil
+	}
+	name := strings.TrimPrefix(ref, prefix)
+	comps, ok := doc["components"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	responses, ok := comps["responses"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	s, _ := responses[name].(map[string]any)
+	return s
 }
 
 func firstSuccessSchema(doc, resps map[string]any) *SchemaInfo {

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -206,6 +206,12 @@ type OperationDetail struct {
 	SpaceHeaderSet bool `json:"space_header_set,omitempty"`
 	Multipart      bool `json:"multipart,omitempty"`
 	BinaryResponse bool `json:"binary_response,omitempty"`
+	// BinaryBody is true only when the operation delivers a binary body inline
+	// on a 2xx success (declared via a 2xx response with a content body), so
+	// the CLI can write those bytes to disk with --output/-o. It is false for
+	// redirect-style binary ops such as file.download, which return a 302 with
+	// no consumable body — offering -o there is a silent no-op footgun.
+	BinaryBody bool `json:"binary_body,omitempty"`
 }
 
 // ListOperations returns every operation for a service, sorted by operationId.
@@ -313,6 +319,11 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 
 	d.Multipart = boolOf(op["x-octo-multipart"])
 	d.BinaryResponse = boolOf(op["x-octo-binary-response"])
+	if d.BinaryResponse {
+		if resps, ok := op["responses"].(map[string]any); ok {
+			d.BinaryBody = hasSuccessBody(resps)
+		}
+	}
 
 	if params, ok := op["parameters"].([]any); ok {
 		for _, p := range params {
@@ -382,6 +393,26 @@ func extractJSONSchema(body map[string]any) map[string]any {
 		}
 	}
 	return nil
+}
+
+// hasSuccessBody reports whether any 2xx response declares a content body,
+// i.e. the operation returns bytes inline on success (docs.scene.export) rather
+// than a bodyless redirect (file.download's 302-only). It gates the --output/-o
+// flag so -o is offered only where it can actually write something.
+func hasSuccessBody(resps map[string]any) bool {
+	for code, r := range resps {
+		if !strings.HasPrefix(code, "2") {
+			continue
+		}
+		rm, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		if content, ok := rm["content"].(map[string]any); ok && len(content) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func firstSuccessSchema(doc, resps map[string]any) *SchemaInfo {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -219,6 +219,34 @@ func TestHeaderParamWithFlagAlias(t *testing.T) {
 	}
 }
 
+// TestQueryParamFlagAliasAvoidsGlobalCollision pins the docs.scene.export fix:
+// its `format` query param carries x-octo-flag "image-format" so the generated
+// CLI flag is --image-format (which does not shadow the global persistent
+// --format output flag), while the wire query parameter name stays `format`.
+func TestQueryParamFlagAliasAvoidsGlobalCollision(t *testing.T) {
+	r := MustNew()
+	op, ok := r.GetOperation("docs.scene.export")
+	if !ok {
+		t.Fatal("docs.scene.export not found")
+	}
+	var found *ParamInfo
+	for i := range op.Parameters {
+		if op.Parameters[i].In == "query" && op.Parameters[i].Name == "format" {
+			found = &op.Parameters[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("docs.scene.export: expected a `format` query parameter")
+	}
+	if found.FlagName != "image-format" {
+		t.Errorf("format query param flag alias = %q, want image-format (from x-octo-flag)", found.FlagName)
+	}
+	if found.Name != "format" {
+		t.Errorf("wire query param name = %q, want format (must be preserved)", found.Name)
+	}
+}
+
 func TestResolvesComponentRef(t *testing.T) {
 	// matter.get's 200 response is a $ref to MatterDetail — the resolver
 	// should inline the properties so the schema command can describe it.

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -41,7 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
-		"docs":    28,
+		"docs":    29,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -279,6 +279,68 @@ func TestBinaryBodyGatingDistinguishesInlineFromRedirect(t *testing.T) {
 	}
 }
 
+// TestHasSuccessBodyResolvesResponseRef pins the item-3 fix: a 2xx response may
+// be expressed inline OR via {"$ref":"#/components/responses/..."}. hasSuccessBody
+// must resolve the ref before checking for a content body, otherwise a spec that
+// factors its success response into components.responses would fail-closed and
+// silently drop the --output/-o flag (BinaryBody=false) for a real binary body.
+func TestHasSuccessBodyResolvesResponseRef(t *testing.T) {
+	doc := map[string]any{
+		"components": map[string]any{
+			"responses": map[string]any{
+				"BoardImage": map[string]any{
+					"description": "shared image response",
+					"content": map[string]any{
+						"image/png": map[string]any{},
+					},
+				},
+				"NoBody": map[string]any{
+					"description": "bodyless shared response",
+				},
+			},
+		},
+	}
+
+	cases := []struct {
+		name  string
+		resps map[string]any
+		want  bool
+	}{
+		{
+			name:  "inline 2xx content body",
+			resps: map[string]any{"200": map[string]any{"content": map[string]any{"image/png": map[string]any{}}}},
+			want:  true,
+		},
+		{
+			name:  "2xx response via components.responses $ref with body",
+			resps: map[string]any{"200": map[string]any{"$ref": "#/components/responses/BoardImage"}},
+			want:  true,
+		},
+		{
+			name:  "2xx response via $ref to a bodyless response",
+			resps: map[string]any{"204": map[string]any{"$ref": "#/components/responses/NoBody"}},
+			want:  false,
+		},
+		{
+			name:  "unresolvable $ref is treated as no body",
+			resps: map[string]any{"200": map[string]any{"$ref": "#/components/responses/Missing"}},
+			want:  false,
+		},
+		{
+			name:  "non-2xx content body is ignored",
+			resps: map[string]any{"400": map[string]any{"content": map[string]any{"application/json": map[string]any{}}}},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasSuccessBody(doc, tc.resps); got != tc.want {
+				t.Errorf("hasSuccessBody = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolvesComponentRef(t *testing.T) {
 	// matter.get's 200 response is a $ref to MatterDetail — the resolver
 	// should inline the properties so the schema command can describe it.

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -247,6 +247,38 @@ func TestQueryParamFlagAliasAvoidsGlobalCollision(t *testing.T) {
 	}
 }
 
+// TestBinaryBodyGatingDistinguishesInlineFromRedirect pins the -o footgun fix:
+// both docs.scene.export and file.download are x-octo-binary-response, but only
+// docs.scene.export delivers a body inline on a 2xx success, so only it should
+// carry BinaryBody (the gate for the --output/-o flag). file.download is a
+// 302-only redirect with no consumable body — offering -o there silently writes
+// nothing.
+func TestBinaryBodyGatingDistinguishesInlineFromRedirect(t *testing.T) {
+	r := MustNew()
+
+	export, ok := r.GetOperation("docs.scene.export")
+	if !ok {
+		t.Fatal("docs.scene.export not found")
+	}
+	if !export.BinaryResponse {
+		t.Error("docs.scene.export: expected BinaryResponse=true")
+	}
+	if !export.BinaryBody {
+		t.Error("docs.scene.export: expected BinaryBody=true (has a 2xx image body, -o must write it)")
+	}
+
+	dl, ok := r.GetOperation("file.download")
+	if !ok {
+		t.Fatal("file.download not found")
+	}
+	if !dl.BinaryResponse {
+		t.Error("file.download: expected BinaryResponse=true (client still surfaces the 302 Location)")
+	}
+	if dl.BinaryBody {
+		t.Error("file.download: expected BinaryBody=false (302-only redirect, -o would silently no-op)")
+	}
+}
+
 func TestResolvesComponentRef(t *testing.T) {
 	// matter.get's 200 response is a $ref to MatterDetail — the resolver
 	// should inline the properties so the schema command can describe it.

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -165,12 +165,12 @@
       "get": {
         "operationId": "docs.scene.export",
         "summary": "Export a whiteboard's live scene as a PNG or SVG image (needs reader)",
-        "description": "Renders the LIVE Excalidraw scene of a doc_type 'board' to an image on the server: `--format png` (default) returns a PNG, `--format svg` returns an SVG. The body is binary, so pass --output/-o to save it to a file (e.g. `docs scene export <docId> --format png -o board.png`); without --output the command only reports the response status, content-type and size. A non-board target returns 409 unsupported_doc_type; an unrecognised format returns 400 invalid_format.",
+        "description": "Renders the LIVE Excalidraw scene of a doc_type 'board' to an image on the server: `--image-format png` (default) returns a PNG, `--image-format svg` returns an SVG. The body is binary, so pass --output/-o to save it to a file (e.g. `docs scene export <docId> --image-format png -o board.png`); without --output the command only reports the response status, content-type and size. A non-board target returns 409 unsupported_doc_type; an unrecognised format returns 400 invalid_format.",
         "x-octo-risk": "read",
         "x-octo-binary-response": true,
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "format", "in": "query", "schema": { "type": "string", "enum": ["png", "svg"], "default": "png" }, "description": "image format (one of: png, svg); default png" }
+          { "name": "format", "in": "query", "x-octo-flag": "image-format", "schema": { "type": "string", "enum": ["png", "svg"], "default": "png" }, "description": "image format (one of: png, svg); default png. Exposed as --image-format so it does not shadow the global --format output flag." }
         ],
         "responses": {
           "200": {

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -167,6 +167,7 @@
         "summary": "Export a whiteboard's live scene as a PNG or SVG image (needs reader)",
         "description": "Renders the LIVE Excalidraw scene of a doc_type 'board' to an image on the server: `--image-format png` (default) returns a PNG, `--image-format svg` returns an SVG. The body is binary, so pass --output/-o to save it to a file (e.g. `docs scene export <docId> --image-format png -o board.png`); without --output the command only reports the response status, content-type and size. A non-board target returns 409 unsupported_doc_type; an unrecognised format returns 400 invalid_format.",
         "x-octo-risk": "read",
+        "x-octo-risk-note": "read reflects the server-side effect: this is a GET that renders and returns the live scene as an image without mutating any doc state. The optional --output/-o writes to a local, user-chosen path (client side, analogous to curl -o) and does not change the API risk class.",
         "x-octo-binary-response": true,
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -161,6 +161,30 @@
         "responses": { "200": { "description": "Deleted" } }
       }
     },
+    "/v1/bot/docs/{docId}/export": {
+      "get": {
+        "operationId": "docs.scene.export",
+        "summary": "Export a whiteboard's live scene as a PNG or SVG image (needs reader)",
+        "description": "Renders the LIVE Excalidraw scene of a doc_type 'board' to an image on the server: `--format png` (default) returns a PNG, `--format svg` returns an SVG. The body is binary, so pass --output/-o to save it to a file (e.g. `docs scene export <docId> --format png -o board.png`); without --output the command only reports the response status, content-type and size. A non-board target returns 409 unsupported_doc_type; an unrecognised format returns 400 invalid_format.",
+        "x-octo-risk": "read",
+        "x-octo-binary-response": true,
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "format", "in": "query", "schema": { "type": "string", "enum": ["png", "svg"], "default": "png" }, "description": "image format (one of: png, svg); default png" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The rendered board image",
+            "content": {
+              "image/png": { "schema": { "type": "string", "format": "binary" } },
+              "image/svg+xml": { "schema": { "type": "string", "format": "binary" } }
+            }
+          },
+          "400": { "description": "invalid_format" },
+          "409": { "description": "unsupported_doc_type / board_snapshot_invalid" }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}/content": {
       "get": {
         "operationId": "docs.content.get",

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -308,15 +308,18 @@ The response body is binary, so pass `--output`/`-o` to save it to a file; witho
 
 ```bash
 # PNG (default). -o writes the bytes to disk and the envelope echoes the saved path.
-octo-cli docs scene export <docId> --format png -o board.png
+octo-cli docs scene export <docId> --image-format png -o board.png
 
 # SVG (vector).
-octo-cli docs scene export <docId> --format svg -o board.svg
+octo-cli docs scene export <docId> --image-format svg -o board.svg
 ```
 
-> `--format` is `png` (default) or `svg`; any other value returns 400
-> `invalid_format`. The export reflects the scene as it is live right now
-> (shapes, text, and embedded images), not a persisted snapshot.
+> `--image-format` is `png` (default) or `svg`; any other value returns 400
+> `invalid_format`. (The flag is named `--image-format`, not `--format`, so it
+> does not collide with the global `--format` output-envelope flag; the wire
+> query parameter is still `format`.) The export reflects the scene as it is live
+> right now (shapes, text, and embedded images), not a persisted snapshot.
+> `-o` overwrites an existing destination file.
 
 
 ## Pagination note

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -299,6 +299,26 @@ octo-cli docs attachments resolve <docId> --attachIds a1 --attachIds a2
 > presigned object-store URL. Do the PUT with `curl` (or any HTTP client) as
 > shown above.
 
+## 8. Whiteboard image export
+
+Render a whiteboard's **live** Excalidraw scene to an image on the server. Works
+only on a `doc_type: board` (a non-board target returns 409 `unsupported_doc_type`).
+The response body is binary, so pass `--output`/`-o` to save it to a file; without
+`-o` the command only reports the response `{status, content_type, size}`.
+
+```bash
+# PNG (default). -o writes the bytes to disk and the envelope echoes the saved path.
+octo-cli docs scene export <docId> --format png -o board.png
+
+# SVG (vector).
+octo-cli docs scene export <docId> --format svg -o board.svg
+```
+
+> `--format` is `png` (default) or `svg`; any other value returns 400
+> `invalid_format`. The export reflects the scene as it is live right now
+> (shapes, text, and embedded images), not a persisted snapshot.
+
+
 ## Pagination note
 
 The docs list endpoints do **not** use the shared `{data, pagination}` envelope,


### PR DESCRIPTION
Closes #77.

## What
Adds the `docs.scene.export` operation so bots can export a whiteboard's live scene:

```
octo-cli docs scene export <docId> --image-format png|svg -o board.png
```

## How
- `internal/registry/specs/docs.json`: new `GET /v1/bot/docs/{docId}/export` operation (`docs.scene.export`) with a `format` enum (png/svg, default png) and `x-octo-binary-response: true`. The query param carries `x-octo-flag: image-format`, so the CLI flag is `--image-format` while the wire param stays `?format=` — the global persistent `--format` output flag (json|table|csv|ndjson) is not shadowed.
- Engine: the existing binary-response path only DESCRIBED a 2xx body (`{status, content_type, size}`). Added an `--output`/`-o` flag that makes the client WRITE the 2xx body to disk and echo the saved path in the envelope. A local write failure is a hard, non-retryable validation error.
- `--output`/`-o` is scoped to operations that return an **inline 2xx binary body** (new `OperationDetail.BinaryBody` signal, derived from whether the op declares a 2xx response with a content body). Redirect-style binary ops such as `file.download` (302-only, no consumable body) no longer register `-o` — previously the flag was accepted there but silently wrote nothing. `x-octo-binary-response` is unchanged, so the 302 Location surfacing still works.
- Hardened `runPaginated`'s next-page request clone to copy the whole struct (was rebuilding it field-by-field and dropping `OutputPath`/`BinaryResponse`/`RawBody`/`ContentType`).
- Updated the registry-count tests and the octo-docs skill (§8).

## Tests
`go build ./...`, `go vet ./...`, `go test ./...` all green. New regressions:
- `TestBinaryBodyGatingDistinguishesInlineFromRedirect` (loader): `docs.scene.export` has `BinaryBody`, `file.download` does not.
- `TestFileDownload_NoOutputFlag`: `file download` exposes no `-o`/`--output`.
- `TestDocsSceneExport_OutputFlagWritesFileToDisk`: `docs scene export -o` still lands bytes on disk.
- Plus the existing `--image-format` collision regressions and client output-to-disk tests.

Pairs with the backend endpoint (Mininglamp-OSS/octo-docs-backend#49, PR Mininglamp-OSS/octo-docs-backend#50).
