### PR TITLE
feat(marketplace): add OpenAPI-driven skill and MCP commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   lives in sibling files loaded on demand: `sheet.md` (spreadsheets), `doc.md`
   (rich-text body), `board.md` (whiteboard), and `common.md` (comments,
   versions, members/sharing, attachments).
+- [`octo-marketplace`](./skills/octo-marketplace/SKILL.md) — search, install,
+  publish, and update Marketplace Skills and MCP server listings.
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -68,7 +68,7 @@ func registerQueryFlags(cmd *cobra.Command, rt *operationRuntime, d *registry.Op
 			continue
 		}
 		flagName := paramFlagName(p)
-		qf := &queryFlag{apiName: p.Name, kind: schemaTypeKind(p.Type)}
+		qf := &queryFlag{apiName: p.Name, kind: queryParamKind(p)}
 		desc := p.Description
 		if len(p.Enum) > 0 {
 			desc = fmt.Sprintf("%s (one of: %s)", desc, formatEnum(p.Enum))
@@ -246,12 +246,16 @@ func promotableKind(p *registry.SchemaInfo) (valueKind, bool) {
 	return 0, false
 }
 
-func schemaTypeKind(t string) valueKind {
-	switch t {
+func queryParamKind(p *registry.ParamInfo) valueKind {
+	switch p.Type {
 	case "integer", "number":
 		return kindInt
 	case "boolean":
 		return kindBool
+	case "array":
+		if p.Items != nil && p.Items.Type == "string" {
+			return kindStringSlice
+		}
 	}
 	return kindString
 }

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -91,21 +91,27 @@ func TestMarketplaceSkillSearchRequest(t *testing.T) {
 }
 
 func TestMarketplaceMCPSearchFiltersRequest(t *testing.T) {
-	var gotQuery string
+	var gotQuery map[string][]string
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.RawQuery
+		gotQuery = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "mcp", "list", "--transport", "stdio", "--visibility", "public", "--source", "space", "--created-by-type", "bot", "--tag", "cli", "--sort", "relevance"})
+	root.SetArgs([]string{"marketplace", "mcp", "list", "--transport", "stdio", "--visibility", "public", "--source", "space", "--created-by-type", "bot", "--tag", "cli", "--tag", "devops", "--sort", "relevance"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	for _, want := range []string{"transport=stdio", "visibility=public", "source=space", "created_by_type=bot", "tag=cli", "sort=relevance"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query = %q, want %q", gotQuery, want)
-		}
+	want := map[string][]string{
+		"transport":       {"stdio"},
+		"visibility":      {"public"},
+		"source":          {"space"},
+		"created_by_type": {"bot"},
+		"tag":             {"cli", "devops"},
+		"sort":            {"relevance"},
+	}
+	if !reflect.DeepEqual(gotQuery, want) {
+		t.Errorf("query = %#v, want %#v", gotQuery, want)
 	}
 }
 

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -16,23 +16,32 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		method string
 		path   string
 	}{
-		"skill_category.list":   {http.MethodGet, "/market/api/v1/skill_categories"},
-		"mcp_category.list":     {http.MethodGet, "/market/api/v1/mcp_categories"},
-		"skill.list":            {http.MethodGet, "/market/api/v1/skills"},
-		"skill.create":          {http.MethodPost, "/market/api/v1/skills"},
-		"skill.get":             {http.MethodGet, "/market/api/v1/skills/{skill_id}"},
-		"skill.update":          {http.MethodPatch, "/market/api/v1/skills/{skill_id}"},
-		"skill.download":        {http.MethodGet, "/market/api/v1/skills/{skill_id}/download"},
-		"skill.reupload.create": {http.MethodPost, "/market/api/v1/skills/{skill_id}/reuploads"},
-		"skill.version.list":    {http.MethodGet, "/market/api/v1/skills/{skill_id}/versions"},
-		"skill_upload.create":   {http.MethodPost, "/market/api/v1/skill_uploads"},
-		"skill_upload.parse":    {http.MethodPost, "/market/api/v1/skill_uploads/{skill_upload_id}/parse"},
-		"skill_parse_task.get":  {http.MethodGet, "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}"},
-		"mcp.list":              {http.MethodGet, "/market/api/v1/mcps"},
-		"mcp.create":            {http.MethodPost, "/market/api/v1/mcps"},
-		"mcp.probe":             {http.MethodPost, "/market/api/v1/mcps/_probe"},
-		"mcp.get":               {http.MethodGet, "/market/api/v1/mcps/{mcp_id}"},
-		"mcp.update":            {http.MethodPatch, "/market/api/v1/mcps/{mcp_id}"},
+		"skill_category.list":      {http.MethodGet, "/market/api/v1/skill_categories"},
+		"mcp_category.list":        {http.MethodGet, "/market/api/v1/mcp_categories"},
+		"skill.list":               {http.MethodGet, "/market/api/v1/skills"},
+		"skill.mine.list":          {http.MethodGet, "/market/api/v1/skills/mine"},
+		"skill.tag.list":           {http.MethodGet, "/market/api/v1/skills/tags"},
+		"skill.publish":            {http.MethodPost, "/market/api/v1/bot/skills/publish"},
+		"skill.create":             {http.MethodPost, "/market/api/v1/skills"},
+		"skill.get":                {http.MethodGet, "/market/api/v1/skills/{skill_id}"},
+		"skill.update":             {http.MethodPatch, "/market/api/v1/skills/{skill_id}"},
+		"skill.delete":             {http.MethodDelete, "/market/api/v1/skills/{skill_id}"},
+		"skill.skillmd.get":        {http.MethodGet, "/market/api/v1/skills/{skill_id}/skill_md"},
+		"skill.download":           {http.MethodGet, "/market/api/v1/skills/{skill_id}/download"},
+		"skill.reupload.create":    {http.MethodPost, "/market/api/v1/skills/{skill_id}/reuploads"},
+		"skill.version.list":       {http.MethodGet, "/market/api/v1/skills/{skill_id}/versions"},
+		"skill_upload.create":      {http.MethodPost, "/market/api/v1/skill_uploads"},
+		"skill_upload.parse":       {http.MethodPost, "/market/api/v1/skill_uploads/{skill_upload_id}/parse"},
+		"skill_parse_task.get":     {http.MethodGet, "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}"},
+		"skill_icon_upload.create": {http.MethodPost, "/market/api/v1/skill_icon_uploads"},
+		"mcp.list":                 {http.MethodGet, "/market/api/v1/mcps"},
+		"mcp.mine.list":            {http.MethodGet, "/market/api/v1/mcps/mine"},
+		"mcp.create":               {http.MethodPost, "/market/api/v1/mcps"},
+		"mcp.probe":                {http.MethodPost, "/market/api/v1/mcps/_probe"},
+		"mcp.get":                  {http.MethodGet, "/market/api/v1/mcps/{mcp_id}"},
+		"mcp.update":               {http.MethodPatch, "/market/api/v1/mcps/{mcp_id}"},
+		"mcp.delete":               {http.MethodDelete, "/market/api/v1/mcps/{mcp_id}"},
+		"mcp_icon_upload.create":   {http.MethodPost, "/market/api/v1/mcp_icon_uploads"},
 	}
 
 	if got := len(r.ListOperations("marketplace")); got != len(wants) {
@@ -64,14 +73,55 @@ func TestMarketplaceSkillSearchRequest(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[],"pagination":{"has_more":false}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "skill", "list", "--q", "deep miner", "--page-size", "20"})
+	root.SetArgs([]string{"marketplace", "skill", "list", "--q", "deep miner", "--tag", "cli", "--sort", "latest", "--page-size", "20"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	if gotPath != "/market/api/v1/skills" {
 		t.Errorf("path = %q", gotPath)
 	}
-	for _, want := range []string{"q=deep+miner", "page_size=20"} {
+	for _, want := range []string{"q=deep+miner", "tag=cli", "sort=latest", "page_size=20"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want %q", gotQuery, want)
+		}
+	}
+	if strings.Contains(gotQuery, "offset=") {
+		t.Errorf("query = %q, must not use removed offset pagination", gotQuery)
+	}
+}
+
+func TestMarketplaceMCPSearchFiltersRequest(t *testing.T) {
+	var gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "mcp", "list", "--transport", "stdio", "--visibility", "public", "--source", "space", "--created-by-type", "bot", "--tag", "cli", "--sort", "relevance"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"transport=stdio", "visibility=public", "source=space", "created_by_type=bot", "tag=cli", "sort=relevance"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want %q", gotQuery, want)
+		}
+	}
+}
+
+func TestMarketplaceMCPCategoryFiltersRequest(t *testing.T) {
+	var gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "mcp-category", "list", "--mode", "mine", "--created-by-type", "bot"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, want := range []string{"mode=mine", "created_by_type=bot"} {
 		if !strings.Contains(gotQuery, want) {
 			t.Errorf("query = %q, want %q", gotQuery, want)
 		}
@@ -98,6 +148,30 @@ func TestMarketplaceSkillPublishRequest(t *testing.T) {
 		t.Errorf("path = %q", gotPath)
 	}
 	if gotBody["parse_task_id"] != "task-1" || gotBody["visibility"] != "space" {
+		t.Errorf("body = %#v", gotBody)
+	}
+}
+
+func TestMarketplaceBotSkillPublishRequest(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"skill_id":"skill-1"}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "skill", "publish", "--skill-upload-id", "upload-1", "--visibility", "space", "--changelog", "Initial release"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/market/api/v1/bot/skills/publish" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody["skill_upload_id"] != "upload-1" || gotBody["visibility"] != "space" || gotBody["changelog"] != "Initial release" {
 		t.Errorf("body = %#v", gotBody)
 	}
 }
