### PR TITLE
XIN-796: reject index-less/illegal whiteboard elements in docs scene edit

### DIFF
--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -806,7 +806,7 @@ func TestDocsSceneEdit_SendsBatchAndIfMatch(t *testing.T) {
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`{"docId":"d1","bytes":256,"baseVersion":"BV_NEXT==","newDocVersionSeq":7}`))
 	})
-	batch := `{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}`
+	batch := `{"elements":[{"id":"e1","type":"rectangle","version":4,"index":"a0"}],"deletedElementIds":["e2"],"files":{}}`
 	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--base-version", "BV_ABC==", "--data", batch})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
@@ -849,5 +849,59 @@ func TestDocsSceneEdit_RequiresBaseVersion(t *testing.T) {
 	}
 	if called {
 		t.Error("server must not be called when required --base-version is missing")
+	}
+}
+
+// TestDocsSceneEdit_RejectsIndexlessElement confirms an upsert element with no
+// `index` is rejected locally (non-zero exit) before any request is sent, so
+// index-less whiteboard elements can no longer reach the backend (XIN-792).
+func TestDocsSceneEdit_RejectsIndexlessElement(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	batch := `{"elements":[{"id":"e1","type":"rectangle","version":4}]}`
+	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--base-version", "BV_ABC==", "--data", batch})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for an element missing `index`")
+	}
+	if called {
+		t.Error("server must not be called when an element is missing `index`")
+	}
+}
+
+// TestDocsSceneEdit_RejectsInvalidIndex confirms the exact repair artifact from
+// XIN-792 (`r00000003`) — a malformed fractional-index — is rejected locally.
+func TestDocsSceneEdit_RejectsInvalidIndex(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	batch := `{"elements":[{"id":"e1","type":"rectangle","version":4,"index":"r00000003"}]}`
+	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--base-version", "BV_ABC==", "--data", batch})
+	if err := root.Execute(); err == nil {
+		t.Fatal("expected error for an element with an invalid `index`")
+	}
+	if called {
+		t.Error("server must not be called when an element carries an invalid `index`")
+	}
+}
+
+// TestDocsSceneEdit_DeleteOnlyBatchAllowed confirms a batch with no `elements`
+// to upsert (only soft-deletes) still passes — index validation applies only to
+// upserted elements.
+func TestDocsSceneEdit_DeleteOnlyBatchAllowed(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","bytes":8,"baseVersion":"BV_NEXT==","newDocVersionSeq":8}`))
+	})
+	root.SetArgs([]string{"docs", "scene", "edit", "d1", "--base-version", "BV_ABC==", "--data", `{"deletedElementIds":["e2"]}`})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("delete-only batch should pass validation: %v", err)
+	}
+	if !called {
+		t.Error("server should be called for a valid delete-only batch")
 	}
 }

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -72,6 +72,14 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 			_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
 			return err
 		}
+		// Reject index-less / malformed-index whiteboard elements locally, before
+		// sending, for operations that declare it in the spec (docs.scene.edit).
+		if d.ValidateElementsIndex {
+			if verr := validateElementsIndex(body); verr != nil {
+				_ = f.EmitError(verr) //nolint:errcheck // best-effort emit before returning err
+				return verr
+			}
+		}
 		req.Body = body
 	}
 

