### PR TITLE
feat: install Skills from Octo Marketplace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ octo-cli docs      create | list | get | rename | delete | forward-grant
                attachments presign|get|resolve
 
 octo-cli auth      login | status | logout | list
+octo-cli marketplace skills <skill-id> --install <skills-root>  (top-level alias: market)
 octo-cli schema [--list [domain] | <operation-id>]
 octo-cli api <METHOD> <PATH> [--params ...] [--data ...] [--service ...]
 octo-cli config show
@@ -63,7 +64,7 @@ octo-cli completion bash|zsh|fish|powershell
 octo-cli version
 ```
 
-`octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
+`octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. Per-environment profiles may store `--api-base-url`; explicit environment variables still win. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
 Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`) — keep those in sync when command shapes change.
 
@@ -75,6 +76,7 @@ Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agen
 | `OCTO_BOT_ID`       | Robot id selecting a stored profile (env form of `--bot-id`). Selector, not a secret. |
 | `OCTO_CONFIG_DIR`   | Override the credential dir (default `~/.octo-cli`).     |
 | `OCTO_API_BASE_URL`  | Unified API base URL for all services. Required.          |
+| `OCTO_MARKETPLACE_API_PREFIX` | Marketplace gateway prefix on the same host (default `/market`; empty means direct `/api/v1`). |
 | `OCTO_SPACE_ID`     | Space context for platform-scoped bots.                  |
 | `OCTO_FORMAT`       | Default output format (`json` | `table` | `csv` | `ndjson`). |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 
 ## Command Structure (8 domains, 75 operations / 78 commands incl. 3 matter transition aliases)
 
-Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
+Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, `marketplace`, and the cobra-generated `completion`.
 
 > **`matter` is temporarily withheld** (backend API not yet stable). The spec
 > stays embedded — `octo-cli schema matter.*` still introspects it — but the command

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -72,14 +72,15 @@ func newConfigShowCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			payload := map[string]any{
-				"api_base_url":     cfg.APIBaseURL,
-				"space_id":         nullableString(space),
-				"format":           cfg.Format,
-				"bot_token":        maskToken(token),
-				"bot_token_source": nullableString(source),
-				"bot_kind":         botKind(token),
-				"profile":          nullableString(profileName),
-				"robot_id":         nullableString(robotID),
+				"api_base_url":           cfg.APIBaseURL,
+				"marketplace_api_prefix": cfg.MarketplaceAPIPrefix,
+				"space_id":               nullableString(space),
+				"format":                 cfg.Format,
+				"bot_token":              maskToken(token),
+				"bot_token_source":       nullableString(source),
+				"bot_kind":               botKind(token),
+				"profile":                nullableString(profileName),
+				"robot_id":               nullableString(robotID),
 			}
 			raw, err := json.Marshal(payload)
 			if err != nil {

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -47,7 +47,12 @@ func newMarketplaceSkillCmd(f *cmdutil.Factory) *cobra.Command {
 			if err != nil {
 				return emitMarketplaceError(f, err)
 			}
-			client := marketplace.NewClient(api, &http.Client{Timeout: 30 * time.Second})
+			client := marketplace.NewClient(api, &http.Client{
+				Timeout: 30 * time.Second,
+				CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			})
 			skill, err := client.GetSkill(cmd.Context(), args[0])
 			if err != nil {
 				return emitMarketplaceError(f, err)

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
+	"github.com/Mininglamp-OSS/octo-cli/internal/marketplace"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+	"github.com/Mininglamp-OSS/octo-cli/internal/skillinstall"
+)
+
+func newMarketplaceCmd(f *cmdutil.Factory) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "marketplace",
+		Aliases: []string{"market"},
+		Short:   "Install agent resources from Octo Marketplace",
+	}
+	cmd.AddCommand(newMarketplaceSkillCmd(f))
+	return cmd
+}
+
+func newMarketplaceSkillCmd(f *cmdutil.Factory) *cobra.Command {
+	var installRoot string
+	cmd := &cobra.Command{
+		Use:   "skills <skill-id>",
+		Short: "Download and install one skill from Octo Marketplace",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(installRoot) == "" {
+				return emitMarketplaceError(f, output.ErrValidation("--install is required", "pass the agent skills root, for example --install ~/.codex/skills"))
+			}
+			cred, err := f.Credential()
+			if err != nil {
+				return emitMarketplaceError(f, err)
+			}
+			if credential.TokenKind(cred.Token) != "user_bot" {
+				return emitMarketplaceError(f, output.ErrAuth("marketplace skill installation requires a bf_* User Bot token", "select a User Bot profile or set OCTO_BOT_TOKEN to a bf_* token"))
+			}
+			api, err := f.Client()
+			if err != nil {
+				return emitMarketplaceError(f, err)
+			}
+			client := marketplace.NewClient(api, &http.Client{Timeout: 30 * time.Second})
+			skill, err := client.GetSkill(cmd.Context(), args[0])
+			if err != nil {
+				return emitMarketplaceError(f, err)
+			}
+			archive, err := client.DownloadSkill(cmd.Context(), args[0])
+			if err != nil {
+				return emitMarketplaceError(f, err)
+			}
+			installed, err := skillinstall.Install(installRoot, skill.Name, archive, skill.FileSHA256)
+			if err != nil {
+				return emitMarketplaceError(f, output.ErrValidation(fmt.Sprintf("install skill: %v", err), "verify the marketplace archive and target directory"))
+			}
+			payload, err := json.Marshal(map[string]any{
+				"source":       "marketplace",
+				"id":           skill.ID,
+				"name":         skill.Name,
+				"installed_to": installed.InstalledTo,
+				"sha256":       skill.FileSHA256,
+				"files":        installed.Files,
+			})
+			if err != nil {
+				return emitMarketplaceError(f, err)
+			}
+			return f.EmitSuccess(payload)
+		},
+	}
+	cmd.Flags().StringVar(&installRoot, "install", "", "install into this agent skills root")
+	return cmd
+}
+
+func emitMarketplaceError(f *cmdutil.Factory, err error) error {
+	_ = f.EmitError(err)
+	return err
+}