@@ -133,12 +207,14 @@ func TestMarketplaceCommandTree(t *testing.T) {
 		t.Fatal("missing marketplace command")
 	}
 	domains := map[string][]string{
-		"skill-category":   {"list"},
-		"mcp-category":     {"list"},
-		"skill":            {"list", "create", "get", "update", "download", "reupload", "version"},
-		"skill-upload":     {"create", "parse"},
-		"skill-parse-task": {"get"},
-		"mcp":              {"list", "create", "probe", "get", "update"},
+		"skill-category":    {"list"},
+		"mcp-category":      {"list"},
+		"skill":             {"list", "mine", "tag", "publish", "create", "get", "update", "delete", "download", "reupload", "version", "skillmd"},
+		"skill-upload":      {"create", "parse"},
+		"skill-parse-task":  {"get"},
+		"skill-icon-upload": {"create"},
+		"mcp":               {"list", "mine", "create", "probe", "get", "update", "delete"},
+		"mcp-icon-upload":   {"create"},
 	}
 	for domain, children := range domains {
 		domainCmd := findCmd(marketplace, domain)
@@ -159,7 +235,7 @@ func TestMarketplaceCommandTree(t *testing.T) {
 
 func TestMarketplaceSkillTagsAreStrings(t *testing.T) {
 	r := registry.MustNew()
-	for _, id := range []string{"skill.create", "skill.update"} {
+	for _, id := range []string{"skill.publish", "skill.create", "skill.update"} {
 		op, ok := r.GetOperation(id)
 		if !ok || op.RequestBody == nil {
 			t.Fatalf("%s request body not found", id)
@@ -179,6 +255,7 @@ func TestMarketplaceVisibilityEnumsMatchBackend(t *testing.T) {
 	}{
 		{"skill.create", []string{"public", "private", "space"}},
 		{"skill.update", []string{"public", "private", "space"}},
+		{"skill.publish", []string{"public", "private", "space"}},
 		{"mcp.create", []string{"public", "private"}},
 		{"mcp.update", []string{"public", "private"}},
 	} {

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -1,0 +1,226 @@
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
+)
+
+func TestMarketplaceRegistryShape(t *testing.T) {
+	r := registry.MustNew()
+	wants := map[string]struct {
+		method string
+		path   string
+	}{
+		"skill_category.list":   {http.MethodGet, "/market/api/v1/skill_categories"},
+		"mcp_category.list":     {http.MethodGet, "/market/api/v1/mcp_categories"},
+		"skill.list":            {http.MethodGet, "/market/api/v1/skills"},
+		"skill.create":          {http.MethodPost, "/market/api/v1/skills"},
+		"skill.get":             {http.MethodGet, "/market/api/v1/skills/{skill_id}"},
+		"skill.update":          {http.MethodPatch, "/market/api/v1/skills/{skill_id}"},
+		"skill.download":        {http.MethodGet, "/market/api/v1/skills/{skill_id}/download"},
+		"skill.reupload.create": {http.MethodPost, "/market/api/v1/skills/{skill_id}/reuploads"},
+		"skill.version.list":    {http.MethodGet, "/market/api/v1/skills/{skill_id}/versions"},
+		"skill_upload.create":   {http.MethodPost, "/market/api/v1/skill_uploads"},
+		"skill_upload.parse":    {http.MethodPost, "/market/api/v1/skill_uploads/{skill_upload_id}/parse"},
+		"skill_parse_task.get":  {http.MethodGet, "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}"},
+		"mcp.list":              {http.MethodGet, "/market/api/v1/mcps"},
+		"mcp.create":            {http.MethodPost, "/market/api/v1/mcps"},
+		"mcp.probe":             {http.MethodPost, "/market/api/v1/mcps/_probe"},
+		"mcp.get":               {http.MethodGet, "/market/api/v1/mcps/{mcp_id}"},
+		"mcp.update":            {http.MethodPatch, "/market/api/v1/mcps/{mcp_id}"},
+	}
+
+	if got := len(r.ListOperations("marketplace")); got != len(wants) {
+		t.Fatalf("marketplace operation count = %d, want %d", got, len(wants))
+	}
+	for id, want := range wants {
+		op, ok := r.GetOperation(id)
+		if !ok {
+			t.Fatalf("operation %q not found", id)
+		}
+		if op.Method != want.method || op.Path != want.path {
+			t.Errorf("%s = %s %s, want %s %s", id, op.Method, op.Path, want.method, want.path)
+		}
+		if op.BaseURLEnv != "OCTO_API_BASE_URL" {
+			t.Errorf("%s base URL env = %q, want OCTO_API_BASE_URL", id, op.BaseURLEnv)
+		}
+		if !op.SpaceHeader {
+			t.Errorf("%s must send the space header", id)
+		}
+	}
+}
+
+func TestMarketplaceSkillSearchRequest(t *testing.T) {
+	var gotPath, gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"has_more":false}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "skill", "list", "--q", "deep miner", "--page-size", "20"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/market/api/v1/skills" {
+		t.Errorf("path = %q", gotPath)
+	}
+	for _, want := range []string{"q=deep+miner", "page_size=20"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want %q", gotQuery, want)
+		}
+	}
+}
+
+func TestMarketplaceSkillPublishRequest(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"skill_id":"skill-1"}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "skill", "create", "--parse-task-id", "task-1", "--visibility", "space"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/market/api/v1/skills" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotBody["parse_task_id"] != "task-1" || gotBody["visibility"] != "space" {
+		t.Errorf("body = %#v", gotBody)
+	}
+}
+
+func TestMarketplaceMCPUpdateRequest(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"mcp_id":"mcp-1"}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "mcp", "update", "mcp-1", "--slogan", "Updated"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPatch || gotPath != "/market/api/v1/mcps/mcp-1" {
+		t.Errorf("request = %s %s", gotMethod, gotPath)
+	}
+	if gotBody["slogan"] != "Updated" {
+		t.Errorf("body = %#v", gotBody)
+	}
+}
+
+func TestMarketplaceCommandTree(t *testing.T) {
+	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {})
+	marketplace := findCmd(root, "marketplace")
+	if marketplace == nil {
+		t.Fatal("missing marketplace command")
+	}
+	domains := map[string][]string{
+		"skill-category":   {"list"},
+		"mcp-category":     {"list"},
+		"skill":            {"list", "create", "get", "update", "download", "reupload", "version"},
+		"skill-upload":     {"create", "parse"},
+		"skill-parse-task": {"get"},
+		"mcp":              {"list", "create", "probe", "get", "update"},
+	}
+	for domain, children := range domains {
+		domainCmd := findCmd(marketplace, domain)
+		if domainCmd == nil {
+			t.Errorf("missing marketplace %s command group", domain)
+			continue
+		}
+		for _, name := range children {
+			if findCmd(domainCmd, name) == nil {
+				t.Errorf("missing marketplace %s %s command", domain, name)
+			}
+		}
+	}
+	if got := childNames(marketplace); len(got) != len(domains) {
+		t.Errorf("marketplace domains = %v, want %v", got, domains)
+	}
+}
+
+func TestMarketplaceSkillTagsAreStrings(t *testing.T) {
+	r := registry.MustNew()
+	for _, id := range []string{"skill.create", "skill.update"} {
+		op, ok := r.GetOperation(id)
+		if !ok || op.RequestBody == nil {
+			t.Fatalf("%s request body not found", id)
+		}
+		tags, ok := op.RequestBody.Properties["tags"]
+		if !ok || tags.Type != "array" || tags.Items == nil || tags.Items.Type != "string" {
+			t.Errorf("%s tags schema = %+v, want string array", id, tags)
+		}
+	}
+}
+
+func TestMarketplaceVisibilityEnumsMatchBackend(t *testing.T) {
+	r := registry.MustNew()
+	for _, tc := range []struct {
+		id   string
+		want []string
+	}{
+		{"skill.create", []string{"public", "private", "space"}},
+		{"skill.update", []string{"public", "private", "space"}},
+		{"mcp.create", []string{"public", "private"}},
+		{"mcp.update", []string{"public", "private"}},
+	} {
+		op, ok := r.GetOperation(tc.id)
+		if !ok || op.RequestBody == nil {
+			t.Fatalf("%s request body not found", tc.id)
+		}
+		visibility, ok := op.RequestBody.Properties["visibility"]
+		if !ok {
+			t.Fatalf("%s visibility schema not found", tc.id)
+		}
+		got := make([]string, 0, len(visibility.Enum))
+		for _, value := range visibility.Enum {
+			got = append(got, value.(string))
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s visibility enum = %v, want %v", tc.id, visibility.Enum, tc.want)
+		}
+	}
+}
+
+func TestMarketplaceDownloadRequest(t *testing.T) {
+	var gotPath, gotQuery, gotSpace string
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotSpace = r.Header.Get("X-Space-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"download_url":"https://example.invalid/skill.zip","file_sha256":"abc"}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "skill", "download", "skill-1", "--response-format", "json"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/market/api/v1/skills/skill-1/download" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if !strings.Contains(gotQuery, "format=json") {
+		t.Errorf("query = %q, want format=json", gotQuery)
+	}
+	if gotSpace != "space-1" {
+		t.Errorf("X-Space-Id = %q, want space-1", gotSpace)
+	}
+}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -61,17 +61,27 @@ func ensureServiceCmd(parent *cobra.Command, svc string) *cobra.Command {
 }
 
 // attachOperation inserts one operation as a leaf command, creating
