### PR TITLE
feat(html): add octo-doc HTML docs CLI domain (publish/versions/drafts/share/grants/assets/comments/element-edit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli html` domain** (20 operations) — an agent-facing CLI for the
+  octo-doc interactive-HTML document service, a **separate backend** from
+  `docs`. Covers the full lifecycle: `publish` immutable versions, `list` /
+  `get` / `versions` / `rm`, author `draft save|promote`, `share` / `unshare`
+  reader codes, per-uid `grant add|list|rm`, media `asset add|ls|rm`, inline
+  `comment list|add`, agent `element get|replace`, and `reply`. Generated from
+  the embedded `internal/registry/specs/html.json` OpenAPI spec; ships with the
+  `octo-html` skill and CLAUDE.md command-tree docs.
 - **`octo-cli docs share get|set`** — program the space-level share scope of a
   document. `docs share get <docId>` reads the current `{docId, shareScope,
   shareRole}` (needs reader); `docs share set <docId> --scope

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (8 domains, 77 operations / 80 commands incl. 3 matter transition aliases)
+## Command Structure (9 domains, 98 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -55,6 +55,14 @@ octo-cli docs      create | list | get | rename | delete | forward-grant
                comments list|add|edit|delete
                versions list|create|state|rename|delete|restore
                attachments presign|get|resolve
+octo-cli html      list | get | publish | versions | rm     (octo-doc HTML docs; distinct backend from `docs`)
+               draft    save|promote
+               share | unshare
+               grant    add|list|rm
+               asset    add|ls|rm
+               comment  list|add
+               element  get|replace
+               reply
 
 octo-cli auth      login | status | logout | list
 octo-cli schema [--list [domain] | <operation-id>]
@@ -66,7 +74,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 75 operations
-across 8 domains — is auto-registered at startup from OpenAPI 3.x specs
+octo-cli is **metadata-driven**. The entire command tree — 98 operations
+across 9 domains — is auto-registered at startup from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.
 
@@ -38,7 +38,8 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `docs`    | 28  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
+| `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
+| `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
@@ -135,6 +136,18 @@ octo-cli docs sheet edit sheet-9 --base-version "<token>" \
 octo-cli docs scene get board-7                       # elements (z-order) + files + base version token
 octo-cli docs scene edit board-7 --base-version "<token>" \
   --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
+
+# HTML docs (octo-doc) — a SEPARATE backend from `docs`. Publish self-contained
+# interactive HTML as immutable versions, then edit a single stamped artifact.
+octo-cli html publish --slug launch --html '<h1>hi</h1>' --mount-type group --group-no <group_no> \
+  --data '{"meta":{"title":"Launch page"}}'   # title lives in meta.title; slug+html required
+octo-cli html list
+octo-cli html versions my-slug
+octo-cli html draft save my-slug --data '{"html":"<h1>wip</h1>"}'   # then: html draft promote my-slug
+octo-cli html share my-slug                                        # mint a reader share code
+octo-cli html grant add my-slug --data '{"uid":"u-1"}'             # per-uid authorization
+octo-cli html element get --slug my-slug --aid <content-hash>      # read one stamped artifact (slug is a flag)
+octo-cli html element replace --slug my-slug --aid <content-hash> --new-html '<p>new</p>'
 
 # Discover the API — fully offline, specs are embedded.
 octo-cli schema --list              # all operations across all domains

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -10,7 +10,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "docs", "event", "file", "group", "matter", "message", "thread"}
+	want := []string{"bot", "docs", "event", "file", "group", "html", "matter", "message", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -42,6 +42,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"bot":     6,
 		"event":   2,
 		"docs":    31,
+		"html":    20,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -164,6 +165,7 @@ func TestServiceSpaceHeaderContract(t *testing.T) {
 		{"group", "group.create", false},
 		{"file", "file.upload", false},
 		{"event", "event.list", false},
+		{"html", "html.publish", false},
 	}
 	for _, c := range cases {
 		op, ok := r.GetOperation(c.opID)

--- a/internal/registry/specs/html.json
+++ b/internal/registry/specs/html.json
@@ -1,0 +1,573 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Octo HTML Docs API",
+    "version": "1.0.0",
+    "description": "Agent-facing surface for octo-doc — the self-hosted, prompt-native interactive HTML document service (distinct from the CRDT docs-backend behind the `docs` domain). Covers the document lifecycle (publish/list/get/versions/delete), author drafts, per-doc share codes, media assets, inline comments, and the agent element read/replace + reply paths. All paths are under the `/v1` prefix and return the `{data}/{error}` envelope."
+  },
+  "x-octo-service": "html",
+  "x-octo-base-url": "OCTO_API_BASE_URL",
+  "x-octo-space-header": false,
+  "paths": {
+    "/v1/docs": {
+      "get": {
+        "operationId": "html.list",
+        "summary": "List documents (owner-scoped index)",
+        "description": "Owner-scoped document index. The owner check is enforced server-side; a non-owner session is rejected 403.",
+        "x-octo-risk": "read",
+        "responses": {
+          "200": {
+            "description": "A list of documents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "slug": { "type": "string" },
+                      "title": { "type": "string" },
+                      "latest": { "type": "integer" },
+                      "updated": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "html.publish",
+        "summary": "Publish an HTML document (creates or bumps a version)",
+        "description": "Publish a self-contained HTML document under a slug. Requires the write token (Bearer). A new slug creates the document; an existing slug appends a new immutable version. The server stamps commentable artifacts and reconciles existing comment anchors.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["slug", "html"],
+                "properties": {
+                  "slug": { "type": "string", "description": "stable document slug" },
+                  "html": { "type": "string", "description": "the full self-contained HTML document body" },
+                  "version": { "type": "integer", "description": "optional explicit version; omit to auto-increment" },
+                  "meta": {
+                    "type": "object",
+                    "description": "optional metadata (e.g. {\"title\":\"...\"})",
+                    "properties": {
+                      "title": { "type": "string" }
+                    }
+                  },
+                  "mount_type": {
+                    "type": "string",
+                    "enum": ["group", "space", "thread"],
+                    "description": "where this doc is mounted; forwarded to docs-backend so the HTML doc is registered into the file sidebar. Omit to skip registration (default). 'group'/'space' register; 'thread' is accepted but not registered (thread mounts are intentionally skipped by the backend)."
+                  },
+                  "group_no": { "type": "string", "description": "group number; supply when mount_type=group" },
+                  "thread_id": { "type": "string", "description": "thread id when mount_type=thread (mount context only; thread mounts are not registered)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Publish result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": { "type": "string" },
+                    "version": { "type": "integer" },
+                    "url": { "type": "string" },
+                    "size": { "type": "integer" },
+                    "aids": { "type": "integer" },
+                    "merged_comments": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/docs/{slug}": {
+      "get": {
+        "operationId": "html.get",
+        "summary": "Fetch one document's metadata (needs reader)",
+        "description": "Return a single document's metadata (slug, title, latest version, timestamps). Backend endpoint GET /v1/docs/{slug} — added to octo-doc to back this command.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Document metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": { "type": "string" },
+                    "title": { "type": "string" },
+                    "latest": { "type": "integer" },
+                    "created": { "type": "string" },
+                    "updated": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "html.rm",
+        "summary": "Delete a document (author-only, soft delete)",
+        "description": "Soft-delete a document. Requires the write token / doc author credential.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Deleted" }
+        }
+      }
+    },
+    "/v1/docs/{slug}/versions": {
+      "get": {
+        "operationId": "html.versions",
+        "summary": "List a document's versions (needs reader)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Version list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "n": { "type": "integer" },
+                      "created": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/docs/{slug}/draft": {
+      "put": {
+        "operationId": "html.draft.save",
+        "summary": "Save the author draft (author-only)",
+        "description": "Write the author-only draft slot for a slug. Does not mint an immutable version until promoted.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["html"],
+                "properties": {
+                  "html": { "type": "string", "description": "the draft HTML body" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Draft saved" }
+        }
+      }
+    },
+    "/v1/docs/{slug}/draft/promote": {
+      "post": {
+        "operationId": "html.draft.promote",
+        "summary": "Promote the author draft to an immutable version (author-only)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Promoted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": { "type": "string" },
+                    "version": { "type": "integer" },
+                    "url": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/docs/{slug}/share": {
+      "post": {
+        "operationId": "html.share",
+        "summary": "Mint / rotate a per-doc read+comment share code (author-only)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Share code",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "string" },
+                    "url": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "html.unshare",
+        "summary": "Revoke the per-doc share code (author-only)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Revoked" }
+        }
+      }
+    },
+    "/v1/docs/{slug}/grants": {
+      "get": {
+        "operationId": "html.grant.list",
+        "summary": "List a document's per-uid access grants (author-only)",
+        "description": "List the uids granted access to this document and their role. Author-only (only the doc creator can view grants).",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Grant list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "uid": { "type": "string" },
+                      "role": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "html.grant.add",
+        "summary": "Grant a uid access to a document (author-only)",
+        "description": "Grant a specific uid access to this document (upsert by uid). role defaults to 'reader' (read published versions + comment/react). Only the doc creator (author) can grant. The granted uid resolves to a reader capability on subsequent requests — no share code needed.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["uid"],
+                "properties": {
+                  "uid": { "type": "string", "description": "the uid to grant access to" },
+                  "role": { "type": "string", "enum": ["reader"], "description": "capability to grant; defaults to 'reader' when omitted" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Grant added" }
+        }
+      }
+    },
+    "/v1/docs/{slug}/grants/{uid}": {
+      "delete": {
+        "operationId": "html.grant.rm",
+        "summary": "Revoke a uid's access grant (author-only)",
+        "description": "Revoke a uid's grant on this document. Author-only. The doc creator cannot be removed (they own the doc) — attempting to returns a conflict.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "uid", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Grant revoked" }
+        }
+      }
+    },
+    "/v1/docs/{slug}/assets": {
+      "get": {
+        "operationId": "html.asset.ls",
+        "summary": "List a document's media assets (needs reader)",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Asset list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "sha256": { "type": "string" },
+                      "name": { "type": "string" },
+                      "size": { "type": "integer" },
+                      "mime": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "html.asset.add",
+        "summary": "Upload a media asset to a document (author-only)",
+        "description": "Upload a media asset for a document via multipart/form-data (form field \"file\"). The asset is content-addressed (sha256); requires the write token / doc author credential.",
+        "x-octo-risk": "write",
+        "x-octo-multipart": true,
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file"],
+                "properties": {
+                  "file": { "type": "string", "format": "binary" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Asset registered",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "sha256": { "type": "string" },
+                    "url": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/docs/{slug}/assets/{sha256}": {
+      "delete": {
+        "operationId": "html.asset.rm",
+        "summary": "Delete a media asset (author-only)",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "sha256", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": { "description": "Deleted" }
+        }
+      }
+    },
+    "/v1/comments": {
+      "get": {
+        "operationId": "html.comment.list",
+        "summary": "List a document's comments (needs reader)",
+        "description": "List comments for a document. The slug is passed as a query parameter.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "slug", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "version", "in": "query", "schema": { "type": "string" }, "description": "version to fold to, or 'all'" }
+        ],
+        "responses": {
+          "200": { "description": "Comment list" }
+        }
+      },
+      "post": {
+        "operationId": "html.comment.add",
+        "summary": "Create a comment on a document (needs reader capability)",
+        "description": "Create a comment anchored to text or an artifact aid. Requires at least a reader capability (the doc's share code) or the write token.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["slug", "text"],
+                "properties": {
+                  "slug": { "type": "string" },
+                  "text": { "type": "string", "description": "comment body" },
+                  "anchor": {
+                    "type": "object",
+                    "description": "optional anchor (text or element by aid); omit for an unanchored comment"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Comment created" }
+        }
+      }
+    },
+    "/v1/agent/replies": {
+      "post": {
+        "operationId": "html.reply",
+        "summary": "Post an agent reply + verdict to a comment (write-token gated)",
+        "description": "Reply to a comment thread as the agent (identity odoc-agent) with an optional verdict: applied / partial / question. Requires the write token.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["slug", "parent_id", "text"],
+                "properties": {
+                  "slug": { "type": "string" },
+                  "parent_id": { "type": "string", "description": "the comment thread root id being replied to" },
+                  "text": { "type": "string", "description": "reply body" },
+                  "status": { "type": "string", "enum": ["applied", "partial", "question"], "description": "optional verdict rendered on the parent" },
+                  "applied_in": { "type": "integer", "description": "optional version the change was applied in" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Reply posted" }
+        }
+      }
+    },
+    "/v1/agent/element/get": {
+      "post": {
+        "operationId": "html.element.get",
+        "summary": "Read one artifact's outer HTML by aid (write-token gated)",
+        "description": "Return the outer HTML of a single artifact located by its stamped data-odoc-aid in a document version (version 0 = latest). Requires the write token.",
+        "x-octo-risk": "read",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["slug", "aid"],
+                "properties": {
+                  "slug": { "type": "string" },
+                  "version": { "type": "integer", "description": "version to read; 0 or omitted = latest" },
+                  "aid": { "type": "string", "description": "the artifact's stamped data-odoc-aid" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Element outer HTML",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "aid": { "type": "string" },
+                    "tag": { "type": "string" },
+                    "html": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/agent/element/replace": {
+      "post": {
+        "operationId": "html.element.replace",
+        "summary": "Replace one artifact's outer HTML by aid and republish (write-token gated)",
+        "description": "Swap one artifact's outer HTML (located by aid in base_version, 0 = latest) with new_html and republish a new version. new_html must be exactly one top-level element and free of scripts / inline event handlers / javascript: URLs. Requires the write token.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["slug", "aid", "new_html"],
+                "properties": {
+                  "slug": { "type": "string" },
+                  "base_version": { "type": "integer", "description": "version whose aid to locate; 0 or omitted = latest" },
+                  "aid": { "type": "string", "description": "the artifact's stamped data-odoc-aid" },
+                  "new_html": { "type": "string", "description": "replacement single top-level element" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Replaced + republished",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "slug": { "type": "string" },
+                    "version": { "type": "integer" },
+                    "url": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/octo-html/SKILL.md
+++ b/skills/octo-html/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: octo-html
+version: 0.1.0
+description: HTML docs domain (octo-doc) — publish and govern self-contained interactive HTML documents, list/get/versions, author drafts, per-doc share codes, media assets, inline comments, and the agent element read/replace + reply paths. This is a DIFFERENT backend from the `octo-docs` (CRDT/Yjs) domain. Load after octo-shared.
+metadata:
+  requires:
+    bins: ["octo-cli"]
+    skills: ["octo-shared"]
+---
+
+# octo-html — HTML documents (octo-doc): publish, versions, drafts, share, assets, comments, agent element edit
+
+> **This is NOT the `octo-docs` domain.** `octo-cli docs …` talks to the CRDT/Yjs
+> collaborative docs-backend (live rich-text/sheet/board over websockets).
+> `octo-cli html …` talks to **octo-doc** — the self-hosted, prompt-native
+> *interactive HTML document* service. A doc here is a full self-contained HTML
+> page, published as an **immutable version** at `/d/<slug>/v/<n>`, with anchored
+> inline comments. An agent authors by publishing HTML, and edits by **replacing a
+> single stamped artifact** (located by its content-hash `aid`) which republishes
+> a new version. Pick the domain that matches the backend you are pointed at.
+
+All commands call `$OCTO_API_BASE_URL/v1/*` and return the `{data}/{error}` envelope.
+
+## Auth & space
+
+- Authenticate with a bot token via a stored profile (`--profile` / `--bot-id`)
+  or `OCTO_BOT_TOKEN`, sent as `Authorization: Bearer`. Confirm with
+  `octo-cli config show`.
+- **Do not pass a space flag.** octo-doc resolves identity/space server-side
+  (via the reverse-proxy trust headers on the fusion deploy); the CLI does not
+  send a client space header.
+- Write operations (`publish`, `draft`, `share`, `rm`, `asset add/rm`, `reply`,
+  `element replace`) require the author/write capability. Reads (`list`, `get`,
+  `versions`, `asset ls`, `comment list`, `element get`) need at least a reader
+  capability (the doc's share code) — the CLI surfaces the backend's 401/403
+  envelopes unchanged.
+
+## 1. Document lifecycle
+
+```bash
+# Publish a self-contained HTML document under a slug. New slug = create;
+# existing slug = append a new immutable version. --data is a JSON object.
+# mount_type is OPTIONAL in the spec but STRONGLY RECOMMENDED (see the
+# sidebar-registration note below); include it on every publish that should
+# appear in the file sidebar.
+octo-cli html publish --data '{"slug":"runbook","html":"<html><body><h1>Runbook</h1></body></html>","meta":{"title":"Runbook"},"mount_type":"group","group_no":"<group_no>"}'
+#   → { slug, version, url, size, aids, merged_comments }
+
+# Register the doc into the file sidebar: pass mount_type (non-empty) on every
+# publish that should be visible there. Omitting it is valid per the spec, but
+# WITHOUT mount_type the backend skips docs-backend registration, so the HTML
+# never shows up in the sidebar file list — this is the #1 "my doc didn't
+# appear" gotcha. Pass 'group' (+ group_no) or 'space'; 'thread' is accepted but
+# intentionally NOT registered. If you want sidebar visibility, treat a
+# missing/empty mount_type as the cause, not a valid default.
+octo-cli html publish --data '{"slug":"runbook","html":"<html>...</html>","meta":{"title":"Runbook"},"mount_type":"group","group_no":"<group_no>"}'
+
+# List documents (owner-scoped index).
+octo-cli html list
+
+# Fetch one document's metadata (slug, title, latest version, timestamps).
+octo-cli html get <slug>
+
+# List a document's versions.
+octo-cli html versions <slug>
+
+# Soft-delete a document (author-only).
+octo-cli html rm <slug>
+```
+
+## 2. Author drafts
+
+A draft is the author-only working slot; it does not mint an immutable version
+until promoted.
+
+```bash
+# Save the draft HTML.
+octo-cli html draft save <slug> --data '{"html":"<html><body><h1>WIP</h1></body></html>"}'
+
+# Promote the draft to an immutable version.
+octo-cli html draft promote <slug>          # → { slug, version, url }
+```
+
+## 3. Sharing
+
+```bash
+# Mint / rotate the per-doc read+comment share code (author-only).
+octo-cli html share <slug>                   # → { code, url }
+
+# Revoke the share code.
+octo-cli html unshare <slug>
+```
+
+## 3b. Per-uid access grants (author-only)
+
+Grant a SPECIFIC uid reader access — precise, per-user authorization, unlike the
+share code (which is a bearer secret anyone holding can use). A granted uid
+resolves to a reader capability on subsequent requests with NO share code needed;
+this is how an author lets a named bot/user read+comment a private doc. All three
+are author-only (only the doc creator can grant/revoke/list).
+
+```bash
+# Grant a uid reader access (upsert by uid). role defaults to 'reader'.
+# Either individual flags or --data JSON work; flags override --data.
+octo-cli html grant add <slug> --uid <uid> --role reader
+octo-cli html grant add <slug> --data '{"uid":"<uid>","role":"reader"}'
+#   → { slug, uid, role }
+
+# List a doc's grants (uid + role).
+octo-cli html grant list <slug>
+
+# Revoke a uid's grant. The creator cannot be removed (409 conflict).
+octo-cli html grant rm <slug> <uid>
+```
+
+## 4. Media assets
+
+```bash
+# List a document's assets (reader).
+octo-cli html asset ls <slug>
+
+# Upload an asset (author). Multipart form-data (field "file"); pass a local path.
+octo-cli html asset add <slug> --file ./chart.png
+
+# Delete an asset by its sha256 (author).
+octo-cli html asset rm <slug> <sha256>
+```
+
+## 5. Comments
+
+Comments anchor to highlighted text or to a stamped artifact (by `aid`). They
+survive edits and re-anchor across versions; an artifact that is genuinely
+replaced goes `lost` rather than silently re-attaching.
+
+```bash
+# List a document's comments. --version accepts a number or 'all'.
+octo-cli html comment list --slug <slug> [--version all]
+
+# Create a comment. Omit anchor for an unanchored comment.
+octo-cli html comment add --data '{"slug":"runbook","text":"Please clarify this","anchor":{"kind":"element","aid":"<content-hash>"}}'
+```
+
+## 6. Agent element edit (read / replace) + reply
+
+This is the core "agent edits the HTML" path. An agent reads one artifact by its
+stamped `data-odoc-aid`, replaces it, and the server republishes a new version
+(re-stamping aids and reconciling comment anchors).
+
+```bash
+# Read one artifact's current outer HTML by aid (version 0 or omitted = latest).
+octo-cli html element get --data '{"slug":"runbook","aid":"<content-hash>"}'
+#   → { aid, tag, html }
+
+# Replace that artifact and republish. new_html MUST be exactly ONE top-level
+# element and free of <script>/<style>, inline on*= handlers, and javascript:
+# URLs (the backend rejects otherwise). base_version 0/omitted = latest.
+octo-cli html element replace --data '{"slug":"runbook","aid":"<content-hash>","new_html":"<section>updated body</section>"}'
+#   → { slug, version, url }
+
+# Reply to a comment thread as the agent (identity odoc-agent) with a verdict.
+# status ∈ applied | partial | question (rendered as ✅/🟡/❓ on the parent).
+octo-cli html reply --data '{"slug":"runbook","parent_id":"<comment-root-id>","text":"Done, updated the section.","status":"applied"}'
+```
+
+**Editing discipline (keep comment anchors alive).** Each `element replace`
+republishes and re-stamps every aid, then reconciles anchors. To minimise
+comments going `lost`: change an element's *content* only, avoid changing its tag
+type or the nearest heading, and prefer narrow single-artifact edits over broad
+rewrites.
+
+## Errors
+
+The CLI surfaces the backend envelope unchanged. Common cases:
+- `401 / 403` — missing or insufficient capability (need write token / share code).
+- `404` — slug or aid not found.
+- element replace rejects a fragment that is not exactly one safe top-level
+  element (multi-element, `<script>`, `on*=`, `javascript:`).
+
+## Schema lookup
+
+```bash
+octo-cli schema --list html
+octo-cli schema html.publish
+octo-cli schema html.element.replace
+octo-cli schema html.reply
+```


### PR DESCRIPTION
## What
新增 octo-doc HTML 文档域的 CLI 支持(与现有 CRDT 的 `docs` 域不同后端):
- 文档生命周期:publish / list / get / versions / rm
- 作者草稿:draft save / promote
- 分享:share / unshare + 按 uid 授权 grant add/list/rm
- 媒体资源:asset ls/add/rm
- 评论 + agent 元素编辑:comment、element get/replace、reply

## Files
- `internal/registry/specs/html.json` — html 域 OpenAPI spec(20 ops,base URL 走 `OCTO_API_BASE_URL` 环境变量,无硬编码)
- `skills/octo-html/SKILL.md` — 新 skill 文档
- `skills/octo-docs/*` 重组、`cmd/skills.go` 等适配

## Verification
- `go build ./...` ✅
- `go test ./...` 全绿 ✅
- `golangci-lint run ./...`(v2.12.2,与 CI 同版)0 issues ✅
- 已 rebase 到上游最新 main,linear history,无冲突

## 部署前提 / 必配环境变量
- `OCTO_API_BASE_URL` — html 域所有请求的 base(spec 里以此环境变量名声明,不配则无默认地址)
- `OCTO_BOT_TOKEN`(或 `--profile`/`--bot-id` 的存储 profile)— Bearer 认证;写操作必需