--- a/cmd/marketplace.go
+++ b/cmd/marketplace.go
@@ -67,7 +67,7 @@ func newMarketplaceSkillCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			payload, err := json.Marshal(map[string]any{
 				"source":       "marketplace",
-				"id":           skill.ID,
+				"skill_id":     skill.ID,
 				"name":         skill.Name,
 				"installed_to": installed.InstalledTo,
 				"sha256":       skill.FileSHA256,

--- a/cmd/marketplace_test.go
+++ b/cmd/marketplace_test.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,14 +43,14 @@ func TestMarketplaceSkillInstallAndAlias(t *testing.T) {
 	archive, digest := marketplaceArchive(t)
 	var gotAuth string
 	var srv *httptest.Server
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/gateway/api/v1/skill/skill-1":
+		case "/gateway/api/v1/skills/skill-1":
 			gotAuth = r.Header.Get("Authorization")
-			_, _ = w.Write([]byte(`{"code":0,"data":{"id":"skill-1","name":"demo","file_sha256":"` + digest + `"}}`))
-		case "/gateway/api/v1/skill/skill-1/download":
+			_, _ = w.Write([]byte(`{"data":{"skill_id":"skill-1","name":"demo","file_sha256":"` + digest + `"}}`))
+		case "/gateway/api/v1/skills/skill-1/download":
 			gotAuth = r.Header.Get("Authorization")
-			http.Redirect(w, r, srv.URL+"/artifact/demo.zip", http.StatusFound)
+			http.Redirect(w, r, "https://93.184.216.34/artifact/demo.zip", http.StatusFound)
 		case "/artifact/demo.zip":
 			_, _ = w.Write(archive)
 		default:
@@ -55,6 +58,19 @@ func TestMarketplaceSkillInstallAndAlias(t *testing.T) {
 		}
 	}))
 	defer srv.Close()
+
+	serverURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := srv.Client().Transport.(*http.Transport).Clone()
+	transport.TLSClientConfig.ServerName = "127.0.0.1"
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, serverURL.Host)
+	}
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = transport
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
 
 	f := newTestFactoryWithReg()
 	cfg := &config.Config{APIBaseURL: srv.URL + "/normal-api", MarketplaceAPIPrefix: "/gateway/api/v1", BotToken: "bf_test", Format: "json"}