--- a/cmd/service/validate.go
+++ b/cmd/service/validate.go
@@ -1,0 +1,65 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/fracindex"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+// indexHint is the guidance attached to every fractional-index validation
+// error so a caller (typically an agent) learns the correct way to produce a
+// key instead of inventing one.
+const indexHint = "every whiteboard element must carry a valid fractional-index `index` (z-order key) — generate it with the fractional-indexing / Excalidraw rules (e.g. \"a0\", \"a1\"); never omit it or fabricate an \"r\"+digits, plain-integer, or timestamp value"
+
+// validateElementsIndex enforces that every element in a scene-edit body carries
+// a valid fractional-index `index`. It is invoked only for operations that
+// declare x-octo-validate-elements-index in the spec. Rejecting here — before
+// the request is sent — stops index-less / garbage-index elements from reaching
+// the backend, where a buggy repair path would rewrite them into an invalid key
+// (XIN-792) and break the board.
+//
+// A body with no `elements` key (e.g. a delete-only batch) is left untouched.
+func validateElementsIndex(body any) *output.ExitError {
+	m, ok := body.(map[string]any)
+	if !ok {
+		// No structured body (or --data was not an object); nothing to check.
+		return nil
+	}
+	raw, present := m["elements"]
+	if !present {
+		return nil
+	}
+	elems, ok := raw.([]any)
+	if !ok {
+		return output.ErrValidation("`elements` must be a JSON array", indexHint)
+	}
+	for i, e := range elems {
+		el, ok := e.(map[string]any)
+		if !ok {
+			return output.ErrValidation(fmt.Sprintf("elements[%d] must be a JSON object", i), indexHint)
+		}
+		label := elementLabel(el, i)
+		idxRaw, has := el["index"]
+		if !has {
+			return output.ErrValidation(fmt.Sprintf("%s is missing `index`", label), indexHint)
+		}
+		idx, ok := idxRaw.(string)
+		if !ok {
+			return output.ErrValidation(fmt.Sprintf("%s `index` must be a string", label), indexHint)
+		}
+		if err := fracindex.ValidateOrderKey(idx); err != nil {
+			return output.ErrValidation(fmt.Sprintf("%s has an invalid `index`: %v", label, err), indexHint)
+		}
+	}
+	return nil
+}
+
+// elementLabel builds a human-readable reference to an element for error
+// messages, preferring its id when present.
+func elementLabel(el map[string]any, i int) string {
+	if id, ok := el["id"].(string); ok && id != "" {
+		return fmt.Sprintf("elements[%d] (id %q)", i, id)
+	}
+	return fmt.Sprintf("elements[%d]", i)
+}

--- a/internal/fracindex/fracindex.go
+++ b/internal/fracindex/fracindex.go
@@ -1,11 +1,19 @@
 // Package fracindex validates fractional-index order keys — the z-order keys
 // the whiteboard backend expects on every Excalidraw element.
 //