-// intermediate "resource" commands (matter assignee, matter timeline, …) on
-// the way down. operationId segments after the first are treated as the path
-// to the leaf.
+// intermediate "resource" commands (matter assignee, marketplace skill, …)
+// on the way down. When operationId starts with the registry service name that
+// segment is omitted; otherwise it is preserved as a domain below the service.
 func attachOperation(svcCmd *cobra.Command, f *cmdutil.Factory, d *registry.OperationDetail) {
 	segs := strings.Split(d.ID, ".")
 	if len(segs) < 2 {
 		return
 	}
+	// Most specs use an operationId whose first segment matches the registry
+	// service (docs.create under service docs). A multi-domain backend may expose
+	// several resource families from one service, for example skill.list and
+	// mcp.list under service marketplace. Preserve that first segment as a
+	// resource group when it differs from the service name so both operations
+	// become addressable instead of colliding as marketplace list.
+	start := 1
+	if segs[0] != d.Service {
+		start = 0
+	}
 	cur := svcCmd
-	for i := 1; i < len(segs)-1; i++ {
-		name := segs[i]
+	for i := start; i < len(segs)-1; i++ {
+		name := strings.ReplaceAll(segs[i], "_", "-")
 		sub := findChild(cur, name)
 		if sub == nil {
 			sub = &cobra.Command{
@@ -84,7 +94,7 @@ func attachOperation(svcCmd *cobra.Command, f *cmdutil.Factory, d *registry.Oper
 		}
 		cur = sub
 	}
-	leaf := buildOperationCmd(f, d, segs[len(segs)-1])
+	leaf := buildOperationCmd(f, d, strings.ReplaceAll(segs[len(segs)-1], "_", "-"))
 	cur.AddCommand(leaf)
 }
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -116,6 +116,19 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 	}
 }
 
+func TestRegisterServiceCommands_PreservesForeignOperationDomain(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+	marketplace := findCmd(root, "marketplace")
+	if marketplace == nil {
+		t.Fatal("missing marketplace service command")
+	}
+	for _, domain := range []string{"skill", "mcp"} {
+		if findCmd(marketplace, domain) == nil {
+			t.Errorf("marketplace must preserve %q from the operationId", domain)
+		}
+	}
+}
+
 // --- operation execution (matter.list) ---
 
 func TestMatterList_QueryParamsFromFlags(t *testing.T) {

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -1,5 +1,5 @@
 // Package registry loads the embedded OpenAPI 3.x specs for each Octo service
-// domain (matter, message, group, thread, file, bot, event). Consumers read
+// domain (matter, message, group, thread, file, bot, event, marketplace). Consumers read
 // operation metadata — parameters, request body shape, response shape, risk,
 // pagination — to drive flag generation, request building, and `octo-cli schema`.
 //

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -140,13 +140,14 @@ type OperationInfo struct {
 // the `In` field records which. Type/Default/Enum come from the nested
 // schema when present.
 type ParamInfo struct {
-	Name        string `json:"name"`
-	In          string `json:"in"`
-	Required    bool   `json:"required,omitempty"`
-	Type        string `json:"type,omitempty"`
-	Description string `json:"description,omitempty"`
-	Default     any    `json:"default,omitempty"`
-	Enum        []any  `json:"enum,omitempty"`
+	Name        string      `json:"name"`
+	In          string      `json:"in"`
+	Required    bool        `json:"required,omitempty"`
+	Type        string      `json:"type,omitempty"`
+	Items       *SchemaInfo `json:"items,omitempty"`
+	Description string      `json:"description,omitempty"`
+	Default     any         `json:"default,omitempty"`
+	Enum        []any       `json:"enum,omitempty"`
 	// FlagName is the optional CLI flag override from the x-octo-flag
 	// extension on the parameter. It lets a spec expose a header/query param
 	// whose wire name is awkward as a flag (e.g. the `If-Match` header) under a
@@ -355,6 +356,10 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 			if sch, ok := pm["schema"].(map[string]any); ok {
 				pi.Type = stringOf(sch["type"])
 				pi.Default = sch["default"]
+				if items, ok := sch["items"].(map[string]any); ok {
+					resolved := resolveSchema(doc, items)
+					pi.Items = &resolved
+				}
 				if enum, ok := sch["enum"].([]any); ok {
 					pi.Enum = enum
 				}

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -10,7 +10,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "docs", "event", "file", "group", "html", "matter", "message", "thread"}
+	want := []string{"bot", "docs", "event", "file", "group", "html", "marketplace", "matter", "message", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -43,6 +43,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"event":   2,
 		"docs":    31,
 		"html":    20,
+		"marketplace": 17,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -146,8 +147,9 @@ func TestGetOperationMessageSend_DMWorkimBase(t *testing.T) {
 // X-Space-Id only when a spec explicitly declares x-octo-space-header:false
 // (SpaceHeaderSet && !SpaceHeader); the values below are the intended,
 // server-verified per-service behaviour:
-//   - message / matter: true  — the server reads X-Space-Id (DM multi-space
-//     hint / space-scoped matters), so the client must keep sending it.
+//   - message / matter / marketplace: true — the server reads X-Space-Id
+//     (DM multi-space hint / space-scoped resources), so the client must keep
+//     sending it.
 //   - docs and the rest: false — those bot mounts server-resolve the space and
 //     ignore the header, so the client honestly suppresses it.
 func TestServiceSpaceHeaderContract(t *testing.T) {
@@ -159,6 +161,7 @@ func TestServiceSpaceHeaderContract(t *testing.T) {
 	}{
 		{"message", "message.send", true},
 		{"matter", "matter.create", true},
+		{"marketplace", "skill.get", true},
 		{"docs", "docs.create", false},
 		{"bot", "bot.register", false},
 		{"thread", "thread.create", false},

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -34,16 +34,16 @@ func TestAllDomainOperationCounts(t *testing.T) {
 	// matter.transition) — the spec tracks actual routes, not CLI surface.
 	r := MustNew()
 	expected := map[string]int{
-		"matter":  14,
-		"message": 4,
-		"group":   9,
-		"thread":  8,
-		"file":    4,
-		"bot":     6,
-		"event":   2,
-		"docs":    31,
-		"html":    20,
-		"marketplace": 17,
+		"matter":      14,
+		"message":     4,
+		"group":       9,
+		"thread":      8,
+		"file":        4,
+		"bot":         6,
+		"event":       2,
+		"docs":        31,
+		"html":        20,
+		"marketplace": 26,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -1,545 +1,4234 @@
 {
   "openapi": "3.1.0",
   "info": {
+    "contact": {
+      "name": "OCTO API Team",
+      "url": "https://github.com/Mininglamp-OSS/octo-marketplace"
+    },
+    "description": "Skill and MCP marketplace API for OCTO.",
     "title": "Octo Marketplace API",
-    "description": "Skill and MCP Marketplace operations used by agent runtimes.",
     "version": "1.0.0"
   },
   "x-octo-service": "marketplace",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": true,
   "paths": {
-    "/market/api/v1/skill_categories": {
-      "get": {
-        "operationId": "skill_category.list",
-        "summary": "List Skill categories",
-        "description": "Return Skill category IDs, names, icons, and visible Skill counts.",
-        "x-octo-risk": "read",
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+    "/market/api/v1/bot/skills/publish": {
+      "post": {
+        "description": "Parse an uploaded Skill archive synchronously through the bounded worker pool, then create a Skill owned by the bot owner.",
+        "operationId": "skill.publish",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_upload.BotPublishSkillRequest"
+              }
+            }
+          },
+          "description": "Bot publish request",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "CONFLICT"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Publish Skill as bot",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "write"
       }
     },
     "/market/api/v1/mcp_categories": {
       "get": {
+        "description": "Return MCP category keys and visible record counts for the current Space.",
         "operationId": "mcp_category.list",
+        "parameters": [
+          {
+            "description": "Scope: all or mine",
+            "in": "query",
+            "name": "mode",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "mine"
+              ]
+            }
+          },
+          {
+            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
+            "in": "query",
+            "name": "created_by_type",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_model_CategoryFilter"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
         "summary": "List MCP categories",
-        "description": "Return MCP category keys and visible record counts in the current Space.",
-        "x-octo-risk": "read",
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "read"
+      }
+    },
+    "/market/api/v1/mcp_icon_uploads": {
+      "post": {
+        "description": "Create a presigned upload target and persistent URL for an MCP icon.",
+        "operationId": "mcp_icon_upload.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler.MCPIconUploadRequest"
+              }
+            }
+          },
+          "description": "Icon metadata",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "PAYLOAD_TOO_LARGE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Initialize MCP icon upload",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/mcps": {
+      "get": {
+        "description": "List MCP servers visible in the current Space using offset pagination.",
+        "operationId": "mcp.list",
+        "parameters": [
+          {
+            "description": "Search keyword",
+            "in": "query",
+            "name": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Category key",
+            "in": "query",
+            "name": "category",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Transport filters",
+            "in": "query",
+            "name": "transport",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Visibility filters",
+            "in": "query",
+            "name": "visibility",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Source filters: system, space, mine",
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
+            "in": "query",
+            "name": "created_by_type",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Tag filters",
+            "in": "query",
+            "name": "tag",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Sort: relevance, updated",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number, default 1",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size, default 20, max 100",
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List MCP servers",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "read"
+      },
+      "post": {
+        "description": "Create an MCP server owned by the authenticated user in the current Space.",
+        "operationId": "mcp.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreateRequest"
+              }
+            }
+          },
+          "description": "MCP server",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "DUPLICATE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Create MCP server",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/mcps/_probe": {
+      "post": {
+        "description": "Probe a remote MCP server connection without persisting the supplied configuration.",
+        "operationId": "mcp.probe",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeRequest"
+              }
+            }
+          },
+          "description": "Connection to probe",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_ProbeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Probe MCP server",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/mcps/{mcp_id}": {
+      "delete": {
+        "description": "Soft-delete an MCP server owned by the caller. Repeated deletion returns not found.",
+        "operationId": "mcp.delete",
+        "parameters": [
+          {
+            "description": "MCP ID",
+            "in": "path",
+            "name": "mcp_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Delete MCP server",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "write"
+      },
+      "get": {
+        "description": "Return one MCP server visible to the caller without exposing stored secrets.",
+        "operationId": "mcp.get",
+        "parameters": [
+          {
+            "description": "MCP ID",
+            "in": "path",
+            "name": "mcp_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Get MCP server",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "read"
+      },
+      "patch": {
+        "description": "Partially update an MCP server owned by the authenticated user.",
+        "operationId": "mcp.update",
+        "parameters": [
+          {
+            "description": "MCP ID",
+            "in": "path",
+            "name": "mcp_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.PatchRequest"
+              }
+            }
+          },
+          "description": "MCP changes",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "DUPLICATE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Update MCP server",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/mcps/mine": {
+      "get": {
+        "description": "List MCP servers owned by the authenticated user in the current Space.",
+        "operationId": "mcp.mine.list",
+        "parameters": [
+          {
+            "description": "Search keyword",
+            "in": "query",
+            "name": "keyword",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Category key",
+            "in": "query",
+            "name": "category",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Transport filters",
+            "in": "query",
+            "name": "transport",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Visibility filters",
+            "in": "query",
+            "name": "visibility",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Source filters: system, space, mine",
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
+            "in": "query",
+            "name": "created_by_type",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Tag filters",
+            "in": "query",
+            "name": "tag",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Sort: relevance, updated",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page number, default 1",
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size, default 20, max 100",
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List owned MCP servers",
+        "tags": [
+          "mcp"
+        ],
+        "x-octo-risk": "read"
+      }
+    },
+    "/market/api/v1/skill_categories": {
+      "get": {
+        "description": "Return all Skill categories and their visible Skill counts.",
+        "operationId": "skill_category.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_CategoryItem"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List Skill categories",
+        "tags": [
+          "skill_category"
+        ],
+        "x-octo-risk": "read"
+      }
+    },
+    "/market/api/v1/skill_icon_uploads": {
+      "post": {
+        "description": "Create an upload target for a Skill icon without changing a Skill record.",
+        "operationId": "skill_icon_upload.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_upload.IconUploadRequest"
+              }
+            }
+          },
+          "description": "Icon metadata",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "PAYLOAD_TOO_LARGE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Initialize Skill icon upload",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}": {
+      "get": {
+        "description": "Return the current parse state for one Skill archive upload.",
+        "operationId": "skill_parse_task.get",
+        "parameters": [
+          {
+            "description": "Skill parse task ID",
+            "in": "path",
+            "name": "skill_parse_task_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_PollResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Get Skill parse task",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "read"
+      }
+    },
+    "/market/api/v1/skill_uploads": {
+      "post": {
+        "description": "Create a bounded upload target for a Skill archive without publishing it.",
+        "operationId": "skill_upload.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_upload.InitUploadRequest"
+              }
+            }
+          },
+          "description": "Archive metadata",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_InitResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "PAYLOAD_TOO_LARGE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Initialize Skill upload",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/skill_uploads/{skill_upload_id}/parse": {
+      "post": {
+        "description": "Start parsing a previously initialized Skill archive upload.",
+        "operationId": "skill_upload.parse",
+        "parameters": [
+          {
+            "description": "Skill upload ID",
+            "in": "path",
+            "name": "skill_upload_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-map_string_string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "CONFLICT"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "RATE_LIMITED"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Parse Skill upload",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "write"
       }
     },
     "/market/api/v1/skills": {
       "get": {
+        "description": "List skills visible in the current Space with cursor pagination.",
         "operationId": "skill.list",
-        "summary": "Search Skills",
-        "description": "List Skills visible in the current Space using cursor pagination.",
+        "parameters": [
+          {
+            "description": "Search query",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Category ID",
+            "in": "query",
+            "name": "category_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated tag names; all tags must match",
+            "in": "query",
+            "name": "tags",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Repeated tag names; all tags must match",
+            "in": "query",
+            "name": "tag",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Sort mode: latest (default), comprehensive, downloads, views",
+            "in": "query",
+            "name": "sort",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Cursor for next page; used with default/latest sort",
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, default 20, max 50",
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List skills",
+        "tags": [
+          "skill"
+        ],
         "x-octo-risk": "read",
         "x-octo-pagination": {
           "cursorParam": "cursor",
           "limitParam": "page_size",
           "cursorField": "pagination.next_cursor",
           "hasMoreField": "pagination.has_more"
-        },
-        "parameters": [
-          { "name": "q", "in": "query", "description": "Search query", "schema": { "type": "string" } },
-          { "name": "category_id", "in": "query", "description": "Category ID", "schema": { "type": "string" } },
-          { "name": "cursor", "in": "query", "description": "Cursor for next page", "schema": { "type": "string" } },
-          { "name": "page_size", "in": "query", "description": "Page size, default 20, max 50", "schema": { "type": "integer", "default": 20, "maximum": 50 } }
-        ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        }
       },
       "post": {
+        "description": "Publish a parsed Skill archive for the authenticated user and current Space.",
         "operationId": "skill.create",
-        "summary": "Publish a Skill",
-        "description": "Publish a successfully parsed Skill archive in the current Space.",
-        "x-octo-risk": "write",
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SkillCreateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_skill.CreateRequest"
+              }
             }
+          },
+          "description": "Skill",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "CONFLICT"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
           }
         },
-        "responses": { "201": { "description": "Created" } },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Create skill",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "write"
       }
     },
     "/market/api/v1/skills/{skill_id}": {
-      "get": {
-        "operationId": "skill.get",
-        "summary": "Get Skill metadata",
-        "description": "Return one Skill visible to the authenticated caller.",
+      "delete": {
+        "description": "Delete a Skill owned by the authenticated user.",
+        "operationId": "skill.delete",
         "parameters": [
           {
-            "name": "skill_id",
-            "in": "path",
-            "required": true,
             "description": "Skill ID",
-            "schema": { "type": "string" }
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SkillEnvelope" }
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp"
+                }
               }
-            }
+            },
+            "description": "OK"
           },
-          "401": { "$ref": "#/components/responses/AuthRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
         },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Delete skill",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "write"
       },
-      "patch": {
-        "operationId": "skill.update",
-        "summary": "Update a Skill",
-        "description": "Update owned Skill metadata or apply a parsed ZIP as a new immutable version.",
-        "x-octo-risk": "write",
+      "get": {
+        "description": "Return one skill visible to the authenticated caller.",
+        "operationId": "skill.get",
         "parameters": [
           {
-            "name": "skill_id",
-            "in": "path",
-            "required": true,
             "description": "Skill ID",
-            "schema": { "type": "string" }
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Get skill",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read"
+      },
+      "patch": {
+        "description": "Partially update a Skill owned by the authenticated user.",
+        "operationId": "skill.update",
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/SkillUpdateRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_skill.UpdateRequest"
+              }
             }
+          },
+          "description": "Skill changes",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "CONFLICT"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
           }
         },
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Update skill",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "write"
       }
     },
     "/market/api/v1/skills/{skill_id}/download": {
       "get": {
+        "description": "Authorize access and redirect to the artifact URL, or return it when format=json.",
         "operationId": "skill.download",
-        "summary": "Get a Skill archive download URL",
-        "description": "Authorize access and return the artifact URL and SHA-256 digest when format=json.",
         "parameters": [
           {
-            "name": "skill_id",
-            "in": "path",
-            "required": true,
             "description": "Skill ID",
-            "schema": { "type": "string" }
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
           {
-            "name": "format",
+            "description": "Use json to return the download URL",
             "in": "query",
-            "description": "Use json to return the download URL instead of redirecting",
+            "name": "format",
             "schema": {
-              "type": "string",
-              "enum": ["json"]
+              "type": "string"
             },
             "x-octo-flag": "response-format"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/DownloadEnvelope" }
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_upload_DownloadResponse"
+                }
               }
-            }
+            },
+            "description": "OK"
           },
-          "302": { "description": "Redirect to the Skill artifact" },
-          "401": { "$ref": "#/components/responses/AuthRequired" },
-          "403": { "$ref": "#/components/responses/Forbidden" },
-          "404": { "$ref": "#/components/responses/NotFound" }
+          "302": {
+            "description": "Redirect to artifact"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
         },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Download Skill archive",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read"
       }
     },
     "/market/api/v1/skills/{skill_id}/reuploads": {
       "post": {
-        "operationId": "skill.reupload.create",
-        "summary": "Initialize a Skill version upload",
         "description": "Create an upload target for a new immutable version of an owned Skill.",
-        "x-octo-risk": "write",
+        "operationId": "skill.reupload.create",
         "parameters": [
           {
-            "name": "skill_id",
-            "in": "path",
-            "required": true,
             "description": "Skill ID",
-            "schema": { "type": "string" }
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
-          "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/ArchiveUploadRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler_upload.ReuploadRequest"
+              }
             }
+          },
+          "description": "Archive metadata",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_InitResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "PAYLOAD_TOO_LARGE"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
           }
         },
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Initialize Skill reupload",
+        "tags": [
+          "skill_upload"
+        ],
+        "x-octo-risk": "write"
+      }
+    },
+    "/market/api/v1/skills/{skill_id}/skill_md": {
+      "get": {
+        "description": "Return the SKILL.md content for the current version of a visible Skill.",
+        "operationId": "skill.skillmd.get",
+        "parameters": [
+          {
+            "description": "Skill ID",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillMDResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "Get SKILL.md",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read"
       }
     },
     "/market/api/v1/skills/{skill_id}/versions": {
       "get": {
+        "description": "List immutable release history for one visible Skill.",
         "operationId": "skill.version.list",
-        "summary": "List Skill versions",
-        "description": "List immutable releases for one visible Skill.",
-        "x-octo-risk": "read",
         "parameters": [
           {
-            "name": "skill_id",
-            "in": "path",
-            "required": true,
             "description": "Skill ID",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
-      }
-    },
-    "/market/api/v1/skill_uploads": {
-      "post": {
-        "operationId": "skill_upload.create",
-        "summary": "Initialize a Skill ZIP upload",
-        "description": "Create a bounded presigned upload target without publishing the Skill.",
-        "x-octo-risk": "write",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/ArchiveUploadRequest" }
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillVersionList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
         },
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
-      }
-    },
-    "/market/api/v1/skill_uploads/{skill_upload_id}/parse": {
-      "post": {
-        "operationId": "skill_upload.parse",
-        "summary": "Parse a Skill ZIP upload",
-        "description": "Start parsing an archive previously uploaded to its presigned target.",
-        "x-octo-risk": "write",
-        "parameters": [
+        "security": [
           {
-            "name": "skill_upload_id",
-            "in": "path",
-            "required": true,
-            "description": "Skill upload ID",
-            "schema": { "type": "string" }
+            "Bearer": [
+
+            ]
           }
         ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "summary": "List skill versions",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read"
       }
     },
-    "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}": {
+    "/market/api/v1/skills/mine": {
       "get": {
-        "operationId": "skill_parse_task.get",
-        "summary": "Get a Skill parse task",
-        "description": "Return the current parse state and parsed Skill metadata.",
-        "x-octo-risk": "read",
+        "description": "List skills owned by the authenticated user in the current Space.",
+        "operationId": "skill.mine.list",
         "parameters": [
           {
-            "name": "skill_parse_task_id",
-            "in": "path",
-            "required": true,
-            "description": "Skill parse task ID",
-            "schema": { "type": "string" }
+            "description": "Search query",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated tag names; all tags must match",
+            "in": "query",
+            "name": "tags",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Repeated tag names; all tags must match",
+            "in": "query",
+            "name": "tag",
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Cursor for next page",
+            "in": "query",
+            "name": "cursor",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, default 20, max 50",
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
+        },
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List owned skills",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "limitParam": "page_size",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        }
       }
     },
-    "/market/api/v1/mcps": {
+    "/market/api/v1/skills/tags": {
       "get": {
-        "operationId": "mcp.list",
-        "summary": "Search MCP servers",
-        "description": "List MCP servers visible in the current Space using offset pagination.",
-        "x-octo-risk": "read",
-        "parameters": [
-          { "name": "keyword", "in": "query", "description": "Search keyword", "schema": { "type": "string" } },
-          { "name": "category", "in": "query", "description": "Category key", "schema": { "type": "string" } },
-          { "name": "page", "in": "query", "description": "Page number, default 1", "schema": { "type": "integer", "default": 1 } },
-          { "name": "page_size", "in": "query", "description": "Page size, default 20, max 100", "schema": { "type": "integer", "default": 20, "maximum": 100 } }
-        ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
-      },
-      "post": {
-        "operationId": "mcp.create",
-        "summary": "Create an MCP server listing",
-        "description": "Create an MCP server owned by the caller in the current Space.",
-        "x-octo-risk": "write",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPCreateRequest" }
-            }
-          }
-        },
-        "responses": { "201": { "description": "Created" } },
-        "security": [{ "Bearer": [] }]
-      }
-    },
-    "/market/api/v1/mcps/_probe": {
-      "post": {
-        "operationId": "mcp.probe",
-        "summary": "Probe an MCP server",
-        "description": "Validate an MCP connection without persisting it.",
-        "x-octo-risk": "read",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPProbeRequest" }
-            }
-          }
-        },
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
-      }
-    },
-    "/market/api/v1/mcps/{mcp_id}": {
-      "get": {
-        "operationId": "mcp.get",
-        "summary": "Get MCP server details",
-        "description": "Return visible MCP metadata and its secret-redacted quick-start configuration.",
-        "x-octo-risk": "read",
+        "description": "List custom Skill tags created in the current Space. Supports fuzzy search by q.",
+        "operationId": "skill.tag.list",
         "parameters": [
           {
-            "name": "mcp_id",
-            "in": "path",
-            "required": true,
-            "description": "MCP ID",
-            "schema": { "type": "string" }
-          }
-        ],
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
-      },
-      "patch": {
-        "operationId": "mcp.update",
-        "summary": "Update an MCP server listing",
-        "description": "Partially update an owned MCP server. MCP listings have no release versions.",
-        "x-octo-risk": "write",
-        "parameters": [
+            "description": "Fuzzy tag search",
+            "in": "query",
+            "name": "q",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
-            "name": "mcp_id",
-            "in": "path",
-            "required": true,
-            "description": "MCP ID",
-            "schema": { "type": "string" }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": { "$ref": "#/components/schemas/MCPUpdateRequest" }
+            "description": "Limit, default 50, max 100",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
             }
           }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillTagList"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "AUTH_REQUIRED"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "FORBIDDEN"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "NOT_FOUND"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "INTERNAL_ERROR"
+          }
         },
-        "responses": { "200": { "description": "OK" } },
-        "security": [{ "Bearer": [] }]
+        "security": [
+          {
+            "Bearer": [
+
+            ]
+          }
+        ],
+        "summary": "List skill tags",
+        "tags": [
+          "skill"
+        ],
+        "x-octo-risk": "read"
       }
     }
   },
   "components": {
     "schemas": {
-      "ArchiveUploadRequest": {
-        "type": "object",
-        "required": ["file_name", "file_size"],
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse": {
         "properties": {
-          "file_name": { "type": "string", "description": "ZIP file name" },
-          "file_size": { "type": "integer", "format": "int64", "description": "ZIP size in bytes" }
-        }
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/internal_api_handler_skill.SkillResponse"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorPagination"
+          }
+        },
+        "type": "object"
       },