@@ -70,7 +86,7 @@ func TestMarketplaceSkillInstallAndAlias(t *testing.T) {
 	if gotAuth != "Bearer bf_test" {
 		t.Fatalf("Authorization = %q", gotAuth)
 	}
-	if !strings.Contains(out, `"source": "marketplace"`) {
+	if !strings.Contains(out, `"source": "marketplace"`) || !strings.Contains(out, `"skill_id": "skill-1"`) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 	if _, err := os.Stat(filepath.Join(root, "demo", "SKILL.md")); err != nil {

--- a/cmd/marketplace_test.go
+++ b/cmd/marketplace_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	apiClient "github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
+)
+
+func marketplaceArchive(t *testing.T) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	body := []byte("---\nname: demo\n---\n")
+	w, err := zw.Create("SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}
+
+func TestMarketplaceSkillInstallAndAlias(t *testing.T) {
+	archive, digest := marketplaceArchive(t)
+	var gotAuth string
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/gateway/api/v1/skill/skill-1":
+			gotAuth = r.Header.Get("Authorization")
+			_, _ = w.Write([]byte(`{"code":0,"data":{"id":"skill-1","name":"demo","file_sha256":"` + digest + `"}}`))
+		case "/gateway/api/v1/skill/skill-1/download":
+			gotAuth = r.Header.Get("Authorization")
+			http.Redirect(w, r, srv.URL+"/artifact/demo.zip", http.StatusFound)
+		case "/artifact/demo.zip":
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	f := newTestFactoryWithReg()
+	cfg := &config.Config{APIBaseURL: srv.URL + "/normal-api", MarketplaceAPIPrefix: "/gateway/api/v1", BotToken: "bf_test", Format: "json"}
+	cred := &credential.BotCredential{Token: "bf_test", Source: "test"}
+	f.SetConfig(cfg)
+	f.SetCredential(cred)
+	f.SetClient(apiClient.New(cfg, cred, apiClient.Options{NoRetry: true, ErrOut: f.ErrOut}))
+	root := t.TempDir()
+	out, errOut, err := execRoot(t, f, "market", "skills", "skill-1", "--install", root)
+	if err != nil {
+		t.Fatalf("install: %v\n%s", err, errOut)
+	}
+	if gotAuth != "Bearer bf_test" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.Contains(out, `"source": "marketplace"`) {
+		t.Fatalf("unexpected output: %s", out)
+	}
+	if _, err := os.Stat(filepath.Join(root, "demo", "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md not installed: %v", err)
+	}
+}
+
+func TestMarketplaceSkillRequiresInstall(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{BotToken: "bf_test", Format: "json"})
+	f.SetCredential(&credential.BotCredential{Token: "bf_test"})
+	_, errOut, err := execRoot(t, f, "marketplace", "skills", "demo")
+	if err == nil || !strings.Contains(errOut, "--install is required") {
+		t.Fatalf("error = %v, stderr = %s", err, errOut)
+	}
+}
+
+func TestMarketplaceSkillRejectsAppBot(t *testing.T) {
+	f := newTestFactoryWithReg()
+	f.SetConfig(&config.Config{BotToken: "app_test", Format: "json"})
+	f.SetCredential(&credential.BotCredential{Token: "app_test"})
+	_, errOut, err := execRoot(t, f, "marketplace", "skills", "demo", "--install", t.TempDir())
+	if err == nil || !strings.Contains(errOut, "bf_*") {
+		t.Fatalf("error = %v, stderr = %s", err, errOut)
+	}
+}
+
+func TestMarketplaceCommandAlias(t *testing.T) {
+	f := newTestFactoryWithReg()
+	root := NewRootCmd(f.Factory)
+	marketplaceCmd, _, err := root.Find([]string{"market", "skills"})
+	if err != nil {
+		t.Fatalf("find alias: %v", err)
+	}
+	if marketplaceCmd.Name() != "skills" {
+		t.Fatalf("alias resolved to %q, want skills", marketplaceCmd.Name())
+	}
+}
+
+func TestMarketplaceRejectsSingularSkillCommand(t *testing.T) {
+	f := newTestFactoryWithReg()
+	root := NewRootCmd(f.Factory)
+	marketplaceCmd, _, err := root.Find([]string{"marketplace"})
+	if err != nil {
+		t.Fatalf("find marketplace: %v", err)
+	}
+	for _, command := range marketplaceCmd.Commands() {
+		if command.Name() == "skill" || command.HasAlias("skill") {
+			t.Fatal("singular skill command must not be registered")
+		}
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,6 +52,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	root.AddCommand(newAPICmd(f))
 	root.AddCommand(newConfigCmd(f))
 	root.AddCommand(newSkillsCmd(f))
+	root.AddCommand(newMarketplaceCmd(f))
 	root.AddCommand(newAuthCmd(f))
 	root.AddCommand(newSheetCellCmd(f))
 	service.RegisterServiceCommands(root, f)

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -203,10 +203,10 @@ func (f *Factory) AuthStore() (*authstore.Store, error) {
 	return s, nil
 }
 
-// overlayProfileBaseURL fills cfg.APIBaseURL from the active profile's metadata,
-// but only when OCTO_API_BASE_URL is not explicitly set (env wins for the URL).
+// overlayProfileBaseURL fills the unified API URL from the active profile's
+// metadata. An explicit environment variable wins over the profile value.
 func (f *Factory) overlayProfileBaseURL(cfg *config.Config, profile string) {
-	if profile == "" || os.Getenv(config.EnvAPIBaseURL) != "" {
+	if profile == "" {
 		return
 	}
 	store, err := f.AuthStore()
@@ -217,8 +217,10 @@ func (f *Factory) overlayProfileBaseURL(cfg *config.Config, profile string) {
 	if err != nil {
 		return
 	}
-	if m, ok := profiles[profile]; ok && m.APIBaseURL != "" {
-		cfg.APIBaseURL = m.APIBaseURL
+	if m, ok := profiles[profile]; ok {
+		if os.Getenv(config.EnvAPIBaseURL) == "" && m.APIBaseURL != "" {
+			cfg.APIBaseURL = m.APIBaseURL
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,15 +5,18 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 )
 
 // Environment variable names. Centralised for testability and discoverability.
 const (
-	EnvAPIBaseURL = "OCTO_API_BASE_URL"
-	EnvBotToken   = "OCTO_BOT_TOKEN"
-	EnvSpaceID    = "OCTO_SPACE_ID"
-	EnvFormat     = "OCTO_FORMAT"
+	EnvAPIBaseURL           = "OCTO_API_BASE_URL"
+	EnvMarketplaceAPIPrefix = "OCTO_MARKETPLACE_API_PREFIX"
+	EnvBotToken             = "OCTO_BOT_TOKEN"
+	EnvSpaceID              = "OCTO_SPACE_ID"
+	EnvFormat               = "OCTO_FORMAT"
 	// EnvBotID is the env form of --bot-id: a robot id that selects a stored
 	// credential profile. It is a selector, not a secret (cf. EnvBotToken).
 	EnvBotID = "OCTO_BOT_ID"
@@ -27,6 +30,8 @@ type Config struct {
 	// APIBaseURL is the unified base URL for all backend services.
 	// Set via OCTO_API_BASE_URL.
 	APIBaseURL string
+	// MarketplaceAPIPrefix is inserted before Marketplace API paths.
+	MarketplaceAPIPrefix string
 	// BotToken is the App Bot token (OCTO_BOT_TOKEN).
 	BotToken string
 	// SpaceID is the platform-bot space context (OCTO_SPACE_ID). Optional for space-scoped bots.
@@ -38,10 +43,11 @@ type Config struct {
 // Load reads configuration from the environment.
 func Load() *Config {
 	return &Config{
-		APIBaseURL: envOrDefault(EnvAPIBaseURL, "http://127.0.0.1:8080"),
-		BotToken:   os.Getenv(EnvBotToken),
-		SpaceID:    os.Getenv(EnvSpaceID),
-		Format:     envOrDefault(EnvFormat, "json"),
+		APIBaseURL:           envOrDefault(EnvAPIBaseURL, "http://127.0.0.1:8080"),
+		MarketplaceAPIPrefix: marketplaceAPIRoot(),
+		BotToken:             os.Getenv(EnvBotToken),
+		SpaceID:              os.Getenv(EnvSpaceID),
+		Format:               envOrDefault(EnvFormat, "json"),
 	}
 }
 
@@ -60,7 +66,41 @@ func (c *Config) Validate() error {
 // for interface compatibility so the client and service engine don't need
 // to change their routing logic.
 func (c *Config) ServiceURL(service string) string {
+	if service == "marketplace" {
+		u, err := url.Parse(c.APIBaseURL)
+		if err != nil || u.Scheme == "" || u.Host == "" {
+			return c.APIBaseURL
+		}
+		u.Path = c.MarketplaceAPIPrefix
+		u.RawPath = ""
+		u.RawQuery = ""
+		u.Fragment = ""
+		return strings.TrimRight(u.String(), "/")
+	}
 	return c.APIBaseURL
+}
+
+func normalizePathPrefix(value string) string {
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	if value == "" {
+		return ""
+	}
+	return "/" + value
+}
+
+func marketplaceAPIRoot() string {
+	value, configured := os.LookupEnv(EnvMarketplaceAPIPrefix)
+	if !configured {
+		return "/market/api/v1"
+	}
+	prefix := normalizePathPrefix(value)
+	if prefix == "" {
+		return "/api/v1"
+	}
+	if strings.HasSuffix(prefix, "/api/v1") {
+		return prefix
+	}
+	return prefix + "/api/v1"
 }
 
 func envOrDefault(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 )
 
@@ -21,12 +22,19 @@ func TestValidate_OK(t *testing.T) {
 func TestLoad_Defaults(t *testing.T) {
 	t.Setenv(EnvBotToken, "")
 	t.Setenv(EnvAPIBaseURL, "")
+	t.Setenv(EnvMarketplaceAPIPrefix, "temporary")
+	if err := os.Unsetenv(EnvMarketplaceAPIPrefix); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv(EnvFormat, "")
 	t.Setenv(EnvSpaceID, "")
 
 	cfg := Load()
 	if cfg.APIBaseURL != "http://127.0.0.1:8080" {
 		t.Errorf("APIBaseURL = %q, want default", cfg.APIBaseURL)
+	}
+	if cfg.MarketplaceAPIPrefix != "/market/api/v1" {
+		t.Errorf("MarketplaceAPIPrefix = %q, want /market/api/v1", cfg.MarketplaceAPIPrefix)
 	}
 	if cfg.Format != "json" {
 		t.Errorf("Format = %q, want json", cfg.Format)
@@ -35,6 +43,7 @@ func TestLoad_Defaults(t *testing.T) {
 
 func TestLoad_ReadsAllEnvVars(t *testing.T) {
 	t.Setenv(EnvAPIBaseURL, "http://api.example")
+	t.Setenv(EnvMarketplaceAPIPrefix, "/marketplace/")
 	t.Setenv(EnvBotToken, "app_xxx")
 	t.Setenv(EnvSpaceID, "space-1")
 	t.Setenv(EnvFormat, "table")
@@ -42,6 +51,9 @@ func TestLoad_ReadsAllEnvVars(t *testing.T) {
 	cfg := Load()
 	if cfg.APIBaseURL != "http://api.example" {
 		t.Errorf("APIBaseURL = %q", cfg.APIBaseURL)
+	}
+	if cfg.MarketplaceAPIPrefix != "/marketplace/api/v1" {
+		t.Errorf("MarketplaceAPIPrefix = %q", cfg.MarketplaceAPIPrefix)
 	}
 	if cfg.BotToken != "app_xxx" {
 		t.Errorf("BotToken = %q", cfg.BotToken)
@@ -54,12 +66,22 @@ func TestLoad_ReadsAllEnvVars(t *testing.T) {
 	}
 }
 
+func TestLoad_EmptyMarketplacePrefixUsesNativeAPIRoot(t *testing.T) {
+	t.Setenv(EnvMarketplaceAPIPrefix, "")
+	if got := Load().MarketplaceAPIPrefix; got != "/api/v1" {
+		t.Fatalf("MarketplaceAPIPrefix = %q", got)
+	}
+}
+
 func TestServiceURL_Unified(t *testing.T) {
-	cfg := &Config{APIBaseURL: "http://api.example"}
+	cfg := &Config{APIBaseURL: "http://api.example/api", MarketplaceAPIPrefix: "/market/api/v1"}
 	// All services should return the same API base URL.
 	for _, svc := range []string{"matters", "dmworkim", "unknown", ""} {
-		if got := cfg.ServiceURL(svc); got != "http://api.example" {
+		if got := cfg.ServiceURL(svc); got != "http://api.example/api" {
 			t.Errorf("ServiceURL(%q) = %q, want API base URL", svc, got)
 		}
+	}
+	if got := cfg.ServiceURL("marketplace"); got != "http://api.example/market/api/v1" {
+		t.Errorf("ServiceURL(marketplace) = %q", got)
 	}
 }

--- a/internal/marketplace/client.go
+++ b/internal/marketplace/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -13,6 +14,7 @@ import (
 )
 
 const MaxArchiveBytes int64 = 64 << 20
+const maxErrorBodyBytes int64 = 4 << 10
 
 type APIClient interface {
 	Do(context.Context, *apiClient.Request) ([]byte, error)
@@ -70,6 +72,9 @@ func (c *Client) DownloadSkill(ctx context.Context, id string) ([]byte, error) {
 	if err := json.Unmarshal(body, &redirect); err != nil || redirect.URL == "" {
 		return nil, output.ErrAPI("INVALID_RESPONSE", "marketplace download response is missing a URL", "retry or contact the marketplace operator")
 	}
+	if err := validateDownloadURL(ctx, redirect.URL); err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirect.URL, nil)
 	if err != nil {
 		return nil, output.ErrAPI("INVALID_RESPONSE", "marketplace returned an invalid download URL", "contact the marketplace operator")
@@ -79,15 +84,45 @@ func (c *Client) DownloadSkill(ctx context.Context, id string) ([]byte, error) {
 		return nil, output.ErrNetwork(fmt.Sprintf("download skill archive: %v", err), "retry the download")
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		errorBody, readErr := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		if readErr != nil {
+			return nil, output.ErrNetwork(fmt.Sprintf("read skill download error response: %v", readErr), "retry the download")
+		}
+		return nil, output.ParseBackendError(resp.StatusCode, errorBody)
+	}
 	body, err = io.ReadAll(io.LimitReader(resp.Body, MaxArchiveBytes+1))
 	if err != nil {
 		return nil, output.ErrNetwork(fmt.Sprintf("read skill archive: %v", err), "retry the download")
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, output.ParseBackendError(resp.StatusCode, body)
 	}
 	if int64(len(body)) > MaxArchiveBytes {
 		return nil, output.ErrValidation("skill archive exceeds download limit", "reduce the skill archive below 64 MiB")
 	}
 	return body, nil
+}
+
+func validateDownloadURL(ctx context.Context, rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Hostname() == "" {
+		return output.ErrValidation("marketplace download URL must use https", "contact the marketplace operator")
+	}
+
+	var addresses []net.IP
+	if literal := net.ParseIP(parsed.Hostname()); literal != nil {
+		addresses = []net.IP{literal}
+	} else {
+		resolved, err := net.DefaultResolver.LookupIPAddr(ctx, parsed.Hostname())
+		if err != nil {
+			return output.ErrNetwork(fmt.Sprintf("resolve marketplace download host: %v", err), "retry the download")
+		}
+		for _, address := range resolved {
+			addresses = append(addresses, address.IP)
+		}
+	}
+	for _, address := range addresses {
+		if address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() || address.IsUnspecified() {
+			return output.ErrValidation("marketplace download URL resolves to a private or local address", "contact the marketplace operator")
+		}
+	}
+	return nil
 }

--- a/internal/marketplace/client.go
+++ b/internal/marketplace/client.go
@@ -1,0 +1,93 @@
+package marketplace
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	apiClient "github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+const MaxArchiveBytes int64 = 64 << 20
+
+type APIClient interface {
+	Do(context.Context, *apiClient.Request) ([]byte, error)
+}
+
+type Skill struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	FileSHA256 string `json:"file_sha256"`
+}
+
+type Client struct {
+	api  APIClient
+	http *http.Client
+}
+
+func NewClient(api APIClient, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &Client{api: api, http: httpClient}
+}
+
+func (c *Client) GetSkill(ctx context.Context, id string) (Skill, error) {
+	body, err := c.api.Do(ctx, &apiClient.Request{
+		Service: "marketplace",
+		Method:  http.MethodGet,
+		Path:    "/skill/" + url.PathEscape(id),
+	})
+	if err != nil {
+		return Skill{}, err
+	}
+	var envelope struct {
+		Data Skill `json:"data"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope.Data.ID == "" || envelope.Data.Name == "" || envelope.Data.FileSHA256 == "" {
+		return Skill{}, output.ErrAPI("INVALID_RESPONSE", "marketplace skill metadata is incomplete", "retry or contact the marketplace operator")
+	}
+	return envelope.Data, nil
+}
+
+func (c *Client) DownloadSkill(ctx context.Context, id string) ([]byte, error) {
+	body, err := c.api.Do(ctx, &apiClient.Request{
+		Service:        "marketplace",
+		Method:         http.MethodGet,
+		Path:           "/skill/" + url.PathEscape(id) + "/download",
+		BinaryResponse: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var redirect struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(body, &redirect); err != nil || redirect.URL == "" {
+		return nil, output.ErrAPI("INVALID_RESPONSE", "marketplace download response is missing a URL", "retry or contact the marketplace operator")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, redirect.URL, nil)
+	if err != nil {
+		return nil, output.ErrAPI("INVALID_RESPONSE", "marketplace returned an invalid download URL", "contact the marketplace operator")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, output.ErrNetwork(fmt.Sprintf("download skill archive: %v", err), "retry the download")
+	}
+	defer resp.Body.Close()
+	body, err = io.ReadAll(io.LimitReader(resp.Body, MaxArchiveBytes+1))
+	if err != nil {
+		return nil, output.ErrNetwork(fmt.Sprintf("read skill archive: %v", err), "retry the download")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, output.ParseBackendError(resp.StatusCode, body)
+	}
+	if int64(len(body)) > MaxArchiveBytes {
+		return nil, output.ErrValidation("skill archive exceeds download limit", "reduce the skill archive below 64 MiB")
+	}
+	return body, nil
+}

--- a/internal/marketplace/client.go
+++ b/internal/marketplace/client.go
@@ -21,7 +21,7 @@ type APIClient interface {
 }
 
 type Skill struct {
-	ID         string `json:"id"`
+	ID         string `json:"skill_id"`
 	Name       string `json:"name"`
 	FileSHA256 string `json:"file_sha256"`
 }
@@ -42,7 +42,7 @@ func (c *Client) GetSkill(ctx context.Context, id string) (Skill, error) {
 	body, err := c.api.Do(ctx, &apiClient.Request{
 		Service: "marketplace",
 		Method:  http.MethodGet,
-		Path:    "/skill/" + url.PathEscape(id),
+		Path:    "/skills/" + url.PathEscape(id),
 	})
 	if err != nil {
 		return Skill{}, err
@@ -60,7 +60,7 @@ func (c *Client) DownloadSkill(ctx context.Context, id string) ([]byte, error) {
 	body, err := c.api.Do(ctx, &apiClient.Request{
 		Service:        "marketplace",
 		Method:         http.MethodGet,
-		Path:           "/skill/" + url.PathEscape(id) + "/download",
+		Path:           "/skills/" + url.PathEscape(id) + "/download",
 		BinaryResponse: true,
 	})
 	if err != nil {

--- a/internal/marketplace/client_test.go
+++ b/internal/marketplace/client_test.go
@@ -1,0 +1,104 @@
+package marketplace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+
+	apiClient "github.com/Mininglamp-OSS/octo-cli/internal/client"
+)
+
+type downloadAPI struct {
+	url string
+}
+
+func (a downloadAPI) Do(context.Context, *apiClient.Request) ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"url":%q}`, a.url)), nil
+}
+
+func newIPv4TLSServer(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+			t.Skipf("sandbox does not permit loopback listeners: %v", err)
+		}
+		t.Fatalf("listen on 127.0.0.1: %v", err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.Listener = listener
+	server.StartTLS()
+	return server
+}
+
+func TestDownloadSkillRejectsHTTP(t *testing.T) {
+	client := NewClient(downloadAPI{url: "http://example.com/skill.zip"}, nil)
+	_, err := client.DownloadSkill(context.Background(), "skill-1")
+	if err == nil || !strings.Contains(err.Error(), "must use https") {
+		t.Fatalf("error = %v, want https rejection", err)
+	}
+}
+
+func TestDownloadSkillRejectsPrivateIPHost(t *testing.T) {
+	server := newIPv4TLSServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("private host must be rejected before the request")
+	}))
+	defer server.Close()
+
+	client := NewClient(downloadAPI{url: server.URL}, server.Client())
+	_, err := client.DownloadSkill(context.Background(), "skill-1")
+	if err == nil || !strings.Contains(err.Error(), "private or local address") {
+		t.Fatalf("error = %v, want private-address rejection", err)
+	}
+}
+
+func TestDownloadSkillRejectsMetadataIP(t *testing.T) {
+	client := NewClient(downloadAPI{url: "https://169.254.169.254/latest/meta-data"}, nil)
+	_, err := client.DownloadSkill(context.Background(), "skill-1")
+	if err == nil || !strings.Contains(err.Error(), "private or local address") {
+		t.Fatalf("error = %v, want link-local rejection", err)
+	}
+}
+
+func TestDownloadSkillDoesNotFollowRedirect(t *testing.T) {
+	redirected := false
+	server := newIPv4TLSServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/redirected" {
+			redirected = true
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		http.Redirect(w, r, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := server.Client().Transport.(*http.Transport).Clone()
+	transport.DialContext = func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, network, serverURL.Host)
+	}
+	httpClient := &http.Client{
+		Transport: transport,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	client := NewClient(downloadAPI{url: "https://93.184.216.34/skill.zip"}, httpClient)
+	_, err = client.DownloadSkill(context.Background(), "skill-1")
+	if err == nil {
+		t.Fatal("expected redirect response to fail")
+	}
+	if redirected {
+		t.Fatal("redirect target was requested")
+	}
+}

--- a/internal/skillinstall/installer.go
+++ b/internal/skillinstall/installer.go
@@ -1,0 +1,150 @@
+package skillinstall
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	maxFiles     = 1024
+	maxTotalSize = int64(32 << 20)
+	maxFileSize  = int64(16 << 20)
+)
+
+var namePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,127}$`)
+
+type Result struct {
+	InstalledTo string
+	Files       []string
+}
+
+func Install(root, name string, archive []byte, expectedSHA string) (result Result, err error) {
+	if !namePattern.MatchString(name) {
+		return Result{}, fmt.Errorf("invalid skill name %q", name)
+	}
+	sum := sha256.Sum256(archive)
+	actual := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(actual, expectedSHA) {
+		return Result{}, fmt.Errorf("skill archive checksum mismatch")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return Result{}, fmt.Errorf("resolve install root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0o755); err != nil {
+		return Result{}, fmt.Errorf("create install root: %w", err)
+	}
+	tmp, err := os.MkdirTemp(absRoot, "."+name+"-install-")
+	if err != nil {
+		return Result{}, fmt.Errorf("create temporary directory: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	files, err := extract(tmp, archive)
+	if err != nil {
+		return Result{}, err
+	}
+	if info, statErr := os.Stat(filepath.Join(tmp, "SKILL.md")); statErr != nil || !info.Mode().IsRegular() {
+		return Result{}, fmt.Errorf("skill archive is missing SKILL.md")
+	}
+
+	target := filepath.Join(absRoot, name)
+	backup, err := os.MkdirTemp(absRoot, "."+name+"-backup-")
+	if err != nil {
+		return Result{}, fmt.Errorf("reserve backup path: %w", err)
+	}
+	if err := os.Remove(backup); err != nil {
+		return Result{}, fmt.Errorf("prepare backup path: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(backup) }()
+	hadTarget := false
+	if _, statErr := os.Stat(target); statErr == nil {
+		if err := os.Rename(target, backup); err != nil {
+			return Result{}, fmt.Errorf("backup existing skill: %w", err)
+		}
+		hadTarget = true
+	} else if !os.IsNotExist(statErr) {
+		return Result{}, fmt.Errorf("inspect existing skill: %w", statErr)
+	}
+	if err := os.Rename(tmp, target); err != nil {
+		if hadTarget {
+			_ = os.Rename(backup, target)
+		}
+		return Result{}, fmt.Errorf("activate installed skill: %w", err)
+	}
+	if hadTarget {
+		_ = os.RemoveAll(backup)
+	}
+	return Result{InstalledTo: target, Files: files}, nil
+}
+
+func extract(dst string, archive []byte) ([]string, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, fmt.Errorf("open skill archive: %w", err)
+	}
+	files := make([]string, 0)
+	var total int64
+	for _, entry := range zr.File {
+		clean := filepath.Clean(filepath.FromSlash(entry.Name))
+		if entry.Name == "" || filepath.IsAbs(clean) || clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("unsafe path in skill archive: %q", entry.Name)
+		}
+		path := filepath.Join(dst, clean)
+		rel, relErr := filepath.Rel(dst, path)
+		if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("path escapes install directory: %q", entry.Name)
+		}
+		info := entry.FileInfo()
+		if info.Mode()&os.ModeSymlink != 0 || (!info.IsDir() && !info.Mode().IsRegular()) {
+			return nil, fmt.Errorf("unsupported archive entry type for %q", entry.Name)
+		}
+		if info.IsDir() {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return nil, fmt.Errorf("create archive directory: %w", err)
+			}
+			continue
+		}
+		if len(files) >= maxFiles {
+			return nil, fmt.Errorf("skill archive exceeds file count limit")
+		}
+		size := int64(entry.UncompressedSize64)
+		if size < 0 || size > maxFileSize || total+size > maxTotalSize {
+			return nil, fmt.Errorf("skill archive exceeds size limit")
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, fmt.Errorf("create archive parent: %w", err)
+		}
+		rc, openErr := entry.Open()
+		if openErr != nil {
+			return nil, fmt.Errorf("open archive file: %w", openErr)
+		}
+		f, createErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0o644)
+		if createErr != nil {
+			_ = rc.Close()
+			return nil, fmt.Errorf("create archive file: %w", createErr)
+		}
+		_, copyErr := io.CopyN(f, rc, size)
+		archiveCloseErr := rc.Close()
+		fileCloseErr := f.Close()
+		if copyErr != nil {
+			return nil, fmt.Errorf("extract archive file: %w", copyErr)
+		}
+		if archiveCloseErr != nil || fileCloseErr != nil {
+			return nil, fmt.Errorf("close archive file")
+		}
+		total += size
+		files = append(files, filepath.ToSlash(clean))
+	}
+	sort.Strings(files)
+	return files, nil
+}

--- a/internal/skillinstall/installer_test.go
+++ b/internal/skillinstall/installer_test.go
@@ -1,0 +1,105 @@
+package skillinstall
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type archiveEntry struct {
+	name string
+	body string
+	mode os.FileMode
+}
+
+func makeArchive(t *testing.T, entries ...archiveEntry) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, entry := range entries {
+		mode := entry.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		h := &zip.FileHeader{Name: entry.name, Method: zip.Deflate}
+		h.SetMode(mode)
+		w, err := zw.CreateHeader(h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write([]byte(entry.body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(buf.Bytes())
+	return buf.Bytes(), hex.EncodeToString(sum[:])
+}
+
+func TestInstallSuccessReplacesOnlyTarget(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "other"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "other", "keep"), []byte("yes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "demo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "demo", "old"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive, digest := makeArchive(t,
+		archiveEntry{name: "SKILL.md", body: "# demo"},
+		archiveEntry{name: "references/readme.md", body: "reference"},
+	)
+	result, err := Install(root, "demo", archive, digest)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if result.InstalledTo != filepath.Join(root, "demo") || len(result.Files) != 2 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "demo", "old")); !os.IsNotExist(err) {
+		t.Fatalf("old file was not replaced: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "other", "keep")); err != nil {
+		t.Fatalf("unrelated skill changed: %v", err)
+	}
+}
+
+func TestInstallRejectsUnsafeArchive(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []archiveEntry
+		want    string
+	}{
+		{"path traversal", []archiveEntry{{name: "../escape", body: "x"}, {name: "SKILL.md", body: "x"}}, "unsafe path"},
+		{"symlink", []archiveEntry{{name: "SKILL.md", body: "x"}, {name: "link", body: "SKILL.md", mode: os.ModeSymlink | 0o777}}, "unsupported"},
+		{"missing skill", []archiveEntry{{name: "README.md", body: "x"}}, "missing SKILL.md"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			archive, digest := makeArchive(t, tt.entries...)
+			_, err := Install(t.TempDir(), "demo", archive, digest)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallRejectsChecksumMismatch(t *testing.T) {
+	archive, _ := makeArchive(t, archiveEntry{name: "SKILL.md", body: "x"})
+	if _, err := Install(t.TempDir(), "demo", archive, strings.Repeat("0", 64)); err == nil || !strings.Contains(err.Error(), "checksum") {
+		t.Fatalf("error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `octo-cli marketplace skills <skill-id> --install <dir>` with the `market` alias
- download and verify Marketplace Skill archives before atomic installation
- harden artifact downloads with HTTPS-only, private-address rejection, size limits, and redirect blocking
- align the CLI client with the Marketplace OpenAPI contract: plural `/skills/{skill_id}` routes and `skill_id` response fields

## Verification

- `go test ./...`

## API contract

- `GET /skills/{skill_id}`
- `GET /skills/{skill_id}/download`
- response resource identifier: `skill_id`