-// It is a faithful port of the reference `fractional-indexing` library's
-// validateOrderKey (the same rules the frontend and backend enforce). The CLI
-// uses it to reject malformed keys locally, before they reach the backend, so
-// callers can no longer send index-less or garbage-index elements (e.g. the
-// "r00000003" repair artifact from XIN-792) that corrupt a board.
+// A key is accepted only if it satisfies every rule the frontend and backend
+// enforce, so the CLI rejects locally exactly what they reject server-side:
+//   - a well-formed integer part (correct length for its head character), from
+//     the reference `fractional-indexing` library's validateOrderKey;
+//   - a full-key base-62 charset, from the frontend/backend INDEX_RE
+//     (/^[A-Za-z0-9]+$/) — the integer part is charset-checked, not just the
+//     fraction;
+//   - no trailing '0' in the fractional part, from the reference
+//     validateOrderKey (a non-canonical key).
+//
+// The CLI uses it to reject malformed keys locally, before they reach the
+// backend, so callers can no longer send index-less or garbage-index elements
+// (e.g. the "r00000003" repair artifact from XIN-792) that corrupt a board.
 package fracindex
 
 import (
@@ -52,12 +60,21 @@ func ValidateOrderKey(key string) error {
 	if intLen > len(key) {
 		return fmt.Errorf("invalid order key: %q (integer part truncated)", key)
 	}
-	// The fractional part (everything after the integer part) must be composed
-	// entirely of base-62 digits.
-	for i := intLen; i < len(key); i++ {
+	// Every byte of the key — integer part and fractional part alike — must be a
+	// base-62 digit. The frontend (INDEX_RE = /^[A-Za-z0-9]+$/) and backend
+	// (identical regex) apply this gate to the whole key, so a non-base62
+	// integer-part byte such as the '!' in "a!" must be rejected here too.
+	for i := 0; i < len(key); i++ {
 		if !isBase62(key[i]) {
-			return fmt.Errorf("invalid order key: %q (bad fractional digit %q)", key, string(key[i]))
+			return fmt.Errorf("invalid order key: %q (bad digit %q)", key, string(key[i]))
 		}
+	}
+	// The fractional part (everything after the integer part) must not end in the
+	// first digit '0': a trailing zero is non-canonical and equivalent to the
+	// shorter key, so the reference validateOrderKey and the frontend/backend all
+	// reject it (e.g. "a00", "a10").
+	if len(key) > intLen && key[len(key)-1] == base62Digits[0] {
+		return fmt.Errorf("invalid order key: %q (fractional part ends in zero)", key)
 	}
 	return nil
 }

--- a/internal/fracindex/fracindex.go
+++ b/internal/fracindex/fracindex.go
@@ -1,0 +1,72 @@
+// Package fracindex validates fractional-index order keys — the z-order keys
+// the whiteboard backend expects on every Excalidraw element.
+//
+// It is a faithful port of the reference `fractional-indexing` library's
+// validateOrderKey (the same rules the frontend and backend enforce). The CLI
+// uses it to reject malformed keys locally, before they reach the backend, so
+// callers can no longer send index-less or garbage-index elements (e.g. the
+// "r00000003" repair artifact from XIN-792) that corrupt a board.
+package fracindex
+
+import (
+	"errors"
+	"fmt"
+)
+
+// base62Digits is the ordered digit alphabet used for the fractional part of a
+// key. The integer part's magnitude is encoded in the head character.
+const base62Digits = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// smallestInteger is the reserved lower bound the library never emits as a real
+// key; treating it as valid would let a caller pin an element below every other.
+const smallestInteger = "A00000000000000000000000000"
+
+// integerLength returns the total length the integer part must have given its
+// head character. Mirrors the reference getIntegerLength: 'a'..'z' encode
+// increasing positive magnitudes, 'A'..'Z' increasing negative magnitudes.
+func integerLength(head byte) (int, error) {
+	switch {
+	case head >= 'a' && head <= 'z':
+		return int(head-'a') + 2, nil
+	case head >= 'A' && head <= 'Z':
+		return int('Z'-head) + 2, nil
+	default:
+		return 0, fmt.Errorf("invalid order key head: %q", string(head))
+	}
+}
+
+// ValidateOrderKey reports whether key is a well-formed fractional index. It
+// returns nil for a valid key and a descriptive error otherwise. An empty key
+// is always invalid.
+func ValidateOrderKey(key string) error {
+	if key == "" {
+		return errors.New("order key is empty")
+	}
+	if key == smallestInteger {
+		return fmt.Errorf("invalid order key: %q (reserved lower bound)", key)
+	}
+	intLen, err := integerLength(key[0])
+	if err != nil {
+		return err
+	}
+	if intLen > len(key) {
+		return fmt.Errorf("invalid order key: %q (integer part truncated)", key)
+	}
+	// The fractional part (everything after the integer part) must be composed
+	// entirely of base-62 digits.
+	for i := intLen; i < len(key); i++ {
+		if !isBase62(key[i]) {
+			return fmt.Errorf("invalid order key: %q (bad fractional digit %q)", key, string(key[i]))
+		}
+	}
+	return nil
+}
+
+func isBase62(c byte) bool {
+	for i := 0; i < len(base62Digits); i++ {
+		if base62Digits[i] == c {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/fracindex/fracindex_test.go
+++ b/internal/fracindex/fracindex_test.go
@@ -27,6 +27,20 @@ func TestValidateOrderKey(t *testing.T) {
 		{"bad head", "!0", true},
 		{"truncated integer part", "b0", true}, // head 'b' requires a 3-char integer part
 		{"bad fractional digit", "a0-", true},
+
+		// Integer-part charset: every byte of the key must be base62, not just
+		// the fractional part. The frontend (INDEX_RE = /^[A-Za-z0-9]+$/) and
+		// backend (identical regex) reject a non-base62 integer-part byte, so
+		// the CLI must too.
+		{"integer-part non-base62", "a!", true},
+		{"integer-part non-base62 with fraction", "c00!", true},
+
+		// Trailing-zero rule: the fractional part must not end in the first
+		// digit '0' (a non-canonical key). The reference validateOrderKey and
+		// the frontend/backend all reject these.
+		{"trailing zero", "a00", true},
+		{"trailing zero short", "a10", true},
+		{"trailing zero deep", "a0V0", true},
 	}
 
 	for _, tc := range tests {

--- a/internal/fracindex/fracindex_test.go
+++ b/internal/fracindex/fracindex_test.go
@@ -1,0 +1,43 @@
+package fracindex
+
+import "testing"
+
+func TestValidateOrderKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+	}{
+		// Valid keys produced by the fractional-indexing library.
+		{"integer zero", "a0", false},
+		{"integer one", "a1", false},
+		{"integer with fractional part", "a0V", false},
+		{"upper-head integer", "Zz", false},
+		{"deep fractional", "a0zzzzzzzzzz", false},
+
+		// The exact repair artifact from XIN-792 must be rejected: head 'r'
+		// demands a 19-char integer part but the key is only 9 chars.
+		{"repair artifact r00000003", "r00000003", true},
+
+		// Other malformed shapes.
+		{"empty", "", true},
+		{"plain integer", "3", true},
+		{"timestamp", "1720598400000", true},
+		{"reserved smallest integer", smallestInteger, true},
+		{"bad head", "!0", true},
+		{"truncated integer part", "b0", true}, // head 'b' requires a 3-char integer part
+		{"bad fractional digit", "a0-", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateOrderKey(tc.key)
+			if tc.wantErr && err == nil {
+				t.Errorf("ValidateOrderKey(%q) = nil, want error", tc.key)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("ValidateOrderKey(%q) = %v, want nil", tc.key, err)
+			}
+		})
+	}
+}

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -212,6 +212,12 @@ type OperationDetail struct {
 	// redirect-style binary ops such as file.download, which return a 302 with
 	// no consumable body — offering -o there is a silent no-op footgun.
 	BinaryBody bool `json:"binary_body,omitempty"`
+	// ValidateElementsIndex captures the x-octo-validate-elements-index
+	// extension. When true, the CLI rejects a request whose body carries any
+	// `elements[]` entry missing a valid fractional-index `index` before it is
+	// sent — so index-less / garbage-index whiteboard elements (XIN-792) can no
+	// longer reach the backend and corrupt a board.
+	ValidateElementsIndex bool `json:"validate_elements_index,omitempty"`
 }
 
 // ListOperations returns every operation for a service, sorted by operationId.
@@ -319,6 +325,7 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 
 	d.Multipart = boolOf(op["x-octo-multipart"])
 	d.BinaryResponse = boolOf(op["x-octo-binary-response"])
+	d.ValidateElementsIndex = boolOf(op["x-octo-validate-elements-index"])
 	if d.BinaryResponse {
 		if resps, ok := op["responses"].(map[string]any); ok {
 			d.BinaryBody = hasSuccessBody(doc, resps)

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -447,8 +447,9 @@
       "patch": {
         "operationId": "docs.scene.edit",
         "summary": "Apply an element upsert/delete batch to a whiteboard scene (needs writer)",
-        "description": "Applies a batch of element upserts and soft-deletes to a doc_type 'board' scene under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs scene get` via --base-version (sent as the If-Match header); the server rejects with 412 base_version_stale if the live scene moved since that read. `elements` are full elements to upsert (CAS: the higher `version` wins), `deletedElementIds` are soft-delete tombstones, and `files` upserts file refs; the batch is a structured object, so pass it as JSON through --data. Only doc_type 'board' is accepted (doc / sheet return 409 unsupported_doc_type). Gates: element count over the max → 413 too_many_elements, a single element too large → 413 element_too_large, whole scene over the cap → 413 doc_too_large, an element failing the whitelist → 422 board_element_invalid, a file ref with no usable attachId → 422 board_file_invalid, missing base version or malformed shape → 400 invalid_body.",
+        "description": "Applies a batch of element upserts and soft-deletes to a doc_type 'board' scene under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs scene get` via --base-version (sent as the If-Match header); the server rejects with 412 base_version_stale if the live scene moved since that read. `elements` are full elements to upsert (CAS: the higher `version` wins), `deletedElementIds` are soft-delete tombstones, and `files` upserts file refs; the batch is a structured object, so pass it as JSON through --data. Every element in `elements` must carry a valid fractional-index `index` (z-order key); the CLI rejects an index-less or malformed-index element locally before sending. Only doc_type 'board' is accepted (doc / sheet return 409 unsupported_doc_type). Gates: element count over the max → 413 too_many_elements, a single element too large → 413 element_too_large, whole scene over the cap → 413 doc_too_large, an element failing the whitelist → 422 board_element_invalid, a file ref with no usable attachId → 422 board_file_invalid, missing base version or malformed shape → 400 invalid_body.",
         "x-octo-risk": "write",
+        "x-octo-validate-elements-index": true,
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
           {
@@ -470,7 +471,7 @@
                   "elements": {
                     "type": "array",
                     "items": { "type": "object" },
-                    "description": "full Excalidraw elements to upsert; on a key collision the element with the higher `version` (then smaller `versionNonce`) wins the CAS. Pass via --data."
+                    "description": "full Excalidraw elements to upsert; on a key collision the element with the higher `version` (then smaller `versionNonce`) wins the CAS. Each element MUST carry a valid fractional-index `index` (z-order key produced by the fractional-indexing / Excalidraw rules, e.g. `a0`); an index-less or malformed-index element is rejected locally before sending. Pass via --data."
                   },
                   "deletedElementIds": {
                     "type": "array",

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -175,9 +175,21 @@ octo-cli docs scene get <docId>
 #   elements          — full elements to upsert (CAS: higher `version` wins)
 #   deletedElementIds — element ids to soft-delete (tombstone)
 #   files             — file refs to upsert
+# Every element MUST carry a valid fractional-index `index` (z-order key); the
+# CLI rejects an index-less or malformed-index element locally before sending.
 octo-cli docs scene edit <docId> --base-version "<token>" \
-  --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
+  --data '{"elements":[{"id":"e1","type":"rectangle","version":4,"index":"a0"}],"deletedElementIds":["e2"],"files":{}}'
 ```
+
+> **`index` is mandatory on every upserted element.** It must be a valid
+> fractional-index (z-order) key — the same jitterbug / Excalidraw key format the
+> board uses, generated with the `fractional-indexing` rules (e.g. `a0`, `a1`,
+> `a0V`). Never omit `index`, and never fabricate one as an `r`+digits string, a
+> plain integer, or a timestamp: an index-less element used to slip through to a
+> buggy backend repair path that rewrote it into an invalid key (like
+> `r00000003`) and broke the board. The CLI now rejects such elements with a
+> non-zero exit before the request is sent.
+
 
 The upsert is element-level: only the ids named in `elements` / `deletedElementIds`
 are touched (the rest of the board is left as-is). On a key collision the element


### PR DESCRIPTION
## What

`docs scene edit` passed each whiteboard element's fractional-index `index`
through untouched — it never produced, validated, or normalized it. An element
sent with no `index` (or a malformed one) reached the backend, where a buggy
repair path rewrote it into an invalid order key such as `r00000003`, which
broke the board when opened.

This change rejects index-less / malformed-index elements **client-side, before
the request is sent**, and stops the CLI's own docs skill from teaching callers
to omit `index`.

## Changes

- **`internal/fracindex`** — a small, dependency-free port of the
  `fractional-indexing` library's `validateOrderKey`, so the CLI recognizes the
  same valid/invalid z-order keys the frontend and backend do (the exact
  `r00000003` artifact fails as a truncated integer part).
- **Spec-driven validation** — a new `x-octo-validate-elements-index` extension
  on `docs.scene.edit` (`internal/registry/specs/docs.json`), parsed into
  `OperationDetail.ValidateElementsIndex`. `runOperation` validates every
  upserted element's `index` when the flag is set and fails with a
  `VALIDATION_ERROR` (exit code 2) plus a hint on how to produce a correct key.
  Keeping it in the spec avoids a hard-coded operationId carve-out in the engine.
- **Delete-only batches** (no `elements` to upsert) are unaffected.
- **`skills/octo-docs/SKILL.md`** — the example previously showed an index-less
  element; it now carries a valid `index` (`a0`) and the doc states that `index`
  is mandatory and must be a real fractional index (never an `r`+digits, plain
  integer, or timestamp).

## Behavior

```
# missing index      -> VALIDATION_ERROR, exit 2, not sent
# index "r00000003"  -> VALIDATION_ERROR, exit 2, not sent
# index "a0"         -> passes, request sent as before
```

## Tests

- `internal/fracindex` unit tests (valid keys, the `r00000003` artifact, empty,
  plain integer, timestamp, reserved bound, truncated integer part, bad digit).
- End-to-end `docs scene edit` tests: index-less element rejected before any
  request, invalid `index` rejected, delete-only batch still allowed, and the
  existing happy-path batch updated to carry a valid `index`.
- `go build ./...`, `go vet ./...`, and `go test ./... -count=1` all green.

## Note for reviewers

A complementary server-side guard is worth adding: the scene-edit endpoint
should return `422 board_element_invalid` for an element with a missing/invalid
`index` rather than routing it through the repair path. That is a backend change
outside this PR's scope, but recommended as a second line of defense.

Refs XIN-796.