-      "SkillCreateRequest": {
-        "type": "object",
-        "required": ["parse_task_id"],
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorPagination": {
         "properties": {
-          "parse_task_id": { "type": "string", "description": "Successful parse task ID" },
-          "name": { "type": "string" },
-          "display_name": { "type": "string" },
-          "icon_url": { "type": "string" },
-          "description": { "type": "string" },
-          "category_id": { "type": "string" },
-          "tags": { "type": "array", "items": { "type": "string" }, "description": "Free-form Skill tags" },
-          "visibility": { "type": "string", "enum": ["public", "private", "space"] },
-          "version": { "type": "string", "description": "Version parsed from the ZIP may be overridden when publishing" }
-        }
+          "has_more": {
+            "type": "boolean"
+          },
+          "next_cursor": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
-      "SkillUpdateRequest": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_model_CategoryFilter": {
         "properties": {
-          "name": { "type": "string" },
-          "display_name": { "type": "string" },
-          "icon_url": { "type": "string" },
-          "description": { "type": "string" },
-          "category_id": { "type": "string" },
-          "tags": { "type": "array", "items": { "type": "string" }, "description": "Free-form Skill tags" },
-          "visibility": { "type": "string", "enum": ["public", "private", "space"] },
-          "version": { "type": "string", "description": "New release version when applying a parsed ZIP" },
-          "parse_task_id": { "type": "string", "description": "Successful reupload parse task ID" },
-          "changelog": { "type": "string", "description": "Release notes for the new ZIP version" }
-        }
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CategoryFilter"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
       },
