### PR TITLE
feat(docs): add docs.share get/set for programmatic share scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`octo-cli docs share get|set`** — program the space-level share scope of a
+  document. `docs share get <docId>` reads the current `{docId, shareScope,
+  shareRole}` (needs reader); `docs share set <docId> --scope
+  restricted|anyone_in_space [--role read|edit]` changes it (needs admin). The
+  scope enum is `restricted` / `anyone_in_space` and the role enum is `read` /
+  `edit`; a valid `--role` is required with `--scope anyone_in_space` and is
+  ignored (stored as `read`) with `--scope restricted`, matching the
+  docs-backend `/v1/bot/docs/{docId}/share` contract byte-for-byte. Backed by a
+  new `x-octo-flag` alias on request-body properties, so the clean `--scope` /
+  `--role` flags front the `shareScope` / `shareRole` wire keys.
+
 ### Changed
 - **Renamed the binary and CLI command from `octo` to `octo-cli`** for
   consistency with the repository and Go module name. This affects every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   restricted|anyone_in_space [--role read|edit]` changes it (needs admin). The
   scope enum is `restricted` / `anyone_in_space` and the role enum is `read` /
   `edit`; a valid `--role` is required with `--scope anyone_in_space` and is
-  ignored (stored as `read`) with `--scope restricted`, matching the
-  docs-backend `/v1/bot/docs/{docId}/share` contract byte-for-byte. Backed by a
+  ignored (stored as `read`) with `--scope restricted`. This targets the
+  planned `/v1/bot/docs/{docId}/share` endpoint (backend lands in
+  octo-docs-backend#68); merge this after that endpoint ships. Backed by a
   new `x-octo-flag` alias on request-body properties, so the clean `--scope` /
   `--role` flags front the `shareScope` / `shareRole` wire keys.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (8 domains, 75 operations / 78 commands incl. 3 matter transition aliases)
+## Command Structure (8 domains, 77 operations / 80 commands incl. 3 matter transition aliases)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -51,6 +51,7 @@ octo-cli docs      create | list | get | rename | delete | forward-grant
                sheet    get|edit
                scene    get|edit
                members  list|set|remove
+               share    get|set
                comments list|add|edit|delete
                versions list|create|state|rename|delete|restore
                attachments presign|get|resolve

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -377,11 +378,14 @@ func TestDocsMembersRemove_TwoPathArgs(t *testing.T) {
 }
 
 // TestDocsShareGet_ReadPath checks docs.share.get is a plain GET on the
-// /share sub-resource with the docId in the path and no body.
+// /share sub-resource with the docId in the path and no request body — a read
+// must not ship a payload, so the handler asserts the received body is empty.
 func TestDocsShareGet_ReadPath(t *testing.T) {
 	var gotMethod, gotPath string
+	var gotBody []byte
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath = r.Method, r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`{"docId":"d1","shareScope":"restricted","shareRole":"read"}`))
 	})
@@ -391,6 +395,9 @@ func TestDocsShareGet_ReadPath(t *testing.T) {
 	}
 	if gotMethod != "GET" || gotPath != "/v1/bot/docs/d1/share" {
 		t.Errorf("got %s %s, want GET /v1/bot/docs/d1/share", gotMethod, gotPath)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("GET must send an empty request body; got %q", gotBody)
 	}
 }
 

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -38,6 +38,7 @@ func TestDocs_TreeShape(t *testing.T) {
 		"sheet":       {"get", "edit"},
 		"scene":       {"get", "edit", "export"},
 		"members":     {"list", "set", "remove"},
+		"share":       {"get", "set"},
 		"comments":    {"list", "add", "edit", "delete"},
 		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
 		"attachments": {"presign", "get", "resolve"},
@@ -79,6 +80,8 @@ func TestDocs_RegistryShape(t *testing.T) {
 		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
 		"docs.members.set":         {"PUT", "/v1/bot/docs/{docId}/members"},
 		"docs.members.remove":      {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
+		"docs.share.get":           {"GET", "/v1/bot/docs/{docId}/share"},
+		"docs.share.set":           {"PUT", "/v1/bot/docs/{docId}/share"},
 		"docs.forward-grant":       {"POST", "/v1/bot/docs/{docId}/forward-grant"},
 		"docs.comments.list":       {"GET", "/v1/bot/docs/{docId}/comments"},
 		"docs.comments.add":        {"POST", "/v1/bot/docs/{docId}/comments"},
@@ -370,6 +373,103 @@ func TestDocsMembersRemove_TwoPathArgs(t *testing.T) {
 	}
 	if gotMethod != "DELETE" || gotPath != "/v1/bot/docs/d1/members/u9" {
 		t.Errorf("got %s %s, want DELETE /v1/bot/docs/d1/members/u9", gotMethod, gotPath)
+	}
+}
+
+// TestDocsShareGet_ReadPath checks docs.share.get is a plain GET on the
+// /share sub-resource with the docId in the path and no body.
+func TestDocsShareGet_ReadPath(t *testing.T) {
+	var gotMethod, gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","shareScope":"restricted","shareRole":"read"}`))
+	})
+	root.SetArgs([]string{"docs", "share", "get", "d1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/v1/bot/docs/d1/share" {
+		t.Errorf("got %s %s, want GET /v1/bot/docs/d1/share", gotMethod, gotPath)
+	}
+}
+
+// TestDocsShareSet_RestrictedBody checks --scope restricted maps to a PUT on
+// /share with the byte-exact {shareScope} wire key and no shareRole (a
+// restricted doc ignores the role; the backend normalizes it to read).
+func TestDocsShareSet_RestrictedBody(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","shareScope":"restricted","shareRole":"read"}`))
+	})
+	root.SetArgs([]string{"docs", "share", "set", "d1", "--scope", "restricted"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "PUT" || gotPath != "/v1/bot/docs/d1/share" {
+		t.Errorf("got %s %s, want PUT /v1/bot/docs/d1/share", gotMethod, gotPath)
+	}
+	if gotBody["shareScope"] != "restricted" {
+		t.Errorf("body shareScope = %v, want restricted", gotBody["shareScope"])
+	}
+	if _, present := gotBody["shareRole"]; present {
+		t.Errorf("body must omit shareRole when --role is not passed; got %v", gotBody)
+	}
+}
+
+// TestDocsShareSet_AnyoneEditBody checks --scope anyone_in_space --role edit
+// maps both flags to their wire keys (shareScope / shareRole), proving the
+// x-octo-flag aliases (--scope, --role) do not leak into the body.
+func TestDocsShareSet_AnyoneEditBody(t *testing.T) {
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","shareScope":"anyone_in_space","shareRole":"edit"}`))
+	})
+	root.SetArgs([]string{"docs", "share", "set", "d1", "--scope", "anyone_in_space", "--role", "edit"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotBody["shareScope"] != "anyone_in_space" || gotBody["shareRole"] != "edit" {
+		t.Errorf("body = %v, want {shareScope:anyone_in_space, shareRole:edit}", gotBody)
+	}
+	// The flag aliases must never appear as body keys.
+	if _, bad := gotBody["scope"]; bad {
+		t.Errorf("body leaked the --scope flag alias as a wire key: %v", gotBody)
+	}
+	if _, bad := gotBody["role"]; bad {
+		t.Errorf("body leaked the --role flag alias as a wire key: %v", gotBody)
+	}
+}
+
+// TestDocsShareSet_FlagAliases confirms the leaf exposes --scope / --role (from
+// x-octo-flag) and NOT the camelCase property names, while --data stays
+// available for the raw-body escape hatch.
+func TestDocsShareSet_FlagAliases(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+	docs := findCmd(root, "docs")
+	share := findCmd(docs, "share")
+	if share == nil {
+		t.Fatal("missing docs share resource group")
+	}
+	set := findCmd(share, "set")
+	if set == nil {
+		t.Fatal("missing docs share set leaf")
+	}
+	for _, want := range []string{"scope", "role", "data"} {
+		if set.Flags().Lookup(want) == nil {
+			t.Errorf("docs share set: expected --%s flag", want)
+		}
+	}
+	for _, bad := range []string{"shareScope", "shareRole", "share-scope", "share-role"} {
+		if set.Flags().Lookup(bad) != nil {
+			t.Errorf("docs share set: --%s must NOT exist (aliased to --scope/--role)", bad)
+		}
 	}
 }
 

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -187,7 +187,14 @@ func registerBodyFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Ope
 		if !ok {
 			continue
 		}
-		flagName := strings.ReplaceAll(name, "_", "-")
+		// Flag name: an explicit x-octo-flag override on the property wins (so a
+		// clean --scope can front a shareScope wire key); otherwise derive it from
+		// the property name with underscores turned into dashes. The wire body key
+		// (bf.apiName) always stays the property name regardless of the flag alias.
+		flagName := prop.FlagName
+		if flagName == "" {
+			flagName = strings.ReplaceAll(name, "_", "-")
+		}
 		// Avoid collisions with --data, --file, a query param, or a spec-declared
 		// header flag of the same name (e.g. an If-Match header exposed as
 		// --base-version takes precedence over a body baseVersion mirror).

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -172,6 +172,13 @@ type SchemaInfo struct {
 	MaxLength   int                   `json:"max_length,omitempty"`
 	MaxItems    int                   `json:"max_items,omitempty"`
 	Ref         string                `json:"$ref,omitempty"`
+	// FlagName is the optional CLI flag override from the x-octo-flag extension
+	// on a request-body property, mirroring ParamInfo.FlagName for query/header
+	// params. It lets a promoted body field expose a clean flag name (e.g.
+	// --scope) while the wire body key stays the property name (e.g. shareScope),
+	// so the CLI can honour a caller-facing flag without diverging from the
+	// byte-exact backend contract. Empty means "derive from the property name".
+	FlagName string `json:"flag_name,omitempty"`
 }
 
 // PaginationInfo captures the `x-octo-pagination` extension. It tells the
@@ -506,6 +513,7 @@ func resolveSchemaWithDepth(doc, s map[string]any, depth int) SchemaInfo { //nol
 		Type:        stringOf(s["type"]),
 		Format:      stringOf(s["format"]),
 		Description: stringOf(s["description"]),
+		FlagName:    stringOf(s["x-octo-flag"]),
 	}
 	if req, ok := s["required"].([]any); ok {
 		for _, x := range req {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -41,7 +41,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":    4,
 		"bot":     6,
 		"event":   2,
-		"docs":    29,
+		"docs":    31,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -244,6 +244,33 @@ func TestQueryParamFlagAliasAvoidsGlobalCollision(t *testing.T) {
 	}
 	if found.Name != "format" {
 		t.Errorf("wire query param name = %q, want format (must be preserved)", found.Name)
+	}
+}
+
+// TestBodyPropertyFlagAlias pins docs.share.set: its shareScope/shareRole body
+// properties carry x-octo-flag scope/role so the CLI exposes clean --scope /
+// --role flags while the wire body keys stay the byte-exact backend contract
+// (shareScope / shareRole). The property name is never renamed — only the flag
+// alias is added.
+func TestBodyPropertyFlagAlias(t *testing.T) {
+	r := MustNew()
+	op, ok := r.GetOperation("docs.share.set")
+	if !ok {
+		t.Fatal("docs.share.set not found")
+	}
+	if op.RequestBody == nil || op.RequestBody.Properties == nil {
+		t.Fatal("docs.share.set: expected a request body with properties")
+	}
+	cases := map[string]string{"shareScope": "scope", "shareRole": "role"}
+	for prop, wantFlag := range cases {
+		p, ok := op.RequestBody.Properties[prop]
+		if !ok {
+			t.Errorf("docs.share.set: missing body property %q", prop)
+			continue
+		}
+		if p.FlagName != wantFlag {
+			t.Errorf("%s flag alias = %q, want %q (from x-octo-flag)", prop, p.FlagName, wantFlag)
+		}
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -593,6 +593,79 @@
         "responses": { "200": { "description": "Removed" } }
       }
     },
+    "/v1/bot/docs/{docId}/share": {
+      "get": {
+        "operationId": "docs.share.get",
+        "summary": "Read a document's space-level share scope (needs reader)",
+        "description": "Returns the current share settings any viewer can see: {docId, shareScope, shareRole}. shareScope is 'restricted' (only owner/members) or 'anyone_in_space' (every member of the doc's space gets the share role). shareRole is meaningful only when shareScope is anyone_in_space; a restricted doc always reports shareRole 'read'.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current share settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "shareScope": { "type": "string", "enum": ["restricted", "anyone_in_space"] },
+                    "shareRole": { "type": "string", "enum": ["read", "edit"] }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "docs.share.set",
+        "summary": "Set a document's space-level share scope (needs admin)",
+        "description": "Change the share scope so either only owner/members can access (--scope restricted) or every member of the doc's space gets a share role (--scope anyone_in_space --role read|edit). Normalization matches the backend: with --scope anyone_in_space a valid --role is required (a missing/invalid role is 400 invalid_role); with --scope restricted the role is ignored and stored as read, so --role may be omitted. An unknown scope is 400 invalid_scope; a non-admin caller is 403; a missing/cross-space doc is 404; an archived doc is 409. Share only ever RAISES access (owner/members are never downgraded).",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["shareScope"],
+                "properties": {
+                  "shareScope": { "type": "string", "x-octo-flag": "scope", "enum": ["restricted", "anyone_in_space"], "description": "share scope to set" },
+                  "shareRole": { "type": "string", "x-octo-flag": "role", "enum": ["read", "edit"], "description": "share role for anyone_in_space (required when scope=anyone_in_space; ignored and stored as read when scope=restricted)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated share settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "shareScope": { "type": "string", "enum": ["restricted", "anyone_in_space"] },
+                    "shareRole": { "type": "string", "enum": ["read", "edit"] }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "description": "invalid_scope / invalid_role" },
+          "403": { "description": "forbidden (not admin/owner)" },
+          "404": { "description": "not_found (missing or cross-space doc)" },
+          "409": { "description": "conflict (archived doc)" }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}/forward-grant": {
       "post": {
         "operationId": "docs.forward-grant",

--- a/skills/octo-docs/common.md
+++ b/skills/octo-docs/common.md
@@ -116,11 +116,29 @@ octo-cli docs members remove <docId> <uid>                       # admin; owner 
 
 # Grant-only forward access (never downgrades). Only reader|writer are grantable.
 octo-cli docs forward-grant  <docId> --uid <uid> --role reader
+
+# Space-level share scope — read/set who in the space can reach the doc.
+octo-cli docs share get <docId>                                       # reader; {docId, shareScope, shareRole}
+octo-cli docs share set <docId> --scope restricted                    # admin; only owner/members can access
+octo-cli docs share set <docId> --scope anyone_in_space --role read   # admin; every space member gets read
+octo-cli docs share set <docId> --scope anyone_in_space --role edit   # admin; every space member gets edit
 ```
 
 `docs members set` is a PUT-upsert: it adds the member if absent or changes the
 role if already present. The target uid must be a real Octo user — a miss returns
 `404 user_not_found` and writes no ghost member. Schema: `octo-cli schema docs.members.set`.
+
+`docs share set` changes the space-level share scope. Two scopes: `restricted`
+(only the owner and explicit members reach the doc — the default) and
+`anyone_in_space` (every member of the doc's own space is granted the share
+role). The `--role` (`read` | `edit`) is **required** with `--scope
+anyone_in_space` and is **ignored** with `--scope restricted` (the backend
+normalizes it to `read`), so omit `--role` when restricting. Sharing only ever
+*raises* access — an owner or member is never downgraded by a share setting.
+Error codes: `400 invalid_scope` (unknown scope), `400 invalid_role`
+(anyone_in_space with a missing/invalid role), `403` (caller not admin/owner),
+`404` (missing or cross-space doc), `409` (archived doc). Schema:
+`octo-cli schema docs.share.set`.
 
 ---
 


### PR DESCRIPTION
## What

Adds programmatic control of a document's **space-level share scope** to `octo-cli`, so a bot can read and set who in a space can reach a doc — not just read it. Two new spec-driven operations under the existing docs surface:

- `docs share get <docId>` → `{docId, shareScope, shareRole}` (needs reader)
- `docs share set <docId> --scope restricted|anyone_in_space [--role read|edit]` (needs admin)

Until now `octo-cli` could manage explicit members (`docs members set/remove/list`) but had no share-scope operation.

## Contract

Byte-aligned with the docs-backend handler on `GET/PUT /v1/bot/docs/{docId}/share`:

- Scope enum: `restricted` | `anyone_in_space`; role enum: `read` | `edit`.
- `--role` is **required** with `--scope anyone_in_space` (missing/invalid → `400 invalid_role`).
- `--role` is **ignored** with `--scope restricted` and normalized to `read` by the backend, so it may be omitted.
- The CLI stays a thin transport: scope/role validation and `invalid_scope` / `invalid_role` / `403` / `404` / `409` all remain server-side, matching the members pattern.
- The endpoint is served on the bot mount (`/v1/bot/docs/*`) because docs-backend re-mounts the same `docsRouter` (which owns `/:docId/share`) behind the bot identity middleware — no human endpoint or auth bypass involved.

## Implementation notes

`octo-cli` is metadata-driven, so the commands are added purely in `internal/registry/specs/docs.json`. One small enabling change: `x-octo-flag` — which already aliases query/header params — now also applies to **request-body properties**, so the clean caller-facing flags `--scope` / `--role` front the exact wire body keys `shareScope` / `shareRole`. The property name always stays the JSON body key; only the flag label changes.

## Tests

- Registry: operation counts, method/path shape, and the new body-property flag alias.
- Service engine: `get` read path; `set` with `--scope restricted` (body omits `shareRole`); `set` with `--scope anyone_in_space --role edit`; and that the leaf exposes `--scope`/`--role` (not the camelCase property names) with the aliases never leaking into the body.
- Full suite green (`go build ./... && go vet ./... && go test ./...`), `gofmt` clean.

## Related

- octo-docs #64 (space-scoped document share permissions)
- Depends on the docs-backend share endpoint (`feat/space-scoped-share-permissions`); enums/normalization/error codes are matched to that handler.

Draft — opened to carry review before it goes in.