-      "MCPCreateRequest": {
-        "type": "object",
-        "required": ["name", "transport"],
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_AdminItem": {
         "properties": {
-          "name": { "type": "string" },
-          "slug": { "type": "string", "description": "Identifier used as the mcpServers config key" },
-          "slogan": { "type": "string" },
-          "category": { "type": "string" },
-          "icon": { "type": "string" },
-          "tags": { "type": "array", "items": { "type": "string" } },
-          "transport": { "$ref": "#/components/schemas/MCPTransport" },
-          "url": { "type": "string" },
-          "command": { "type": "string" },
-          "args": { "type": "array", "items": { "type": "string" } },
-          "env": { "type": "object", "additionalProperties": { "type": "string" } },
-          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
-          "auth_type": { "type": "string" },
-          "tools": { "type": "array", "items": { "$ref": "#/components/schemas/MCPTool" } },
-          "usage_examples": { "type": "array", "items": { "type": "string" } },
-          "faqs": { "type": "array", "items": { "$ref": "#/components/schemas/MCPFAQ" } },
-          "notes": { "type": "array", "items": { "type": "string" } },
-          "visibility": { "type": "string", "enum": ["public", "private"] }
-        }
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
       },
-      "MCPUpdateRequest": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_CategoryItem": {
         "properties": {
-          "name": { "type": "string" },
-          "slug": { "type": "string" },
-          "slogan": { "type": "string" },
-          "category": { "type": "string" },
-          "icon": { "type": "string" },
-          "tags": { "type": "array", "items": { "type": "string" } },
-          "transport": { "$ref": "#/components/schemas/MCPTransport" },
-          "url": { "type": "string" },
-          "command": { "type": "string" },
-          "args": { "type": "array", "items": { "type": "string" } },
-          "env": { "type": "object", "additionalProperties": { "type": "string" } },
-          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
-          "auth_type": { "type": "string" },
-          "tools": { "type": "array", "items": { "$ref": "#/components/schemas/MCPTool" } },
-          "usage_examples": { "type": "array", "items": { "type": "string" } },
-          "faqs": { "type": "array", "items": { "$ref": "#/components/schemas/MCPFAQ" } },
-          "notes": { "type": "array", "items": { "type": "string" } },
-          "visibility": { "type": "string", "enum": ["public", "private"] }
-        }
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.CategoryItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
       },
-      "MCPProbeRequest": {
-        "type": "object",
-        "required": ["transport"],
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp": {
         "properties": {
-          "transport": { "$ref": "#/components/schemas/MCPTransport" },
-          "url": { "type": "string" },
-          "command": { "type": "string" },
-          "args": { "type": "array", "items": { "type": "string" } },
-          "env": { "type": "object", "additionalProperties": { "type": "string" } },
-          "headers": { "type": "object", "additionalProperties": { "type": "string" } }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.EmptyResp"
+          }
+        },
+        "type": "object"
       },
-      "MCPTransport": {
-        "type": "string",
-        "enum": ["stdio", "streamable-http", "sse"]
-      },
-      "MCPTool": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail": {
         "properties": {
-          "name": { "type": "string" },
-          "description": { "type": "string" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Detail"
+          }
+        },
+        "type": "object"
       },
-      "MCPFAQ": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_IconResult": {
         "properties": {
-          "question": { "type": "string" },
-          "answer": { "type": "string" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.IconResult"
+          }
+        },
+        "type": "object"
       },
-      "SkillEnvelope": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_ProbeResponse": {
         "properties": {
-          "data": { "$ref": "#/components/schemas/Skill" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeResponse"
+          }
+        },
+        "type": "object"
       },
-      "Skill": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_AdminItem": {
         "properties": {
-          "skill_id": { "type": "string" },
-          "name": { "type": "string" },
-          "display_name": { "type": "string" },
-          "description": { "type": "string" },
-          "version": { "type": "string" },
-          "file_name": { "type": "string" },
-          "file_size": { "type": "integer", "format": "int64" },
-          "readme_content": { "type": "string" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem"
+          }
+        },
+        "type": "object"
       },
-      "DownloadEnvelope": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult": {
         "properties": {
-          "data": { "$ref": "#/components/schemas/Download" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.IconUploadResult"
+          }
+        },
+        "type": "object"
       },
-      "Download": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_InitResult": {
         "properties": {
-          "download_url": { "type": "string" },
-          "file_sha256": { "type": "string" }
-        }
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.InitResult"
+          }
+        },
+        "type": "object"
       },
-      "Error": {
-        "type": "object",
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_PollResult": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.PollResult"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_SessionResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler.SessionResponse"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillMDResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler_skill.SkillMDResponse"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler_skill.SkillResponse"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillTagList": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler_skill.SkillTagList"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillVersionList": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler_skill.SkillVersionList"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_upload_DownloadResponse": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/internal_api_handler_upload.DownloadResponse"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-map_string_string": {
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/map_string_string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.EmptyResp": {
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error": {
         "properties": {
           "error": {
-            "type": "object",
-            "properties": {
-              "code": { "type": "string" },
-              "message": { "type": "string" },
-              "details": { "type": "object", "additionalProperties": true },
-              "hint": { "type": "string" }
-            }
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.ErrorBody"
           }
-        }
-      }
-    },
-    "responses": {
-      "AuthRequired": {
-        "description": "AUTH_REQUIRED",
-        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+        },
+        "type": "object"
       },
-      "Forbidden": {
-        "description": "FORBIDDEN",
-        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.ErrorBody": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "details": {
+            "additionalProperties": {
+            },
+            "type": "object"
+          },
+          "hint": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
       },
-      "NotFound": {
-        "description": "NOT_FOUND",
-        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.ListItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination": {
+        "properties": {
+          "page": {
+            "type": "integer"
+          },
+          "page_size": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CategoryFilter": {
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "key": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreateRequest": {
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "auth_type": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "faqs": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "slogan": {
+            "type": "string"
+          },
+          "slug": {
+            "description": "Slug is the ASCII identifier used as the JSON key in the generated\nmcpServers snippet (mcp-v1.md §3, \"服务标识\"). Optional on the wire —\nwhen omitted or empty the server auto-slugifies Name. Must match\n^[a-z0-9-]{1,64}$ after normalization. Unique per Space among live rows.",
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "transport": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
+          },
+          "url": {
+            "type": "string"
+          },
+          "usage_examples": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType": {
+        "description": "Same shape + semantics as Detail (see there for rationale).",
+        "enum": [
+          "human",
+          "bot",
+          "import"
+        ],
+        "type": "string",
+        "x-enum-comments": {
+          "CreatedByImport": "reserved for Git import (#867); not written today."
+        },
+        "x-enum-varnames": [
+          "CreatedByHuman",
+          "CreatedByBot",
+          "CreatedByImport"
+        ]
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Detail": {
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "created_by_bot_name": {
+            "type": "string"
+          },
+          "created_by_bot_uid": {
+            "type": "string"
+          },
+          "created_by_type": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType"
+          },
+          "creator_name": {
+            "type": "string"
+          },
+          "faqs": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "icon": {
+            "type": "string"
+          },
+          "mcp_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "quick_start": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.QuickStart"
+          },
+          "slogan": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "tool_count": {
+            "type": "integer"
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "usage_examples": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ": {
+        "properties": {
+          "answer": {
+            "type": "string"
+          },
+          "question": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.ListItem": {
+        "properties": {
+          "category": {
+            "type": "string"
+          },
+          "created_by_bot_name": {
+            "type": "string"
+          },
+          "created_by_bot_uid": {
+            "type": "string"
+          },
+          "created_by_type": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType"
+          },
+          "creator_name": {
+            "type": "string"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "match_reasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "mcp_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "relevance": {
+            "type": "integer"
+          },
+          "slogan": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "tool_count": {
+            "type": "integer"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.PatchRequest": {
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "auth_type": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "faqs": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "icon": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "slogan": {
+            "type": "string"
+          },
+          "slug": {
+            "description": "Slug — same rules as CreateRequest.Slug. Nil pointer leaves the\nexisting slug untouched; a non-nil empty string is rejected as\nslug_invalid (empty is not a valid identifier).",
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "transport": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
+          },
+          "url": {
+            "type": "string"
+          },
+          "usage_examples": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.QuickStart": {
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "auth_type": {
+            "type": "string"
+          },
+          "command": {
+            "type": "string"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "server_name": {
+            "type": "string"
+          },
+          "slug": {
+            "description": "Slug is the ASCII identifier used as the JSON key in the mcpServers\nsnippet. Frontend template prefers this over ServerName when generating\nthe config; always present in responses for records created after\nmigration 03.",
+            "type": "string"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.SkillVersion": {
+        "properties": {
+          "changed_by": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "skill_id": {
+            "type": "string"
+          },
+          "skill_version_id": {
+            "type": "string"
+          },
+          "storage": {
+            "description": "JSON: {\"type\":\"s3\",\"object_key\":\"...\",\"readme_key\":\"...\"}",
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport": {
+        "enum": [
+          "stdio",
+          "streamable-http",
+          "sse"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "TransportStdio",
+          "TransportStreamableHTTP",
+          "TransportSSE"
+        ]
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility": {
+        "enum": [
+          "public",
+          "private",
+          "system",
+          "space"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "VisibilityPublic",
+          "VisibilityPrivate",
+          "VisibilitySystem",
+          "VisibilitySpace"
+        ]
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.IconResult": {
+        "properties": {
+          "icon_url": {
+            "type": "string"
+          },
+          "version": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeError": {
+        "properties": {
+          "code": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeErrorCode"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeErrorCode": {
+        "enum": [
+          "command_not_found",
+          "timeout",
+          "init_failed",
+          "no_tools_capability"
+        ],
+        "type": "string",
+        "x-enum-varnames": [
+          "ProbeErrCommandNotFound",
+          "ProbeErrTimeout",
+          "ProbeErrInitFailed",
+          "ProbeErrNoToolsCapability"
+        ]
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeRequest": {
+        "properties": {
+          "args": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "command": {
+            "type": "string"
+          },
+          "env": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeResponse": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeError"
+          },
+          "is_ok": {
+            "type": "boolean"
+          },
+          "server_info": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeServerInfo"
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeServerInfo": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem": {
+        "properties": {
+          "icon_key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "skill_category_id": {
+            "type": "string"
+          },
+          "sort_order": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.CategoryItem": {
+        "properties": {
+          "icon_key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "skill_category_id": {
+            "type": "string"
+          },
+          "skill_count": {
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.IconUploadResult": {
+        "properties": {
+          "download_url": {
+            "description": "DownloadURL is the persistent (non-signed) URL where the icon will be\nreachable once the PUT completes. Callers store this on the record so\nthat later reads never touch a signed URL. Filled by InitMcpIconUpload;\nlegacy skill InitIconUpload leaves it empty for backwards compatibility.",
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "method": {
+            "type": "string"
+          },
+          "object_key": {
+            "type": "string"
+          },
+          "presigned_url": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.InitResult": {
+        "properties": {
+          "expires_in": {
+            "type": "integer"
+          },
+          "headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "method": {
+            "type": "string"
+          },
+          "presigned_url": {
+            "type": "string"
+          },
+          "skill_upload_id": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.ParseData": {
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "file_sha256": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "readme_content": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.ParseError": {
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.PollResult": {
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.ParseError"
+          },
+          "result": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse.ParseData"
+          },
+          "skill_parse_task_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "creator_id": {
+            "type": "string"
+          },
+          "creator_name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "download_count": {
+            "type": "integer"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner_name": {
+            "type": "string"
+          },
+          "readme_content": {
+            "type": "string"
+          },
+          "skill_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "view_count": {
+            "type": "integer"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.TagItem": {
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler.MCPIconUploadRequest": {
+        "properties": {
+          "content_type": {
+            "type": "string"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file_name",
+          "file_size"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler.SessionResponse": {
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "space_id": {
+            "type": "string"
+          },
+          "uid": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_category.AdminCategoryRequest": {
+        "properties": {
+          "icon_key": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sort_order": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_metrics.trackRequest": {
+        "properties": {
+          "event_type": {
+            "type": "string"
+          },
+          "resource_id": {
+            "type": "string"
+          },
+          "resource_type": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.AdminCreateRequest": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parse_task_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "parse_task_id"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_skill.AdminReuploadRequest": {
+        "properties": {
+          "changelog": {
+            "type": "string"
+          },
+          "parse_task_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "parse_task_id"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_skill.AdminUpdateRequest": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.CreateRequest": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parse_task_id": {
+            "type": "string"
+          },
+          "source_skill_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "version": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private",
+              "space"
+            ]
+          }
+        },
+        "required": [
+          "parse_task_id"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_skill.SkillMDResponse": {
+        "properties": {
+          "content": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.SkillResponse": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "creator_id": {
+            "type": "string"
+          },
+          "creator_name": {
+            "type": "string"
+          },
+          "current_version_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner_name": {
+            "type": "string"
+          },
+          "readme_content": {
+            "type": "string"
+          },
+          "skill_id": {
+            "type": "string"
+          },
+          "source_skill_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.SkillTagList": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.TagItem"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.SkillVersionList": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.SkillVersion"
+            },
+            "type": "array",
+            "uniqueItems": false
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_skill.UpdateRequest": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parse_task_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "version": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private",
+              "space"
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_upload.BotPublishSkillRequest": {
+        "properties": {
+          "category_id": {
+            "type": "string"
+          },
+          "changelog": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "icon_url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "presigned_url": {
+            "type": "string"
+          },
+          "publish_mode": {
+            "type": "string",
+            "enum": [
+              "create"
+            ],
+            "default": "create"
+          },
+          "skill_upload_id": {
+            "type": "string"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
+          "upload_url": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "public",
+              "private",
+              "space"
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "skill_upload_id"
+        ]
+      },
+      "internal_api_handler_upload.DownloadResponse": {
+        "properties": {
+          "download_url": {
+            "type": "string"
+          },
+          "file_sha256": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "internal_api_handler_upload.IconUploadRequest": {
+        "properties": {
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file_name",
+          "file_size"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_upload.InitUploadRequest": {
+        "properties": {
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file_name",
+          "file_size"
+        ],
+        "type": "object"
+      },
+      "internal_api_handler_upload.ReuploadRequest": {
+        "properties": {
+          "file_name": {
+            "type": "string"
+          },
+          "file_size": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "file_name",
+          "file_size"
+        ],
+        "type": "object"
+      },
+      "map_string_string": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "type": "object"
       }
     },
     "securitySchemes": {
-      "Bearer": { "type": "http", "scheme": "bearer" }
+      "Bearer": {
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      }
     }
   }
 }

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -1,0 +1,545 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Octo Marketplace API",
+    "description": "Skill and MCP Marketplace operations used by agent runtimes.",
+    "version": "1.0.0"
+  },
+  "x-octo-service": "marketplace",
+  "x-octo-base-url": "OCTO_API_BASE_URL",
+  "x-octo-space-header": true,
+  "paths": {
+    "/market/api/v1/skill_categories": {
+      "get": {
+        "operationId": "skill_category.list",
+        "summary": "List Skill categories",
+        "description": "Return Skill category IDs, names, icons, and visible Skill counts.",
+        "x-octo-risk": "read",
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/mcp_categories": {
+      "get": {
+        "operationId": "mcp_category.list",
+        "summary": "List MCP categories",
+        "description": "Return MCP category keys and visible record counts in the current Space.",
+        "x-octo-risk": "read",
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skills": {
+      "get": {
+        "operationId": "skill.list",
+        "summary": "Search Skills",
+        "description": "List Skills visible in the current Space using cursor pagination.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "limitParam": "page_size",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        },
+        "parameters": [
+          { "name": "q", "in": "query", "description": "Search query", "schema": { "type": "string" } },
+          { "name": "category_id", "in": "query", "description": "Category ID", "schema": { "type": "string" } },
+          { "name": "cursor", "in": "query", "description": "Cursor for next page", "schema": { "type": "string" } },
+          { "name": "page_size", "in": "query", "description": "Page size, default 20, max 50", "schema": { "type": "integer", "default": 20, "maximum": 50 } }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      },
+      "post": {
+        "operationId": "skill.create",
+        "summary": "Publish a Skill",
+        "description": "Publish a successfully parsed Skill archive in the current Space.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SkillCreateRequest" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skills/{skill_id}": {
+      "get": {
+        "operationId": "skill.get",
+        "summary": "Get Skill metadata",
+        "description": "Return one Skill visible to the authenticated caller.",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SkillEnvelope" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/AuthRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        },
+        "security": [{ "Bearer": [] }]
+      },
+      "patch": {
+        "operationId": "skill.update",
+        "summary": "Update a Skill",
+        "description": "Update owned Skill metadata or apply a parsed ZIP as a new immutable version.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SkillUpdateRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skills/{skill_id}/download": {
+      "get": {
+        "operationId": "skill.download",
+        "summary": "Get a Skill archive download URL",
+        "description": "Authorize access and return the artifact URL and SHA-256 digest when format=json.",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill ID",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Use json to return the download URL instead of redirecting",
+            "schema": {
+              "type": "string",
+              "enum": ["json"]
+            },
+            "x-octo-flag": "response-format"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DownloadEnvelope" }
+              }
+            }
+          },
+          "302": { "description": "Redirect to the Skill artifact" },
+          "401": { "$ref": "#/components/responses/AuthRequired" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skills/{skill_id}/reuploads": {
+      "post": {
+        "operationId": "skill.reupload.create",
+        "summary": "Initialize a Skill version upload",
+        "description": "Create an upload target for a new immutable version of an owned Skill.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ArchiveUploadRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skills/{skill_id}/versions": {
+      "get": {
+        "operationId": "skill.version.list",
+        "summary": "List Skill versions",
+        "description": "List immutable releases for one visible Skill.",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skill_uploads": {
+      "post": {
+        "operationId": "skill_upload.create",
+        "summary": "Initialize a Skill ZIP upload",
+        "description": "Create a bounded presigned upload target without publishing the Skill.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ArchiveUploadRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skill_uploads/{skill_upload_id}/parse": {
+      "post": {
+        "operationId": "skill_upload.parse",
+        "summary": "Parse a Skill ZIP upload",
+        "description": "Start parsing an archive previously uploaded to its presigned target.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "skill_upload_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill upload ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}": {
+      "get": {
+        "operationId": "skill_parse_task.get",
+        "summary": "Get a Skill parse task",
+        "description": "Return the current parse state and parsed Skill metadata.",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "skill_parse_task_id",
+            "in": "path",
+            "required": true,
+            "description": "Skill parse task ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/mcps": {
+      "get": {
+        "operationId": "mcp.list",
+        "summary": "Search MCP servers",
+        "description": "List MCP servers visible in the current Space using offset pagination.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "keyword", "in": "query", "description": "Search keyword", "schema": { "type": "string" } },
+          { "name": "category", "in": "query", "description": "Category key", "schema": { "type": "string" } },
+          { "name": "page", "in": "query", "description": "Page number, default 1", "schema": { "type": "integer", "default": 1 } },
+          { "name": "page_size", "in": "query", "description": "Page size, default 20, max 100", "schema": { "type": "integer", "default": 20, "maximum": 100 } }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      },
+      "post": {
+        "operationId": "mcp.create",
+        "summary": "Create an MCP server listing",
+        "description": "Create an MCP server owned by the caller in the current Space.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MCPCreateRequest" }
+            }
+          }
+        },
+        "responses": { "201": { "description": "Created" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/mcps/_probe": {
+      "post": {
+        "operationId": "mcp.probe",
+        "summary": "Probe an MCP server",
+        "description": "Validate an MCP connection without persisting it.",
+        "x-octo-risk": "read",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MCPProbeRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    },
+    "/market/api/v1/mcps/{mcp_id}": {
+      "get": {
+        "operationId": "mcp.get",
+        "summary": "Get MCP server details",
+        "description": "Return visible MCP metadata and its secret-redacted quick-start configuration.",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "mcp_id",
+            "in": "path",
+            "required": true,
+            "description": "MCP ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      },
+      "patch": {
+        "operationId": "mcp.update",
+        "summary": "Update an MCP server listing",
+        "description": "Partially update an owned MCP server. MCP listings have no release versions.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "mcp_id",
+            "in": "path",
+            "required": true,
+            "description": "MCP ID",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/MCPUpdateRequest" }
+            }
+          }
+        },
+        "responses": { "200": { "description": "OK" } },
+        "security": [{ "Bearer": [] }]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ArchiveUploadRequest": {
+        "type": "object",
+        "required": ["file_name", "file_size"],
+        "properties": {
+          "file_name": { "type": "string", "description": "ZIP file name" },
+          "file_size": { "type": "integer", "format": "int64", "description": "ZIP size in bytes" }
+        }
+      },
+      "SkillCreateRequest": {
+        "type": "object",
+        "required": ["parse_task_id"],
+        "properties": {
+          "parse_task_id": { "type": "string", "description": "Successful parse task ID" },
+          "name": { "type": "string" },
+          "display_name": { "type": "string" },
+          "icon_url": { "type": "string" },
+          "description": { "type": "string" },
+          "category_id": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" }, "description": "Free-form Skill tags" },
+          "visibility": { "type": "string", "enum": ["public", "private", "space"] },
+          "version": { "type": "string", "description": "Version parsed from the ZIP may be overridden when publishing" }
+        }
+      },
+      "SkillUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "display_name": { "type": "string" },
+          "icon_url": { "type": "string" },
+          "description": { "type": "string" },
+          "category_id": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" }, "description": "Free-form Skill tags" },
+          "visibility": { "type": "string", "enum": ["public", "private", "space"] },
+          "version": { "type": "string", "description": "New release version when applying a parsed ZIP" },
+          "parse_task_id": { "type": "string", "description": "Successful reupload parse task ID" },
+          "changelog": { "type": "string", "description": "Release notes for the new ZIP version" }
+        }
+      },
+      "MCPCreateRequest": {
+        "type": "object",
+        "required": ["name", "transport"],
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string", "description": "Identifier used as the mcpServers config key" },
+          "slogan": { "type": "string" },
+          "category": { "type": "string" },
+          "icon": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "transport": { "$ref": "#/components/schemas/MCPTransport" },
+          "url": { "type": "string" },
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+          "auth_type": { "type": "string" },
+          "tools": { "type": "array", "items": { "$ref": "#/components/schemas/MCPTool" } },
+          "usage_examples": { "type": "array", "items": { "type": "string" } },
+          "faqs": { "type": "array", "items": { "$ref": "#/components/schemas/MCPFAQ" } },
+          "notes": { "type": "array", "items": { "type": "string" } },
+          "visibility": { "type": "string", "enum": ["public", "private"] }
+        }
+      },
+      "MCPUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "slogan": { "type": "string" },
+          "category": { "type": "string" },
+          "icon": { "type": "string" },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "transport": { "$ref": "#/components/schemas/MCPTransport" },
+          "url": { "type": "string" },
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "headers": { "type": "object", "additionalProperties": { "type": "string" } },
+          "auth_type": { "type": "string" },
+          "tools": { "type": "array", "items": { "$ref": "#/components/schemas/MCPTool" } },
+          "usage_examples": { "type": "array", "items": { "type": "string" } },
+          "faqs": { "type": "array", "items": { "$ref": "#/components/schemas/MCPFAQ" } },
+          "notes": { "type": "array", "items": { "type": "string" } },
+          "visibility": { "type": "string", "enum": ["public", "private"] }
+        }
+      },
+      "MCPProbeRequest": {
+        "type": "object",
+        "required": ["transport"],
+        "properties": {
+          "transport": { "$ref": "#/components/schemas/MCPTransport" },
+          "url": { "type": "string" },
+          "command": { "type": "string" },
+          "args": { "type": "array", "items": { "type": "string" } },
+          "env": { "type": "object", "additionalProperties": { "type": "string" } },
+          "headers": { "type": "object", "additionalProperties": { "type": "string" } }
+        }
+      },
+      "MCPTransport": {
+        "type": "string",
+        "enum": ["stdio", "streamable-http", "sse"]
+      },
+      "MCPTool": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      },
+      "MCPFAQ": {
+        "type": "object",
+        "properties": {
+          "question": { "type": "string" },
+          "answer": { "type": "string" }
+        }
+      },
+      "SkillEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": { "$ref": "#/components/schemas/Skill" }
+        }
+      },
+      "Skill": {
+        "type": "object",
+        "properties": {
+          "skill_id": { "type": "string" },
+          "name": { "type": "string" },
+          "display_name": { "type": "string" },
+          "description": { "type": "string" },
+          "version": { "type": "string" },
+          "file_name": { "type": "string" },
+          "file_size": { "type": "integer", "format": "int64" },
+          "readme_content": { "type": "string" }
+        }
+      },
+      "DownloadEnvelope": {
+        "type": "object",
+        "properties": {
+          "data": { "$ref": "#/components/schemas/Download" }
+        }
+      },
+      "Download": {
+        "type": "object",
+        "properties": {
+          "download_url": { "type": "string" },
+          "file_sha256": { "type": "string" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" },
+              "details": { "type": "object", "additionalProperties": true },
+              "hint": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "AuthRequired": {
+        "description": "AUTH_REQUIRED",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      },
+      "Forbidden": {
+        "description": "FORBIDDEN",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      },
+      "NotFound": {
+        "description": "NOT_FOUND",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } }
+      }
+    },
+    "securitySchemes": {
+      "Bearer": { "type": "http", "scheme": "bearer" }
+    }
+  }
+}

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: octo-marketplace
+version: 0.3.0
+description: Search, install, publish, and update Marketplace Skills and MCP server listings. Load after octo-shared.
+metadata:
+  requires:
+    bins: ["octo-cli"]
+    skills: ["octo-shared"]
+---
+
+# octo-marketplace — Skills and MCP servers
+
+All commands use `$OCTO_API_BASE_URL/market/api/v1/*`, authenticate with the
+active bot profile, and send its Space context. Marketplace is one backend with
+two catalog domains, exposed as `marketplace skill` and `marketplace mcp`.
+
+Load only the reference matching the task:
+
+| Task | Read |
+|---|---|
+| Search, install, publish, or update a Skill ZIP | [`skills.md`](skills.md) |
+| Search, install, create, probe, or update an MCP listing | [`mcp.md`](mcp.md) |
+
+## Shared output rule
+
+For a non-paginated command, normalize the backend payload before reading its
+fields because CLI versions may either unwrap the backend envelope or retain it:
+
+```bash
+payload=$(octo-cli marketplace ... | jq -c '.data.data // .data')
+```
+
+Do not apply that expression to paginated search commands: `skill list` and
+`mcp list` expose their result array directly as CLI `.data` and pagination as
+`._pagination`.
+
+## Shared safety rule
+
+- Show the target object and intended mutation before install, publish, create,
+  replacement, or update; continue only after explicit user confirmation.
+- Never print presigned URLs, tokens, headers containing secrets, or raw secret
+  values.
+- Do not change records outside the user-selected Skill or MCP.
+- On failure, preserve the previously installed runtime configuration.

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -6,8 +6,9 @@ rules. MCP listings have no downloadable archive or release version.
 ## Search and inspect
 
 ```bash
-octo-cli marketplace mcp-category list
-octo-cli marketplace mcp list --keyword "<keywords>" --page 1 --page-size 20
+octo-cli marketplace mcp-category list --mode all
+octo-cli marketplace mcp list --keyword "<keywords>" --sort relevance --page 1 --page-size 20
+octo-cli marketplace mcp mine list --page 1 --page-size 20
 octo-cli marketplace mcp get <mcp-id>
 ```
 
@@ -15,6 +16,10 @@ Search is paginated: read results from CLI `.data[]`.
 The category command is non-paginated; normalize it and use a returned `key` as
 the MCP `category` value or list filter. MCP tags are free-form strings; there
 is no tag dictionary endpoint.
+
+Search filters include repeatable/comma-separated `transport`, `visibility`,
+`source`, `created-by-type`, and `tag`. `mcp-category list --mode mine` returns
+counts for owned records; `--created-by-type` narrows provenance.
 
 `key: "all"` is the list-filter sentinel and `key: ""` means uncategorized;
 do not store either as a new listing's category. Category keys are derived from
@@ -85,3 +90,8 @@ string array as create.
 For stdio connection changes, use the local handshake instead of backend probe.
 Re-read with `marketplace mcp get <mcp-id>` and verify the quick-start remains
 secret-redacted and contains no `version` field.
+
+Use `marketplace mcp delete <mcp-id>` only after showing the selected owned
+record and obtaining explicit confirmation. MCP icon uploads use the presigned
+target from `marketplace mcp-icon-upload create`; after uploading, pass the
+returned persistent icon URL through `mcp create` or `mcp update`.

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -1,0 +1,87 @@
+# octo-marketplace — MCP workflows
+
+Read `SKILL.md` first for authentication, payload normalization, and confirmation
+rules. MCP listings have no downloadable archive or release version.
+
+## Search and inspect
+
+```bash
+octo-cli marketplace mcp-category list
+octo-cli marketplace mcp list --keyword "<keywords>" --page 1 --page-size 20
+octo-cli marketplace mcp get <mcp-id>
+```
+
+Search is paginated: read results from CLI `.data[]`.
+The category command is non-paginated; normalize it and use a returned `key` as
+the MCP `category` value or list filter. MCP tags are free-form strings; there
+is no tag dictionary endpoint.
+
+`key: "all"` is the list-filter sentinel and `key: ""` means uncategorized;
+do not store either as a new listing's category. Category keys are derived from
+visible MCP records rather than managed as a separate administrator dictionary.
+
+## Install into an Agent Runtime
+
+Installation means adding the detail response's `quick_start` connection to the
+runtime's MCP configuration.
+
+Before writing configuration, show:
+
+- MCP name and transport;
+- target runtime and config file;
+- command or URL;
+- required environment-variable and header names, without secret values.
+
+After confirmation, preserve existing entries unless replacement was approved.
+Use `quick_start.slug` as the `mcpServers` key. Map stdio to
+`command`/`args`/`env`, and HTTP/SSE to `url`/`headers`. Ask for required
+secrets; never invent, echo, or persist them outside the runtime's approved
+secret mechanism. Reload the runtime and verify the server connects.
+
+## Validate a connection
+
+For `streamable-http` and `sse`, probe without persisting:
+
+```bash
+octo-cli marketplace mcp probe --data @connection.json
+```
+
+Normalize the response and continue only when `is_ok=true`.
+
+Do not call the Marketplace probe endpoint for `stdio`: the server deliberately
+does not spawn user commands. The Agent Runtime must start the proposed command
+locally, complete MCP `initialize` and `tools/list`, then stop the test process.
+
+## Create
+
+Create only after the applicable remote or local validation succeeds and the
+user reviews tools and visibility:
+
+```bash
+octo-cli marketplace mcp create --data @mcp.json
+```
+
+The body is flat: catalog metadata plus `transport`, and either
+`command`/`args`/`env` for stdio or `url`/`headers` for HTTP/SSE. Never submit
+real secret values; use `__OCTO_SECRET_PLACEHOLDER__` where the Marketplace
+contract requires a secret placeholder. `category` must be a key returned by
+`mcp-category list`; `tags` is a free-form string array.
+
+## Update
+
+Updates are partial and do not create versions. Validate changed connection
+fields first, then update only after confirmation:
+
+```bash
+# HTTP/SSE validation when connection fields changed
+octo-cli marketplace mcp probe --data @connection.json
+
+octo-cli marketplace mcp update <mcp-id> --data @changes.json
+```
+
+Category and tag changes use the same `category` key and free-form `tags`
+string array as create.
+
+For stdio connection changes, use the local handshake instead of backend probe.
+Re-read with `marketplace mcp get <mcp-id>` and verify the quick-start remains
+secret-redacted and contains no `version` field.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -1,0 +1,93 @@
+# octo-marketplace — Skill workflows
+
+Read `SKILL.md` first for authentication, payload normalization, and confirmation
+rules.
+
+## Search
+
+```bash
+octo-cli marketplace skill-category list
+octo-cli marketplace skill list --q "<keywords>" --page-size 20
+octo-cli marketplace skill get <skill-id>
+```
+
+Search is paginated: read results from CLI `.data[]`. Use the immutable
+`skill_id`, not a name. Follow `--page-all` only when all results are needed.
+The category command is non-paginated; normalize it and use each returned
+`skill_category_id` for create, update, or search filters.
+
+Skill tags are free-form strings, normally parsed from `SKILL.md` frontmatter.
+There is no separate tag dictionary endpoint.
+
+## Install
+
+Before downloading or modifying the runtime, show the Skill name and version,
+destination Skills root, and whether an existing installation will be replaced.
+
+After confirmation:
+
+1. Run `marketplace skill get <skill-id>` and verify name, version, file name,
+   and file size.
+2. Run `marketplace skill download <skill-id> --response-format json`.
+3. Normalize the result, then read `download_url` and `file_sha256`. Never infer
+   an artifact URL from metadata or log the short-lived URL.
+4. Download into a new temporary directory and require an exact SHA-256 match.
+5. Reject absolute paths, `..` traversal, links, devices, and entries escaping
+   the extraction directory. The extracted root must contain `SKILL.md`; one
+   wrapping ZIP directory is allowed.
+6. Atomically move the verified directory to `<skills-root>/<skill-name>`.
+7. After successful activation, remove staging and backup directories. On
+   failure, restore the backup before returning the error.
+8. Read the installed `SKILL.md` and follow the runtime's normal reload flow.
+
+Never execute archive scripts during installation.
+
+## Publish
+
+The ZIP's `SKILL.md` supplies the Skill version. Do not call `skill create`
+before parsing succeeds.
+
+1. Inspect the ZIP and obtain its byte size.
+2. Initialize with `marketplace skill-upload create --file-name skill.zip
+   --file-size <bytes>`.
+3. Normalize the response, then upload the ZIP to `presigned_url` with the
+   returned HTTP `method` and `headers`.
+4. Run `marketplace skill-upload parse <skill-upload-id>`.
+5. Poll `marketplace skill-parse-task get <skill-parse-task-id>`. Continue only
+   when normalized `payload.status` is `success`. Parsed ZIP metadata is in
+   `payload.result`. On `failed`, return `payload.error` and stop.
+6. Show parsed name, version, description, tags, file size, SHA-256, intended
+   visibility, and selected category. Obtain `category_id` from
+   `marketplace skill-category list`; do not send the display name as the ID.
+   Request confirmation.
+7. Publish with `marketplace skill create`, passing `parse_task_id` and
+   `visibility`.
+
+Optional metadata may override parsed values, including `category_id` and a
+JSON string array `tags`, but do not silently replace the ZIP version.
+
+## Update metadata
+
+Metadata-only changes do not create a release:
+
+```bash
+octo-cli marketplace skill update <skill-id> --data \
+  '{"display_name":"New title","description":"New description","category_id":"<id>","tags":["automation","cli"]}'
+```
+
+Resolve `category_id` through `skill-category list`. Tags remain free-form
+strings and need no dictionary lookup.
+
+## Update ZIP version
+
+1. Initialize with `marketplace skill reupload create <skill-id>` plus the new
+   ZIP's `file_name` and `file_size`.
+2. Upload to the returned presigned target.
+3. Trigger and poll parsing with `skill-upload parse` and
+   `skill-parse-task get`.
+4. Require the parsed version to differ from the current version. Show the new
+   version and changelog and request confirmation.
+5. Apply the release with `marketplace skill update <skill-id>` using
+   `parse_task_id`, `version`, and `changelog`.
+6. Run `marketplace skill version list <skill-id>`, normalize the response, and
+   read releases from `payload.items`.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -7,17 +7,20 @@ rules.
 
 ```bash
 octo-cli marketplace skill-category list
-octo-cli marketplace skill list --q "<keywords>" --page-size 20
+octo-cli marketplace skill tag list --q "<tag>"
+octo-cli marketplace skill list --q "<keywords>" --sort latest --page-size 20
 octo-cli marketplace skill get <skill-id>
 ```
 
-Search is paginated: read results from CLI `.data[]`. Use the immutable
-`skill_id`, not a name. Follow `--page-all` only when all results are needed.
+Search uses cursor pagination: read results from CLI `.data[]` and use
+`--page-all` when all matches are required. Use the immutable `skill_id`, not a
+name. Sort may be `latest`, `comprehensive`, `downloads`, or `views`.
 The category command is non-paginated; normalize it and use each returned
 `skill_category_id` for create, update, or search filters.
 
-Skill tags are free-form strings, normally parsed from `SKILL.md` frontmatter.
-There is no separate tag dictionary endpoint.
+Skill tags are strings normally parsed from `SKILL.md` frontmatter. Use
+`skill tag list` for current-Space and global suggestions; new valid tag values
+may still be submitted when publishing or updating.
 
 ## Install
 
@@ -42,29 +45,55 @@ After confirmation:
 
 Never execute archive scripts during installation.
 
-## Publish
+## Publish as a Bot
 
-The ZIP's `SKILL.md` supplies the Skill version. Do not call `skill create`
-before parsing succeeds.
+The user must first provide a `.zip` / `.skill` package, or an accessible Skill
+directory. Do not search the machine or guess a path.
 
-1. Inspect the ZIP and obtain its byte size.
-2. Initialize with `marketplace skill-upload create --file-name skill.zip
-   --file-size <bytes>`.
-3. Normalize the response, then upload the ZIP to `presigned_url` with the
-   returned HTTP `method` and `headers`.
-4. Run `marketplace skill-upload parse <skill-upload-id>`.
-5. Poll `marketplace skill-parse-task get <skill-parse-task-id>`. Continue only
-   when normalized `payload.status` is `success`. Parsed ZIP metadata is in
-   `payload.result`. On `failed`, return `payload.error` and stop.
-6. Show parsed name, version, description, tags, file size, SHA-256, intended
-   visibility, and selected category. Obtain `category_id` from
-   `marketplace skill-category list`; do not send the display name as the ID.
-   Request confirmation.
-7. Publish with `marketplace skill create`, passing `parse_task_id` and
-   `visibility`.
+1. For a directory, copy it into a fresh `mktemp -d` staging directory and
+   package the copy. Never modify the source directory or use a fixed temporary
+   path. Exclude `.git`, `.github`, caches, dependencies, and build output; keep
+   `SKILL.md`, referenced files, README, and LICENSE. If `version` is absent,
+   use an unambiguous package manifest version or ask once; write it only to the
+   staged `SKILL.md`.
+2. Inspect the package without executing it. Read the root `SKILL.md` and obtain
+   its `name`, `version`, optional `id`, byte size, and SHA-256. Reject an unsafe
+   archive using the same path, link, and size checks required for installation.
+3. Run `marketplace skill mine list --q <name> --page-all`, then compare exact
+   names. This owned-Space lookup is authoritative for the backend uniqueness
+   scope; do not use the public search result for duplicate detection.
+4. Choose exactly one flow:
+   - No exact owned name: continue with the create flow below. An existing
+     package `id` represents its source and the server will publish a new Skill
+     with a new ID and `forked_from` metadata.
+   - Exact owned name and package `id` equals that Skill's `skill_id`: stop the
+     create flow and follow **Update ZIP version** below.
+   - Exact owned name but the package has no `id`, or its `id` differs: report a
+     name conflict and ask the user to rename the package or stop. Never guess
+     that this is an update and never overwrite the existing Skill.
+5. Run `marketplace skill-category list`, resolve the intended category, then
+   show one final plan containing the package path, name, version, size,
+   SHA-256, create/update decision, visibility, and category. Ask for one final
+   confirmation; do not initialize or upload before it.
+6. Initialize with `marketplace skill-upload create --file-name <file>
+   --file-size <bytes>`, then upload to its `presigned_url` using the returned
+   HTTP `method` and `headers`.
+7. Publish once with `marketplace skill publish --skill-upload-id <id>
+   --visibility <visibility>` plus reviewed optional metadata. This endpoint
+   synchronously parses and creates the Skill; do not call `skill-upload parse`,
+   poll `skill-parse-task`, or call `skill create` in the normal Bot flow.
+8. Read the returned `skill_id`, then run `marketplace skill get <skill-id>` to
+   verify the name, version, creator, visibility, and current version.
 
 Optional metadata may override parsed values, including `category_id` and a
-JSON string array `tags`, but do not silently replace the ZIP version.
+JSON string array `tags`, but do not silently replace the package version.
+
+`skill-upload parse`, `skill-parse-task get`, and `skill create` remain exposed
+for Web/legacy compatibility and diagnosis. They are not an alternative Agent
+workflow and must not be used unless the Bot publish endpoint is unavailable.
+If parsing returns `RATE_LIMITED`, wait and retry within the user's timeout. If
+Bot publish returns a gateway timeout, query `skill mine list` before retrying
+so an already-created Skill is never duplicated.
 
 ## Update metadata
 
@@ -80,14 +109,36 @@ strings and need no dictionary lookup.
 
 ## Update ZIP version
 
-1. Initialize with `marketplace skill reupload create <skill-id>` plus the new
+Only enter this flow after exact-name lookup identifies an owned Skill and the
+package `id` equals its `skill_id`. A missing or different package ID is not
+enough evidence to update an existing record.
+
+1. Require the parsed package version to differ from the current version.
+2. Initialize with `marketplace skill reupload create <skill-id>` plus the new
    ZIP's `file_name` and `file_size`.
-2. Upload to the returned presigned target.
-3. Trigger and poll parsing with `skill-upload parse` and
+3. Upload to the returned presigned target.
+4. Trigger and poll parsing with `skill-upload parse` and
    `skill-parse-task get`.
-4. Require the parsed version to differ from the current version. Show the new
-   version and changelog and request confirmation.
-5. Apply the release with `marketplace skill update <skill-id>` using
+5. Show the new version, changelog, file size, and SHA-256 and request
+   confirmation.
+6. Apply the release with `marketplace skill update <skill-id>` using
    `parse_task_id`, `version`, and `changelog`.
-6. Run `marketplace skill version list <skill-id>`, normalize the response, and
+7. Run `marketplace skill version list <skill-id>`, normalize the response, and
    read releases from `payload.items`.
+
+If create returns `DUPLICATE_NAME` after exact owned-name lookup found no live
+record, report that a soft-deleted Skill may still reserve the name. Do not
+retry, auto-rename, or switch to update without user direction.
+
+## Manage owned Skills
+
+Use `marketplace skill mine list` to resolve owned records before update or
+delete. Deletion is a confirmed destructive action:
+
+```bash
+octo-cli marketplace skill delete <skill-id>
+```
+
+Use `marketplace skill skillmd get <skill-id>` when the current raw `SKILL.md`
+is needed without downloading the full package. Skill icon upload is a
+presigned flow initialized by `marketplace skill-icon-upload create`.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -32,6 +32,8 @@ After confirmation:
 1. Run `marketplace skill get <skill-id>` and verify name, version, file name,
    and file size.
 2. Run `marketplace skill download <skill-id> --response-format json`.
+   `--response-format json` is mandatory for this workflow; without it the
+   backend returns an artifact redirect that octo-cli intentionally does not follow.
 3. Normalize the result, then read `download_url` and `file_sha256`. Never infer
    an artifact URL from metadata or log the short-lived URL.
 4. Download into a new temporary directory and require an exact SHA-256 match.

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -66,3 +66,25 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 		}
 	}
 }
+
+func TestOctoMarketplaceReferencesEmbedded(t *testing.T) {
+	b, err := FS.ReadFile("octo-marketplace/SKILL.md")
+	if err != nil {
+		t.Fatalf("octo-marketplace/SKILL.md not embedded: %v", err)
+	}
+	content := string(b)
+	for _, ref := range []string{"skills.md", "mcp.md"} {
+		if !strings.Contains(content, ref) {
+			t.Errorf("octo-marketplace/SKILL.md must route to %q", ref)
+		}
+		path := "octo-marketplace/" + ref
+		rb, readErr := FS.ReadFile(path)
+		if readErr != nil {
+			t.Errorf("reference %q not embedded: %v", path, readErr)
+			continue
+		}
+		if len(rb) == 0 {
+			t.Errorf("reference %q is empty", path)
+		}
+	}
+}

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -88,3 +88,31 @@ func TestOctoMarketplaceReferencesEmbedded(t *testing.T) {
 		}
 	}
 }
+
+func TestOctoMarketplacePublishFlowChecksOwnedNameBeforeMutation(t *testing.T) {
+	b, err := FS.ReadFile("octo-marketplace/skills.md")
+	if err != nil {
+		t.Fatalf("read marketplace skills reference: %v", err)
+	}
+	content := string(b)
+	for _, want := range []string{
+		"or an accessible Skill",
+		"mktemp -d",
+		"Never modify the source directory",
+		"skill mine list --q <name> --page-all",
+		"package `id` equals that Skill's `skill_id`",
+		"name conflict",
+		"soft-deleted Skill may still reserve the name",
+		"do not initialize or upload before it",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("publish workflow must contain %q", want)
+		}
+	}
+	if strings.Index(content, "skill mine list --q <name> --page-all") > strings.Index(content, "skill-upload create --file-name") {
+		t.Error("owned-name lookup must happen before upload initialization")
+	}
+	if strings.Index(content, "skill-category list") > strings.Index(content, "one final plan") {
+		t.Error("category lookup must happen before the final confirmation plan")
+	}
+}


### PR DESCRIPTION
## Summary

- embed the Marketplace OpenAPI operations and generate Skill/MCP CLI commands from the registry
- preserve resource domains when one service spec exposes multiple command families
- add progressive-disclosure agent guidance for Skill and MCP workflows
- cover command shape, request construction, visibility enums, Space headers, and embedded skill references

## Validation

- `go test ./...`
- `git diff --check`
- real local Skill publish/search/download/update flow
- real local MCP create/search/detail/update flow