### PR TITLE
feat(message): add message search command family with token-kind & chat-id routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli message search` family** (6 subcommands) — full-text message and
+  file search: `message search` (messages), `search all` (messages + files),
+  `search files`, `search media` (images/videos, in-channel only, no keyword),
+  `search around` (context window around an anchor message, in-channel only),
+  and `search groups` (cross-channel aggregated overview of which channels
+  matched). `--chat-id` decides scope: with it, in-channel; without it,
+  `search`/`all`/`files` route to their cross-channel `_search_global_*`
+  endpoints (plain `search` cross-channel degrades to a mixed messages+files
+  feed). Three token subjects: `bf_` (User Bot, searches as the bot),
+  `bf_ --on-behalf-of <uid>` (OBO — searches as that real person, requires an
+  active grant), and `uk_` (user API key — real-person identity, routed to
+  `/v1/user/*`). `app_` (App Bot) tokens are **rejected locally** with a
+  `validation` error before any request. Path routing (chat-id → global,
+  `uk_` → `/v1/user`) is done CLI-side in `internal/client/search_route.go`;
+  the `uk_` prefix is now a recognized credential kind (`user_key`).
 - **`octo-cli html` domain** (20 operations) — an agent-facing CLI for the
   octo-doc interactive-HTML document service, a **separate backend** from
   `docs`. Covers the full lifecycle: `publish` immutable versions, `list` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,15 @@
 
 ## Identity Model
 
-- The CLI is **bot-only** — no user login. A bot token is an `app_*` (App Bot) or `bf_*` (User Bot) token.
+- The CLI is **bot-only** — no interactive user login. A bot token is an `app_*` (App Bot) or `bf_*` (User Bot) token. A third kind, `uk_*` (**user API key**), carries a real person's identity and is used mainly for `message search` (routed to `/v1/user/*` rather than `/v1/bot/*`); `credential.TokenKind` reports it as `user_key`.
 - **Credential resolution** (see `internal/credential`, `internal/authstore`): a token comes from a stored encrypted profile or, as a fallback, `OCTO_BOT_TOKEN`. Stored profiles live in `~/.octo-cli` (override `OCTO_CONFIG_DIR`): metadata in plaintext `config.json`, tokens in AES-256-GCM `credentials.enc`. Manage them with `octo-cli auth`.
 - **Selecting a credential at runtime**: `--bot-id <robot_id>` (env `OCTO_BOT_ID`) is the agent's primary selector — robot ids are self-known; `--profile <name>` selects by friendly name. With exactly one profile, selection is implicit; with **two or more, a selector is required** (ambiguity is a hard error, never a silent guess). Precedence: selector > sole/implicit profile > `OCTO_BOT_TOKEN`. The success envelope's `identity` echoes the active `{profile, robot_id, bot_kind, source}` so misuse is visible.
 - **Isolation boundary = OS user**: the encryption key is machine-derived, so the store resists off-machine leakage (commit/backup/sync) but not a same-user process. Isolate mutually-distrusting bots with separate OS users or `OCTO_CONFIG_DIR` values.
 - Each Bot has an **owner**; operations are attributed to the Bot identity. For LLM-backed paths (`matter extract`) the bot acts on behalf of its owner — pass `owner_uid` as `creator_uid`.
+- **Search subjects** (`message search` family): a `bf_` token searches as the bot, or as a real person with `--on-behalf-of <uid>` (OBO — requires an active grant); a `uk_` token searches as the real person it belongs to. An `app_` token cannot search — the CLI rejects it locally (`validation`, in `internal/client/search_route.go`) before any request, distinct from a server-side `FORBIDDEN`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (9 domains, 98 operations)
+## Command Structure (9 domains, 104 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -39,6 +40,7 @@ octo-cli matter    create | list | get | update | delete        (withheld)
                channel  link|unlink
                timeline add|list|delete
 octo-cli message   send | edit | sync | read-receipt
+               search  (default) | all | files | media | around | groups
 octo-cli group     list | get | members | md-get | md-update
                create | update | member-add | member-remove       (User Bot only)
 octo-cli thread    create | list | get | members
@@ -49,7 +51,7 @@ octo-cli event     list | ack
 octo-cli docs      create | list | get | rename | delete | forward-grant
                content  get|edit
                sheet    get|edit
-               scene    get|edit
+               scene    get|edit|export
                members  list|set|remove
                share    get|set
                comments list|add|edit|delete
@@ -80,7 +82,7 @@ Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agen
 
 | Var                 | Purpose                                                  |
 |---------------------|----------------------------------------------------------|
-| `OCTO_BOT_TOKEN`    | Bot token (`app_*` or `bf_*`). Fallback when no stored profile is selected. |
+| `OCTO_BOT_TOKEN`    | Bot token (`app_*`, `bf_*`, or `uk_*`). Fallback when no stored profile is selected. |
 | `OCTO_BOT_ID`       | Robot id selecting a stored profile (env form of `--bot-id`). Selector, not a secret. |
 | `OCTO_CONFIG_DIR`   | Override the credential dir (default `~/.octo-cli`).     |
 | `OCTO_API_BASE_URL`  | Unified API base URL for all services. Required.          |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 98 operations
+octo-cli is **metadata-driven**. The entire command tree — 104 operations
 across 9 domains — is auto-registered at startup from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.
@@ -44,7 +44,7 @@ Key properties:
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
-| `message` | 4   | Messaging — send, edit, sync, read-receipt                     |
+| `message` | 10  | Messaging — send, edit, sync, read-receipt; search (search/all/files/media/around/groups, in-channel or cross-channel) |
 | `file`    | 4   | Files — upload, download, credentials, presigned URLs          |
 | `event`   | 2   | Event polling — list, ack                                      |
 
@@ -105,14 +105,21 @@ export OCTO_API_BASE_URL="https://api.example.com"
 # NOTE: the `matter` domain is temporarily withheld (backend API stabilizing).
 
 # Messaging
-octo-cli message send --data '{"chat_id":"chat-1","text":"hi"}'
-octo-cli message edit --data '{"msg_id":"m-1","text":"updated"}'
+octo-cli message send --data '{"channel_id":"chat-1","channel_type":1,"payload":{"type":1,"content":"hi"}}'
+octo-cli message edit --data '{"message_id":"m-1","channel_id":"chat-1","channel_type":1,"content_edit":"{\"type\":1,\"content\":\"updated\"}"}'
+
+# Message search (User Bot bf_ or user API key uk_ token; App Bot app_ is rejected locally).
+octo-cli message search --chat-id chat-1 --keyword "quarterly report"   # in-channel
+octo-cli message search --keyword "quarterly report"                    # cross-channel (mixed feed)
+octo-cli message search files --chat-id chat-1 --keyword "*.pdf"        # files in a channel
+octo-cli message search groups --keyword "quarterly report"            # which channels matched (L1)
+octo-cli message search all --keyword "budget" --on-behalf-of u-alice  # OBO: as a real person
 
 # Groups and threads
 octo-cli group list
 octo-cli group members group-abc
-octo-cli thread list --chat-id chat-1
-octo-cli thread create --chat-id chat-1 --name "design review"
+octo-cli thread list group-abc
+octo-cli thread create group-abc --name "design review"
 
 # Files
 octo-cli file upload --file ./report.pdf
@@ -162,16 +169,21 @@ octo-cli api POST /v1/messages --data @body.json
 
 ## Authentication
 
-`octo-cli` is bot-only — there is no user login. `OCTO_BOT_TOKEN` carries either
-an **App Bot** (`app_*`) or **User Bot** (`bf_*`) token:
+`octo-cli` is bot-only — there is no interactive user login. `OCTO_BOT_TOKEN`
+carries an **App Bot** (`app_*`), a **User Bot** (`bf_*`), or a **user API key**
+(`uk_*`, a real-person identity used mainly for message search):
 
-| Prefix  | Type     | DM | Group read | Group write | Thread | Voice |
-|---------|----------|----|------------|-------------|--------|-------|
-| `app_*` | App Bot  | yes | yes       | **no**      | **no** | **no**|
-| `bf_*`  | User Bot | yes | yes       | yes         | yes    | yes   |
+| Prefix  | Type         | DM  | Group read | Group write | Thread | Voice | Search |
+|---------|--------------|-----|------------|-------------|--------|-------|--------|
+| `app_*` | App Bot      | yes | yes        | **no**      | **no** | **no**| **no** |
+| `bf_*`  | User Bot     | yes | yes        | yes         | yes    | yes   | yes    |
+| `uk_*`  | User API key | —   | —          | —           | —      | —     | yes    |
 
-The CLI does not enforce capability locally; the backend rejects
-unsupported operations with `FORBIDDEN`.
+The CLI does not enforce capability locally; the backend rejects unsupported
+operations with `FORBIDDEN`. The one local exception: an `app_*` token running
+`message search` is rejected with a `validation` error before any request.
+`uk_*` tokens are routed to `/v1/user/*`; a `bf_*` token can search as a real
+person with `--on-behalf-of <uid>` (OBO, requires an active grant).
 
 ### API Base URL
 
@@ -179,8 +191,10 @@ All backend services are accessed through a single API base URL.
 
 | Var                 | Purpose                                                  |
 |---------------------|----------------------------------------------------------|
-| `OCTO_BOT_TOKEN`    | Bot token (`app_*` or `bf_*`). Required.                 |
+| `OCTO_BOT_TOKEN`    | Bot token (`app_*`, `bf_*`, or `uk_*`). Required.       |
 | `OCTO_API_BASE_URL`  | Unified API base URL for all services. Required.          |
+| `OCTO_BOT_ID`       | Select/assert the bot credential by robot id (see `--bot-id`). |
+| `OCTO_CONFIG_DIR`   | Override the config/credential directory (default `~/.octo-cli`). |
 | `OCTO_SPACE_ID`     | Space context for platform-scoped bots.                  |
 | `OCTO_FORMAT`       | Default output format (`json` \| `table` \| `csv` \| `ndjson`). |
 
@@ -233,7 +247,7 @@ Exit codes: `3` auth, `2` validation/config, `1` everything else.
 
 ```bash
 # Dry-run to inspect the resolved request — no side effects.
-octo-cli message send --data '{"chat_id":"chat-1","text":"Hello"}' --dry-run
+octo-cli message send --data '{"channel_id":"chat-1","channel_type":1,"payload":{"type":1,"content":"Hello"}}' --dry-run
 
 # Extract a single field with jq.
 octo-cli group list --jq '.data[0].id'
@@ -263,6 +277,10 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   versions, members/sharing, attachments).
 - [`octo-marketplace`](./skills/octo-marketplace/SKILL.md) — search, install,
   publish, and update Marketplace Skills and MCP server listings.
+- [`octo-html`](./skills/octo-html/SKILL.md) — HTML docs (octo-doc, a
+  **separate backend** from `octo-docs`): publish immutable versions, drafts,
+  share codes & per-uid grants, media assets, inline comments, agent element
+  read/replace.
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -76,7 +76,7 @@ func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			if token == "" {
 				return failErr(f, output.ErrValidation(
-					"empty token", "provide a non-empty app_* or bf_* bot token"))
+					"empty token", "provide a non-empty app_*, bf_*, or uk_* bot token"))
 			}
 
 			store, err := f.AuthStore()

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -248,15 +248,22 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 			break
 		}
 		// Prepare next request. Copy the whole struct so no field is silently
-		// dropped (RawBody/ContentType/BinaryResponse/OutputPath), then clone
-		// Query and set the next cursor so we don't mutate the previous page's.
-		nextQ := url.Values{}
-		for k, vs := range req.Query {
-			nextQ[k] = append([]string(nil), vs...)
-		}
-		nextQ.Set(cursorParam, nextCursor)
+		// dropped (RawBody/ContentType/BinaryResponse/OutputPath). The cursor
+		// goes wherever the spec declares it: a query parameter (GET endpoints
+		// like matter.list) or a JSON body field (POST endpoints like the
+		// message.search family). Either way we clone the container before
+		// setting so the previous page's request is never mutated.
 		next := req
-		next.Query = nextQ
+		if cursorIsQueryParam(rt, cursorParam) {
+			nextQ := url.Values{}
+			for k, vs := range req.Query {
+				nextQ[k] = append([]string(nil), vs...)
+			}
+			nextQ.Set(cursorParam, nextCursor)
+			next.Query = nextQ
+		} else {
+			next.Body = withCursorBody(req.Body, cursorParam, nextCursor)
+		}
 		req = next
 	}
 
@@ -265,6 +272,35 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 		return err
 	}
 	return f.EmitSuccess(out)
+}
+
+// cursorIsQueryParam reports whether this operation declares its pagination
+// cursor as a URL query parameter (GET endpoints, e.g. matter.list) rather than
+// a JSON body field (POST endpoints, e.g. the message.search family). The spec
+// binds a query-declared cursor to a queryFlag whose apiName is the cursor
+// param; a body-declared cursor has no such binding.
+func cursorIsQueryParam(rt *operationRuntime, cursorParam string) bool {
+	for _, qf := range rt.queryFlags {
+		if qf.apiName == cursorParam {
+			return true
+		}
+	}
+	return false
+}
+
+// withCursorBody returns a shallow clone of the JSON body map with the cursor
+// key set to nextCursor, so paging never mutates the previous page's body. A nil
+// or non-map body yields a fresh single-key map (search bodies are always
+// map[string]any from resolveBody).
+func withCursorBody(body any, cursorParam, nextCursor string) map[string]any {
+	next := map[string]any{}
+	if m, ok := body.(map[string]any); ok {
+		for k, v := range m {
+			next[k] = v
+		}
+	}
+	next[cursorParam] = nextCursor
+	return next
 }
 
 // parsePage extracts {data:[], pagination:{has_more, next_cursor}} from a

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -341,6 +341,63 @@ func TestPagination_PageAllMergesAllPages(t *testing.T) {
 	}
 }
 
+// TestPagination_BodyCursorEndpoint pins S1: for POST-body search endpoints the
+// spec declares `cursor` as a body field (not a query param), so paging must
+// inject the next cursor into the request BODY, never the URL query. A body
+// clone per page must not mutate the previous page's body.
+func TestPagination_BodyCursorEndpoint(t *testing.T) {
+	pages := []string{
+		`{"data":[{"id":"1"}],"pagination":{"has_more":true,"next_cursor":"c2"}}`,
+		`{"data":[{"id":"2"}],"pagination":{"has_more":true,"next_cursor":"c3"}}`,
+		`{"data":[{"id":"3"}],"pagination":{"has_more":false,"next_cursor":""}}`,
+	}
+	var bodyCursors []string
+	var queryCursors []string
+	idx := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryCursors = append(queryCursors, r.URL.Query().Get("cursor"))
+		var body map[string]any
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		c, _ := body["cursor"].(string)
+		bodyCursors = append(bodyCursors, c)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(pages[idx]))
+		idx++
+	}))
+	t.Cleanup(srv.Close)
+
+	tf := cmdutil.NewTestFactory()
+	cfg := &config.Config{APIBaseURL: srv.URL, BotToken: "bf_test", Format: "json"}
+	tf.SetConfig(cfg)
+	cred := &credential.BotCredential{Token: "bf_test", Source: "test"}
+	tf.SetCredential(cred)
+	tf.SetClient(client.New(cfg, cred, client.Options{ErrOut: io.Discard}))
+	tf.RegistryFunc = registry.MustNew
+
+	root := &cobra.Command{Use: "octo-cli", SilenceUsage: true, SilenceErrors: true}
+	RegisterServiceCommands(root, tf.Factory)
+	// message.search is a POST-body endpoint; --chat-id keeps it in-scope.
+	root.SetArgs([]string{"message", "search", "--chat-id", "c1", "--keyword", "hi", "--page-all"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if len(bodyCursors) != 3 {
+		t.Fatalf("wanted 3 requests, got %d (body cursors=%v)", len(bodyCursors), bodyCursors)
+	}
+	// Cursor progresses in the BODY, first page has none.
+	if bodyCursors[0] != "" || bodyCursors[1] != "c2" || bodyCursors[2] != "c3" {
+		t.Errorf("body cursor progression = %v, want ['' c2 c3]", bodyCursors)
+	}
+	// Cursor never leaks into the query string.
+	for i, qc := range queryCursors {
+		if qc != "" {
+			t.Errorf("page %d: cursor leaked into query (%q); it must stay in the body", i, qc)
+		}
+	}
+}
+
 func TestPagination_PageLimitStops(t *testing.T) {
 	page := `{"data":[{"id":"x"}],"pagination":{"has_more":true,"next_cursor":"c"}}`
 	calls := 0

--- a/docs/message-search-integration-plan.md
+++ b/docs/message-search-integration-plan.md
@@ -1,0 +1,152 @@
+# octo-cli 消息检索能力落地方案
+
+> 依据文档:`octo-cli-search-integration.html`(基于 octo-server PR #608 `feat/messages-search-principal`)
+> 核实代码:octo-server @ `ef4e1854`(已同步到最新 upstream/main) + octo-cli @ `0eb40d1`
+> 全部结论来自实读代码,非文档转述。
+
+> ⚠️ **与既有设计的关系**:octo-cli/docs 里已有一份 `octo-cli-search-command-tree.md`(2026-07-16),定义了命令形态(`message search [all|files|media|around]`)、口语化 flag(`--chat-id`/`--keyword`)、端点映射、payload.type 白名单——**那部分命令树设计仍有效,不要推翻**。本方案是它的**契约增量**:PR #608 把检索主体从「as-bot + OBO 两态」升级为「as-bot / OBO / **user-key(uk)** 三主体 + 三条并行路由前缀 + YUJ-58 Space 复检」。即命令树照旧,凭证/路由/主体这层按下文对齐。
+
+---
+
+## 0 · 一句话结论
+
+服务端(PR #608)已把同一套 `_search*` handler 通过**子树挂载**暴露成三条并行路由,octo-cli 侧要做的核心不是"写一堆命令",而是:
+**加一份 search OpenAPI spec(走现有 spec 自动注册机制)+ 补齐凭证层的 `uk_` 主体 + 处理 base 路由前缀/OBO 请求体字段**。
+最小可用集 = 加 spec + 让 client 按凭证 kind 选前缀,as-bot / user-key 单频道 `_search` 即可打通。
+
+---
+
+## 1 · 服务端已提供什么(实读核实)
+
+PR #608 核心机制在 `modules/messages_search/route_subtree.go:54 MountSubtree`:同一个 `Handler` 实例(共享限流桶/sender 缓存),按前缀挂三棵路由树,端点集合与 web `/v1/messages` 完全一致。
+
+| 路由前缀 | 主体 | 鉴权 | subject | 挂 SpaceMiddleware? |
+|---|---|---|---|---|
+| `/v1/messages` | 真人 web(现存) | 登录态 | loginUID | 是 |
+| `/v1/bot/messages` | as-bot / as-user(OBO) | `Bearer <bot_token>` | botUID / grantorUID | **否** |
+| `/v1/user/messages` | user-key(uk) | `Bearer uk_…` | keyUID(真人) | **否** |
+
+bot/uk 两链刻意不挂 SpaceMiddleware:
+- bot 无 space_member(spaceID 恒空,走 per-principal allowlist 收敛)
+- uk 的 spaceID 走 key 上的 `api_key_space_id`,成员资格由 `resolveUKPrincipal` 内联复检(YUJ-58)
+
+核实锚点(都已读到真实代码):
+- `bot_api/search_route.go:42 mountSearchRoutes` → `MountSubtree(r,"/v1/bot/messages",...resolveSearchPrincipal...)`
+- `bot_api/search_route.go:62 resolveSearchPrincipal`:按 body 有无 `on_behalf_of` 切 as-bot / OBO 主体
+- `bot_api/search_route.go:142 validateSearchOBO`:OBO 入口 fail-fast(grant 存在性)
+- `bot_api/obo_check.go checkOBO`:grant + scope + `grantorCanReadChannel` 实时 TOCTOU
+- `botfather/search_route.go:48 resolveUKPrincipal`:uk 主体 + YUJ-58 Space 成员实时复检 → `ErrSharedForbidden`
+
+---
+
+## 2 · 三种主体 & 凭证(与 octo-cli 现状对照)
+
+| 主体 | 凭证形态 | 路由前缀 | 额外字段 | octo-cli 现状 |
+|---|---|---|---|---|
+| ① as-bot | User Bot `bf_` token | `/v1/bot/messages` | 无 | ✅ 已识别 `bf_`(user_bot) |
+| ② as-user(OBO) | 同 `bf_` token | `/v1/bot/messages` | body `on_behalf_of` | ⚠️ 需加 `--on-behalf-of` 注入 |
+| ③ user-key(uk) | 用户 API Key `uk_` | `/v1/user/messages` | 无 | ❌ 未识别 `uk_` 前缀,无 user_key kind |
+
+octo-cli 凭证层现状(`internal/credential/token.go`):
+- 只认两个前缀:`prefixApp="app_"`、`prefixUser="bf_"`;`TokenKind` 返回 app_bot / user_bot / unknown
+- **没有 `uk_`**,`MaskToken` 也不认 `uk_`(会 fallback 到 `***`)
+- ⚠️ App Bot(`app_`)在服务端 search 分支**整体 403 拒绝**(`ErrBotAPIBotUnavailable`),octo-cli 要在客户端就拦掉给友好提示
+
+---
+
+## 3 · octo-cli 命令是 spec 驱动的(关键机制,即"自动注册")
+
+**octo-cli 没有手写 cobra 命令。** 命令来自 `internal/registry/specs/*.json`(嵌入的 OpenAPI 3.1 文档),由 `internal/registry/loader.go` 在运行时解析:
+
+```
+specs/*.json  ──go:embed──▶  registry.New()  ──▶  遍历 paths[].operationId
+                                                   ──▶ 生成命令 + flag + 请求构建
+```
+
+- `loader.go:29 //go:embed specs/*.json`;`New()` 遍历目录,每份 spec 以 `x-octo-service` 命名注册,重名报错
+- 每个 operation 的元数据(parameters / requestBody schema / `x-octo-risk` / 分页)驱动 flag 生成、请求构建、`octo-cli schema` 输出
+- spec 顶层扩展字段:`x-octo-service`(服务名)、`x-octo-base-url`(如 `OCTO_API_BASE_URL`)、`x-octo-space-header`(是否发 `X-Space-Id`)
+- 每个 operation:`x-octo-risk: read|write`
+
+**含义:加 search 能力 = 新增一份 `search.json` spec,大部分工作是声明式的,不用为每个端点写 Go 命令。**
+
+client 侧(`internal/client/client.go`):
+- `attempt()` 统一 `Authorization: Bearer <cred.Token>`(line 208)
+- `cred.SpaceID != "" && !suppressSpaceHeader` 时发 `X-Space-Id`(line 210);spec `x-octo-space-header:false` → `SuppressSpaceHeader`
+- URL = base(来自 `OCTO_API_BASE_URL`)+ path;retry 只对 5xx/429 退避(line 158+)
+
+---
+
+## 4 · 8 个端点(三主体共用,path 只换前缀)
+
+| operationId(建议) | path 后缀 | 用途 | risk |
+|---|---|---|---|
+| `search.messages` | `_search` | 频道内消息 | read |
+| `search.all` | `_search_all` | 消息+文件混排 | read |
+| `search.around` | `_search_around` | 锚点上下文 | read |
+| `search.files` | `_search_files` | 频道内文件(硬锁 type=8) | read |
+| `search.media` | `_search_media` | 图片/视频按月(keyword 必空) | read |
+| `search.global.messages` | `_search_global_messages` | 跨频道消息 | read |
+| `search.global.files` | `_search_global_files` | 跨频道文件(+file_exts/size) | read |
+| `search.global.groups` | `_search_global_groups` | 按群聚合(带 sequence 回显) | read |
+
+- `channel_type`:1=DM(peer uid) / 2=群(group_no) / 5=Thread(`{group_no}____{short_id}`)
+- 单频道端点空 keyword+无 filter → 400;全局端点允许(浏览模式)
+
+---
+
+## 5 · 与现有架构的落地 gap(要动的地方)
+
+### gap A — 凭证层加 `uk_`(P1 必须)
+`internal/credential/token.go`:
+- 加 `prefixUK = "uk_"`,`TokenKind` 增加 `user_key` 分支
+- `MaskToken` 识别 `uk_` 前缀
+`internal/credential/provider.go` / `config.go`:承载 user_key(env `OCTO_USER_KEY` 或 profile),`BotCredential` 已有 `BotKind` 字段可复用
+
+### gap B — base 路由按主体选前缀(P1 必须)
+现有 spec path 是写死的(如 `/v1/bot/sendMessage`)。search 三主体只有前缀不同:
+- 方案(推荐):spec path 写 `/v1/bot/messages/_search`(as-bot/OBO 默认),client 在 kind=user_key 时把 `/v1/bot/messages` **重写为** `/v1/user/messages`
+- 或:spec 里用 `x-octo-search-mount` 扩展声明可切换前缀,loader/client 据 cred.kind 选择
+- 关键:前缀切换是**凭证 kind 驱动**,不是用户手选(避免 token 与前缀错配)
+
+### gap C — OBO 请求体字段(P4)
+`--on-behalf-of <uid>` → 仅当 kind=user_bot 时,往请求 body 注入 `on_behalf_of`;kind=user_key/app_bot 时该 flag 应报错拒绝
+
+### gap D — 错误码 → 友好文案(P1)
+| 服务端 | 客户端处理 |
+|---|---|
+| 403 `ErrBotAPIBotUnavailable` | "本期仅支持 User Bot 搜索",不重试 |
+| 403 `ErrBotAPIOBONotAuthorized` | "grantor 需先授权该 bot",不重试 |
+| 5xx `ErrBotAPIOBOInternal` | 可退避重试 |
+| 403 `ErrSharedForbidden`(uk) | "key 失效/需重新签发",不重试 |
+| 401 | 检查凭证 |
+| 200 但结果不含目标 | 视为"无此结果",**不得**据此推断频道存在/无权限 |
+
+fail-close 语义:越权一律折叠为空结果(防枚举),基础设施出错一律 fail-close。octo-cli **不应**把"空结果"与"无权限/不存在"区分展示。
+
+### gap E — 分页/限流(P5)
+- `pagination.next_cursor` 恒输出(可为空串),续页原样回传到 `cursor`;游标含 HMAC,**只透传不拼接**;深度上限 10000
+- 限流按主体(as-bot/OBO 按 botUID,uk 按 keyUID),同 bot 多入口共享配额;429 退避
+- `_search_global_groups` 的 `sequence` 请求带、响应回显,用于丢弃陈旧响应
+
+---
+
+## 6 · 分阶段落地清单
+
+- **P1 凭证 & 传输层**:token.go 加 `uk_`;client 按 kind 选前缀;错误码→文案映射(§5D)。**打通 as-bot + user_key**
+- **P2 单频道搜索**:`search.json` 声明 `_search`/`_search_all`/`_search_files`/`_search_media`/`_search_around`;flag=channel_type/id、keyword、sender、时间范围;表格/JSON 输出
+- **P3 全局搜索**:`_search_global_*`;channel_ids/types/member_uids/content_types/file_exts;空 keyword 浏览模式
+- **P4 OBO**:`--on-behalf-of`,专门处理 `OBONotAuthorized` 文案;仅 bot profile 生效
+- **P5 分页**:游标透传、`--all` 自动翻页(带上限)、`--page-size`、429 退避
+- **P6 uk 生命周期**:可选,`uk_` 获取/轮换走 botfather onboarding;403 时提示 Space 成员变更失效
+
+**最小可用 = P1 + P2 的 as-bot / user_key 单频道 `_search`。** OBO(P4) 依赖服务端 grant 已建立,是独立里程碑。
+
+---
+
+## 7 · 风险 / 待确认
+
+1. **base 前缀切换的实现位置**:spec 声明 vs client 重写,需定一个约定(建议 client 按 cred.kind 重写前缀,spec 保持单一 path)。这是唯一需要碰 loader/client 泛化逻辑的点。
+2. **App Bot 拦截**:服务端已 403,客户端建议在发请求前就按 `app_` 前缀拦掉,省一次往返。
+3. **uk 获取路径**:文档说 `uk_` 由 botfather onboarding 签发(`getOrCreateUserAPIKey`),octo-cli 是否要集成签发,还是仅消费已有 key —— 建议 P1 只消费,P6 再考虑签发。
+4. 服务端 PR #608 已合入 upstream main(octo-server 现 HEAD `ef4e1854` 含全部 6 个 commit),契约稳定,可直接对接。

--- a/docs/message-search-integration-plan.md
+++ b/docs/message-search-integration-plan.md
@@ -79,16 +79,16 @@ client 侧(`internal/client/client.go`):
 
 ## 4 · 8 个端点(三主体共用,path 只换前缀)
 
-| operationId(建议) | path 后缀 | 用途 | risk |
+> **⚠️ 订正:** 下表把 global messages/files 建模为独立 operationId(`search.global.*`),**与最终实现不符**。实际 operationId 前缀是 `message.search.*`(挂在 message 域下,非顶层 search 域),且 **global messages / global files 不是独立命令**——它们由 `message.search` / `message.search.all` / `message.search.files` 在**无 --chat-id** 时,由 CLI client(`search_route.go` 的 `searchGlobalFallback`)改写落到 `_search_global_messages` / `_search_global_files`。真正独立成命令的 global 端点只有 **groups**(`message.search.groups`)。即:6 个命令 + chat-id→global 回退,而非 8 个独立命令。
+
+| operationId(实际) | path 后缀 | 用途 | risk |
 |---|---|---|---|
-| `search.messages` | `_search` | 频道内消息 | read |
-| `search.all` | `_search_all` | 消息+文件混排 | read |
-| `search.around` | `_search_around` | 锚点上下文 | read |
-| `search.files` | `_search_files` | 频道内文件(硬锁 type=8) | read |
-| `search.media` | `_search_media` | 图片/视频按月(keyword 必空) | read |
-| `search.global.messages` | `_search_global_messages` | 跨频道消息 | read |
-| `search.global.files` | `_search_global_files` | 跨频道文件(+file_exts/size) | read |
-| `search.global.groups` | `_search_global_groups` | 按群聚合(带 sequence 回显) | read |
+| `message.search` | `_search`(无 chat-id → `_search_global_messages`) | 频道内消息 / 跨频道混合 | read |
+| `message.search.all` | `_search_all`(无 chat-id → `_search_global_messages`) | 消息+文件混排 | read |
+| `message.search.around` | `_search_around` | 锚点上下文(仅会话内) | read |
+| `message.search.files` | `_search_files`(无 chat-id → `_search_global_files`) | 文件(硬锁 type=8) | read |
+| `message.search.media` | `_search_media` | 图片/视频(仅会话内,keyword 必空) | read |
+| `message.search.groups` | `_search_global_groups` | 按群聚合(仅跨会话,带 sequence 回显) | read |
 
 - `channel_type`:1=DM(peer uid) / 2=群(group_no) / 5=Thread(`{group_no}____{short_id}`)
 - 单频道端点空 keyword+无 filter → 400;全局端点允许(浏览模式)
@@ -146,7 +146,7 @@ fail-close 语义:越权一律折叠为空结果(防枚举),基础设施出错�
 
 ## 7 · 风险 / 待确认
 
-1. **base 前缀切换的实现位置**:spec 声明 vs client 重写,需定一个约定(建议 client 按 cred.kind 重写前缀,spec 保持单一 path)。这是唯一需要碰 loader/client 泛化逻辑的点。
+1. **base 前缀切换 + chat-id→global 回退的实现位置**:最终由 **client 侧 `search_route.go` 的 `routeSearchPath` 处理两处逻辑**——(a) 按 cred.kind 切换路由前缀(`uk_` → `/v1/user/messages`),(b) `search`/`all`/`files` 在无 chat-id 时把 suffix 改写为 `_search_global_*`。spec 保持每个 operationId 单一固定 path。(原以为「前缀切换是唯一需碰 client 的点」,实际还多了 chat-id→global 回退这一处。)
 2. **App Bot 拦截**:服务端已 403,客户端建议在发请求前就按 `app_` 前缀拦掉,省一次往返。
 3. **uk 获取路径**:文档说 `uk_` 由 botfather onboarding 签发(`getOrCreateUserAPIKey`),octo-cli 是否要集成签发,还是仅消费已有 key —— 建议 P1 只消费,P6 再考虑签发。
 4. 服务端 PR #608 已合入 upstream main(octo-server 现 HEAD `ef4e1854` 含全部 6 个 commit),契约稳定,可直接对接。

--- a/docs/octo-cli-design.md
+++ b/docs/octo-cli-design.md
@@ -2,7 +2,7 @@
 
 > Source: dmworkim develop + matters main, handler-level verification
 > Reviewer: 齐静春（架构师）
-> Date: 2026-05-10
+> Date: 2026-07-21
 
 ---
 
@@ -10,14 +10,19 @@
 
 | Token Prefix | Type | Capabilities |
 |-------------|------|-------------|
-| `app_*` | App Bot | DM only, no group/thread write, no voice |
-| `bf_*` | User Bot | Full access (DM + group + thread + voice) |
+| `app_*` | App Bot | DM only, no group/thread write, no voice; **cannot search** (CLI rejects locally) |
+| `bf_*` | User Bot | Full access (DM + group + thread + voice); can search (as bot, or as a person via `--on-behalf-of`) |
+| `uk_*` | User API key | Real-person identity, used mainly for `message search`; routed to `/v1/user/*`. `bot_kind` shows `user_key` |
 
-> The CLI recognizes the prefix for display only (`octo-cli config show` → `bot_kind`); it does **not** gate commands by bot kind. An App Bot calling a User-Bot-only command sends the request and gets a server-side `FORBIDDEN`.
+> The CLI recognizes the prefix for display only (`octo-cli config show` → `bot_kind`); it does **not** gate commands by bot kind, with one exception: an `app_*` token running `message search` is rejected locally (`validation`) before the request. Otherwise an App Bot calling a User-Bot-only command sends the request and gets a server-side `FORBIDDEN`.
 
 ---
 
 ## Domain 1: matter (matters service, 17 commands)
+
+> Note: "17 commands" counts the CLI command surface, which includes convenience
+> aliases (e.g. `close`/`reopen`/`archive` over the `transition` op). The backend
+> operationId count is 14 (as in README / CLAUDE.md / the spec registry).
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
@@ -57,7 +62,7 @@ Notes:
 
 ---
 
-## Domain 2: message (dmworkim bot_api, 4 commands)
+## Domain 2: message (dmworkim bot_api, 10 commands)
 
 | # | Command | Method | Path | App Bot | User Bot |
 |---|---------|--------|------|---------|----------|
@@ -65,18 +70,29 @@ Notes:
 | 19 | `octo-cli message edit` | POST | /v1/bot/message/edit | Y | Y |
 | 20 | `octo-cli message sync` | POST | /v1/bot/messages/sync | Y (DM only) | Y (DM+group) |
 | 21 | `octo-cli message read-receipt` | POST | /v1/bot/readReceipt | Y | Y |
+| 21a | `octo-cli message search` | POST | /v1/bot/messages/_search | **N** | Y |
+| 21b | `octo-cli message search all` | POST | /v1/bot/messages/_search_all | **N** | Y |
+| 21c | `octo-cli message search files` | POST | /v1/bot/messages/_search_files | **N** | Y |
+| 21d | `octo-cli message search media` | POST | /v1/bot/messages/_search_media | **N** | Y |
+| 21e | `octo-cli message search around` | POST | /v1/bot/messages/_search_around | **N** | Y |
+| 21f | `octo-cli message search groups` | POST | /v1/bot/messages/_search_global_groups | **N** | Y |
 
 Flags:
 - send: --channel-id*, --channel-type*(uint8), --stream-no, --on-behalf-of; payload (object) via --data
 - edit: --message-id*, --message-seq, --channel-id*, --channel-type*, --content-edit*
 - sync: --data (JSON body with channel_id, channel_type, etc.)
 - read-receipt: --channel-id*, --channel-type(default:1), --message-ids*(str[])
+- search / search all / search files: --chat-id (optional; omit → cross-channel `_search_global_*`), --channel-type, --keyword, --sort(time_desc|time_asc|relevance), --page-size, --on-behalf-of; extra `filters` via --data. Paginated (cursor in body; `--page-all`).
+- search media: --chat-id* (required; in-channel only), --channel-type, --sort, --page-size, --on-behalf-of; **no** --keyword. Paginated.
+- search around: --chat-id* (required), --channel-type, --anchor-message-id*, --on-behalf-of; extra `filters` via --data. Not paginated.
+- search groups: --keyword, --on-behalf-of; extra `filters` via --data. **--chat-id not supported** (cross-channel only). Not paginated.
 
 Notes:
 - App Bot sendMessage: checkSendPermission enforces channelType=1 (DM only), requires friend relationship.
 - User Bot sendMessage: DM + group (membership check) + thread (parent group membership check).
 - payload is map[string]interface{} — object fields aren't promoted to flags, so it goes inside --data JSON. payload.type is an integer code (1=Text…; see common.ContentType / octo-messaging skill).
 - sync: App Bot explicitly blocked for group channel type.
+- search: `--chat-id` decides in-channel vs cross-channel. Without it, `search`/`all`/`files` route (CLI-side, `internal/client/search_route.go`) to `_search_global_messages` / `_search_global_files`; plain `search` cross-channel becomes a **mixed messages+files** feed. `media`/`around` require `--chat-id`; `groups` forbids it. `app_` tokens are rejected locally; `uk_` tokens are rewritten to `/v1/user/messages/*`.
 
 ---
 
@@ -195,14 +211,14 @@ Notes:
 | Domain | Commands | App Bot (Y) | App Bot (N) | User Bot (Y) | User Bot (N) |
 |--------|----------|-------------|-------------|---------------|--------------|
 | matter | 17 | 17 | 0 | 17 | 0 |
-| message | 4 | 4 (DM only) | 0 | 4 | 0 |
+| message | 10 | 4 (DM only) | 6 (search) | 10 | 0 |
 | group | 9 | 5 | 4 | 9 | 0 |
 | thread | 8 | 0 | 8 | 8 | 0 |
 | file | 4 | 4 | 0 | 4 | 0 |
 | bot | 6 | 6 | 0 | 6 | 0 |
 | event | 2 | 2 | 0 | 2 | 0 |
-| **Total** | **50** | **38** | **12** | **50** | **0** |
+| **Total** | **56** | **38** | **18** | **56** | **0** |
 
-- **App Bot**: 38/50 commands available (76%)
-- **User Bot**: 50/50 commands available (100%)
-- **App Bot blocked**: group write (4) + thread all (8) = 12 commands
+- **App Bot**: 38/56 commands available (68%)
+- **User Bot**: 56/56 commands available (100%)
+- **App Bot blocked**: group write (4) + thread all (8) + message search (6) = 18 commands

--- a/docs/octo-cli-search-command-tree.md
+++ b/docs/octo-cli-search-command-tree.md
@@ -11,14 +11,15 @@ octo-cli
 │
 ├─【service 域 · spec 自动注册】
 │
-├─ docs (29) ─ 文档 / 表格 / 白板
+├─ docs (31) ─ 文档 / 表格 / 白板
 │    ├─ 直接        create · list · get · rename · delete · forward-grant
 │    ├─ content     get · edit
 │    ├─ sheet       get · edit
 │    ├─ scene       get · edit · export
 │    ├─ members     list · set · remove
+│    ├─ share       get · set
 │    ├─ comments    list · add · edit · delete
-│    ├─ versions    list · create · state · rename · restore · delete
+│    ├─ versions    list · create · state · rename · delete · restore
 │    └─ attachments presign · get · resolve
 │
 ├─ message (4 → 10) ─ 消息
@@ -61,11 +62,15 @@ octo-cli
 | CLI 命令              | operationId          | 会话内(带 --chat-id) | 跨会话(不带 --chat-id)            | --chat-id |
 |-----------------------|----------------------|----------------------|-----------------------------------|-----------|
 | 🆕 message search      | message.search       | POST /_search        | POST /_search_global_messages ※   | 可选      |
-| 🆕 message search all  | message.search-all   | POST /_search_all    | POST /_search_global_messages     | 可选      |
-| 🆕 message search files| message.search-files | POST /_search_files  | POST /_search_global_files        | 可选      |
-| 🆕 message search media| message.search-media | POST /_search_media  | ✗（无 global media 端点）         | 必填      |
-| 🆕 message search around | message.search-around | POST /_search_around | ✗（定位需单会话锚点）           | 必填      |
-| 🆕 message search groups | message.search-groups | ✗（groups 仅跨会话）  | POST /_search_global_groups       | 禁用      |
+| 🆕 message search all  | message.search.all   | POST /_search_all    | POST /_search_global_messages     | 可选      |
+| 🆕 message search files| message.search.files | POST /_search_files  | POST /_search_global_files        | 可选      |
+| 🆕 message search media| message.search.media | POST /_search_media  | ✗（无 global media 端点）         | 必填      |
+| 🆕 message search around | message.search.around | POST /_search_around | ✗（定位需单会话锚点）           | 必填      |
+| 🆕 message search groups | message.search.groups | ✗（groups 仅跨会话）  | POST /_search_global_groups       | 禁用      |
+
+> operationId 用**点号**分段（`message.search.all` → `message search all` 三级命令）；loader 按 `.` split 建命令树，连字符会错误生成两级命令。
+> 「会话内 → 跨会话」的 path 改写由 **CLI client**(`internal/client/search_route.go` 的 `routeSearchPath`)按 token 前缀 + chat-id 有无完成,**非后端分发**;spec 里每个 operationId 仍绑一个真实固定 path。
+
 
 后端有 3 个 global 端点：_search_global_messages（消息+文件混合）、_search_global_files（文件）、_search_global_groups（按群聚合概览 L1）。
 media/around 没有跨会话端点 → --chat-id 必填；groups 只有跨会话端点 → --chat-id 禁用。
@@ -159,9 +164,9 @@ octo-cli message search files --data '{"filters":{"file_exts":["pdf"],"file_size
 # 浏览模式（keyword 与 filter 全空，列所有会话近期消息）
 octo-cli message search all
 
-# ✗ media / around 无跨会话端点，不带 --chat-id 会报 VALIDATION（chat-id 必填）
-octo-cli message search media          # 报错：--chat-id required
-octo-cli message search around         # 报错：--chat-id required
+# ✗ media / around 无跨会话端点，不带 --chat-id 由后端拒绝（channel_id 必填；CLI 不做本地强制，请求会发到后端返回校验错误）
+octo-cli message search media          # 后端拒：channel_id required
+octo-cli message search around         # 后端拒：channel_id required
 
 # groups 仅跨会话（聚合概览，看哪些会话命中）；带 --chat-id 应报错
 octo-cli message search groups --keyword "发布"

--- a/docs/octo-cli-search-command-tree.md
+++ b/docs/octo-cli-search-command-tree.md
@@ -1,0 +1,197 @@
+# octo-cli 完整命令树 · 消息检索（🆕 高亮 · 以源码为依据）
+
+> 依据：octo-server modules/messages_search 源码核对 + 本轮讨论修订。
+> 🆕 = 本次新增。命名遵循既有约定：`域 资源 动作` 由 OpenAPI spec 自动注册；flag 走 Agent 友好口语化（`--chat-id` 而非 `--channel-id`）。
+> --chat-id 下沉到各子命令，由每个 operation 的 spec 单独声明必填/可选。
+
+## 一、完整命令树（全域，🆕 高亮）
+
+```
+octo-cli
+│
+├─【service 域 · spec 自动注册】
+│
+├─ docs (29) ─ 文档 / 表格 / 白板
+│    ├─ 直接        create · list · get · rename · delete · forward-grant
+│    ├─ content     get · edit
+│    ├─ sheet       get · edit
+│    ├─ scene       get · edit · export
+│    ├─ members     list · set · remove
+│    ├─ comments    list · add · edit · delete
+│    ├─ versions    list · create · state · rename · restore · delete
+│    └─ attachments presign · get · resolve
+│
+├─ message (4 → 10) ─ 消息
+│    ├─ 直接        send · edit · sync · read-receipt
+│    └─ 🆕 search ─ 消息检索（OpenSearch 直连 · risk=read）
+│         │  会话内 / 跨会话 = --chat-id 有无；每个子命令自带 --chat-id 并声明必填/可选
+│         │
+│         ├─ 🆕 (默认)  --chat-id 可选：纯消息全文（text/forward/richtext，payload.type∈[1,11,14]）
+│         ├─ 🆕 all     --chat-id 可选：消息+文件混合 feed（payload.type∈[1,8,11,14]，空 kw 追加图/视频）
+│         ├─ 🆕 files   --chat-id 可选：文件（payload.type=8，按文件名/caption）
+│         ├─ 🆕 media   --chat-id 必填：图片+视频（payload.type∈[2,5]，keyword 必空）
+│         ├─ 🆕 around  --chat-id 必填：定位 anchor 消息上下文窗口
+│         └─ 🆕 groups  --chat-id 禁用（仅跨会话）：按群/子区/DM 聚合概览（L1，哪些会话命中了）
+│
+├─ group (9) ─ 群
+│    └─ list · get · members · md-get · md-update
+│       create · update · member-add · member-remove          # 后 4 仅 User Bot
+│
+├─ thread (8) ─ 线程 / 子区
+│    └─ create · list · get · members · join · leave · md-get · md-update
+│
+├─ bot (6) ─ Bot 生命周期
+│    └─ register · user-info · space-members · set-commands · typing · heartbeat
+│
+├─ file (4) ─ 文件
+│    └─ upload · download · credentials · presigned
+│
+├─ event (2) ─ 事件轮询
+│    └─ list · ack
+│
+├─ matter (14) ─ 待办   ⚠️ x-octo-disabled 隐藏
+│
+└─【手写叶子命令 · 非 spec 生成】
+     └─ schema · api · config(show) · auth(login·status·logout·list)
+        skills · version · completion(bash·zsh·fish·powershell)
+```
+
+## 二、🆕 search 子命令 ↔ 端点映射（源码核对）
+
+| CLI 命令              | operationId          | 会话内(带 --chat-id) | 跨会话(不带 --chat-id)            | --chat-id |
+|-----------------------|----------------------|----------------------|-----------------------------------|-----------|
+| 🆕 message search      | message.search       | POST /_search        | POST /_search_global_messages ※   | 可选      |
+| 🆕 message search all  | message.search-all   | POST /_search_all    | POST /_search_global_messages     | 可选      |
+| 🆕 message search files| message.search-files | POST /_search_files  | POST /_search_global_files        | 可选      |
+| 🆕 message search media| message.search-media | POST /_search_media  | ✗（无 global media 端点）         | 必填      |
+| 🆕 message search around | message.search-around | POST /_search_around | ✗（定位需单会话锚点）           | 必填      |
+| 🆕 message search groups | message.search-groups | ✗（groups 仅跨会话）  | POST /_search_global_groups       | 禁用      |
+
+后端有 3 个 global 端点：_search_global_messages（消息+文件混合）、_search_global_files（文件）、_search_global_groups（按群聚合概览 L1）。
+media/around 没有跨会话端点 → --chat-id 必填；groups 只有跨会话端点 → --chat-id 禁用。
+
+【🆕 补充：_search_global_groups 是什么】源码核对（search_global_groups.go）：这是「聚合优先(L1)」的跨会话概览端点，不返回逐条消息，而是返回「哪些群/子区/DM 命中了关键词」的聚合桶列表。每个桶（GroupBucket）含：channel_id/channel_type、群名、（子区还带 thread_id/name）、match_count（命中条数，OS doc_count 近似、match_count_approx=true）、latest_at（最新命中时间，从可见命中重算防泄露）、preview（若干条预览）。响应体 {sequence, query_id, total_groups(HLL 近似), groups[]}，无 sort/page_size/cursor（一次给一份概览，桶按 latest_at 倒序固定）。sequence 请求带、响应原样回显，供前端丢弃陈旧响应。
+典型用法：两级检索的第一级——先用 groups 看「关键词命中了哪些会话」，再对具体会话用 _search/_search_all 拉逐条。
+
+## 三、源码核对结论（为什么 search 跨会话 = 混合，带 ※）
+
+payload.type 白名单（modules/messages_search 源码）：
+- _search              = [1,11,14]           纯消息，无 file，返回 MessageHit
+- _search_all          = [1,8,11,14]（空 kw +2,5）  消息+文件混合，返回 SearchAllHit{message|file}
+- _search_global_messages = [1,8,11,14]（空 kw +2,5） 与 _search_all 白名单完全一致，混合
+- _search_files / _search_global_files = [8]
+- _search_media        = [2,5]
+
+关键事实：
+- _search（纯消息）与 _search_all（混合）不是同一套：前者无 file(8)、返回 MessageHit。
+- _search_all 与 _search_global_messages 是同一套混合 feed，差别仅频道范围（term vs terms allowlist）——这正是"带/不带 --chat-id"本身。
+- ※ 因此 search 不带 --chat-id 时，后端唯一可落的 global 消息端点是 _search_global_messages（混合）。
+  即 search 跨会话会带上文件命中，语义从"纯消息"降级为"消息+文件混合"，与 all 跨会话一致。
+  → 采纳主人决定：search 跨会话复用 _search_global_messages，接受该混合语义（文档明示，避免使用者困惑）。
+
+## 四、🆕 检索主体（三选一：as-bot / OBO / user-key）
+
+【🆕 修正 2026-07-20】PR #608 后检索主体从两种扩为三种，前缀不同：
+```
+默认(不传)              → as bot：bot 自身可见范围（bot 好友 ∪ 已入群 ∪ 群下 Thread），路由 /v1/bot/messages
+🆕 --on-behalf-of <uid>  → as user(OBO)：以某用户身份检索（需该 user 预授 OBO grant 给本 bot，同用 bot_token），路由 /v1/bot/messages
+🆕 user-key(uk_)         → 携用户 API Key 以真人身份检索（不在 bot_api，在 botfather），路由 /v1/user/messages
+```
+服务端 principal 解析（对齐后端「主体中立 SearchService」）：
+```
+无 flag          → requesterUID = robotID，按 bot 可见性解析 allowlist
+🆕 --on-behalf-of → 校验 (grantor,bot) active OBO grant → requesterUID = grantor，按 grantor 重算 allowlist
+```
+前置：
+- as_user 跨会话:checkOBO 是单频道门,全局无单一 channel_id → 以 grantor 为主体重算 allowlist。
+- 放开 on_behalf_of「只能跟 token 创建者」(oboCreateGrant 的 CreatorUID==uid) → 配额度+审计+反枚举。（已按 grant 谓词处理，不再限制创建者）
+- 【🆕 2026-07-20】App Bot(app_) 打检索 → bot_api 直接 403 ErrBotAPIBotUnavailable，CLI 客户端建议提前拦。
+- ✅ 【已修正 2026-07-20】as bot 可见性:**已实现**，非待办。源码 messages_search/authz.go:210 botCheckP2PAccess（#C / YUJ-50）——bot 的 P2P 只判 IsFriend(bot,peer)，不做黑名单、不做 bot 分类；bot 可达集 buildBotAllowlist = 好友 ∪ 已入群 ∪ 群下 Thread。CLI 侧无需再等此后端设计。
+
+## 五、🆕 flag 约定
+
+范围开关:各子命令自带 `--chat-id`(=channel_id)，spec 单独声明必填/可选(search/all/files 可选;media/around 必填);会话内配 `--channel-type`。
+会话内:`--keyword` · `--sort`(time_desc/time_asc/relevance) · `--page-size`;around 特有 `--anchor-message-id`。
+跨会话:专属过滤走 `--data`(channel_ids · channel_types · member_uids · content_types · sender_ids · sent_at_*);files 额外 file_exts · file_size_min · file_size_max。
+主体:`--on-behalf-of <uid>`(不传 = as bot)。
+通用复用:`--page-all` / `--page-limit` · `--jq` · `--format table` · `--dry-run`。
+spec 标注:`x-octo-risk: read` · `x-octo-space-header: true`。
+校验差异(后端做,CLI 透传):会话内 keyword+filter 不能同时为空、relevance 要求 keyword 非空、media 要求 keyword 空;跨会话允许全空(浏览模式)、不支持 relevance。
+
+## 六、🆕 用法示例
+
+### 会话内（带 --chat-id）
+
+```bash
+# 纯消息全文检索（关键词 + 排序 + 分页）
+octo-cli message search --chat-id c_123 --channel-type 2 --keyword "发布" --sort time_desc --page-size 50
+
+# 会话内 · 按发送人 + 时间段（keyword 可空，但 keyword 与 filter 不能同时为空）
+octo-cli message search --chat-id c_123 --channel-type 2 \
+    --data '{"filters":{"sender_ids":["u_1"],"sent_at_from":"2026-07-01","sent_at_to":"2026-07-15"}}'
+
+# 消息+文件混合
+octo-cli message search all --chat-id c_123 --channel-type 2 --keyword "预算"
+
+# 文件（按文件名 / caption）
+octo-cli message search files --chat-id c_123 --channel-type 2 --keyword report.pdf
+
+# 图片+视频（media 必带 --chat-id，keyword 必空）
+octo-cli message search media --chat-id c_123 --channel-type 2
+
+# 定位某条消息的上下文窗口（around 必带 --chat-id）
+octo-cli message search around --chat-id c_123 --channel-type 2 --anchor-message-id 2077314883757445121
+```
+
+### 跨会话（不带 --chat-id，搜 bot 能读的所有会话）
+
+```bash
+# 纯消息动词跨会话 → 落 _search_global_messages（混合，会含文件命中，见第三节 ※）
+octo-cli message search --keyword "上线"
+
+# 混合 feed 跨会话
+octo-cli message search all --keyword "发布" \
+    --data '{"filters":{"channel_types":[2,5],"member_uids":["u_1"]}}'
+
+# 跨会话只搜文件
+octo-cli message search files --data '{"filters":{"file_exts":["pdf"],"file_size_min":1024}}'
+
+# 浏览模式（keyword 与 filter 全空，列所有会话近期消息）
+octo-cli message search all
+
+# ✗ media / around 无跨会话端点，不带 --chat-id 会报 VALIDATION（chat-id 必填）
+octo-cli message search media          # 报错：--chat-id required
+octo-cli message search around         # 报错：--chat-id required
+
+# groups 仅跨会话（聚合概览，看哪些会话命中）；带 --chat-id 应报错
+octo-cli message search groups --keyword "发布"
+octo-cli message search groups --keyword "预算" --data '{"filters":{"channel_types":[2,5]}}'
+```
+
+### as user（--on-behalf-of，以某用户身份检索）
+
+```bash
+# 默认 as bot（不传 = bot 自身可见范围）
+octo-cli message search all --keyword "上线"
+
+# as user：以 alice 能读的会话为边界（需 alice 预授 OBO grant 给本 bot）
+octo-cli message search all --keyword "上线" --on-behalf-of u_alice
+
+# as user 会话内
+octo-cli message search --chat-id c_123 --channel-type 2 --keyword "发布" --on-behalf-of u_alice
+```
+
+### 通用 flag（任意子命令可叠加）
+
+```bash
+# cursor 全量翻页 + jq 提取 + 表格输出
+octo-cli message search all --keyword "发布" --page-all --jq '.data[].message.content' --format table
+
+# 只看请求结构不真发（联调用）
+octo-cli message search all --chat-id c_123 --keyword "x" --dry-run
+```
+
+## 七、落地优先级
+
+1. P0:后端抽主体中立 SearchService + bot handler;CLI 加 5 operation(各自声明 --chat-id 必填/可选)。→ 会话内/跨会话靠 --chat-id 统一,纯封装现有端点,行为不变。
+2. P1:🆕 --on-behalf-of(as user),前置补「as_user 全局 allowlist 生成」小设计 + 放开创建者限制配额/审计。

--- a/docs/octo-cli-search-tech-spec.md
+++ b/docs/octo-cli-search-tech-spec.md
@@ -1,0 +1,178 @@
+# octo-cli 消息检索集成 · 完整技术方案
+
+> 汇总自三份评审文档(CLI 集成方案 / 统一端点设计 / 命令树 v5)。
+> 依据:octo-server @ `ef4e1854`(PR #608 已合)+ octo-cli @ `640e71a`,全部实读源码。
+> 目标:让 octo-cli 支持消息检索,覆盖 server 侧三主体(as-bot / OBO / uk),Agent 友好,且零改 CLI loader 核心。
+
+---
+
+## 一、背景与目标
+
+PR #608 已在 octo-server 落地消息检索(messages_search 模块),对外通过三条并行入口暴露 8 个搜索端点。现要在 octo-cli 增加对应命令,让 Agent/人可用 CLI 检索消息。
+
+约束:
+- octo-cli 命令 **spec 驱动**(`//go:embed specs/*.json` 自动注册),不手写 cobra 命令 → 集成应以「加 spec」为主。
+- 命名 Agent 友好:`--chat-id`(不是 --channel-id)。
+- 权限判定全在 server,CLI 只做前缀路由 + 参数透传,不复制鉴权。
+- octo-cli upstream push 禁用;两仓远端写均需授权。
+
+---
+
+## 二、Server 侧现状(可对接的接口)
+
+### 2.1 三主体 / 三入口
+
+| 主体 | 前缀 | token | 授权模型 |
+|---|---|---|---|
+| as-bot | /v1/bot/messages | bf_ | bot allowlist(好友 ∪ 已入群 ∪ 群下 Thread) |
+| OBO | /v1/bot/messages(body on_behalf_of) | bf_ | active OBO grant + 逐频道 scope |
+| uk | /v1/user/messages | uk_ | 真人可达集 + 实时 Space 成员门(YUJ-58) |
+
+- **as-bot**:User Bot 自身身份。P2P 只判 IsFriend(authz.go:210 botCheckP2PAccess,已实现)。App Bot(app_)→ 403。
+- **OBO**:resolveSearchPrincipal 按 on_behalf_of 切主体;入口 validateSearchOBO 查 grant 存在性(无→403),逐频道 scope+TOCTOU 下沉到 obo gate,经 SetOBOChecker 注入,复用发消息侧同一 checkOBO(读写一致)。
+- **uk**:botfather 挂载,以真人 API Key 身份直接搜;resolveUKPrincipal 内联补 CheckMembership 实时 Space 成员门(绕过 SpaceMiddleware 后必须补,否则存量 key 越权枚举 DM)。
+
+### 2.2 八个搜索端点(三入口共用同一 messages_search Handler)
+
+| 端点 | 用途 | 态 |
+|---|---|---|
+| _search | 频道内纯消息(type 1,11,14) | 会话内 |
+| _search_all | 消息+文件混排(1,8,11,14) | 会话内 |
+| _search_around | 锚点上下文窗口 | 会话内 |
+| _search_files | 频道内文件(type 8) | 会话内 |
+| _search_media | 图片/视频(2,5,keyword 必空) | 会话内 |
+| _search_global_messages | 跨频道消息(混合,同 _search_all 白名单) | 跨会话 |
+| _search_global_files | 跨频道文件 | 跨会话 |
+| _search_global_groups | 跨频道按群聚合概览(L1) | 跨会话 |
+
+关键事实:_search_all 与 _search_global_messages payload.type 白名单**完全一致**(都是混合 feed),差别仅频道范围 term(单) vs terms(allowlist)——这正是「有无 chat_id」本身。
+
+### 2.3 搜索中间件链
+```
+authBot → botActorUID → SharedUIDRateLimiter → resolveSearchPrincipal → searchRateLimiter → audit → backendGate
+```
+刻意不挂 SpaceMiddleware(bot 无 space_member);限流按 botUID(botActorUID 落 uid)。
+
+---
+
+## 三、octo-cli 现状(决定集成形态)
+
+- loader(`internal/registry/loader.go`):embed specs,按 `x-octo-service` 建表;`OperationDetail.Path` 是**单一固定 path**——一个 operationId 死绑一个 URL,**不支持运行时按参数切 path**。
+- 命令树构建(`cmd/service/service.go:68`):`strings.Split(d.ID, ".")` 按 operationId 的 `.` 分段建命令层级(`message.search.all` → `message search all`),中间 resource 节点自动补。
+- 现有 9 spec 无 search;credential 层(token.go)只认 `app_`/`bf_`,**无 uk_**。
+- message.json 的 sendMessage 已带 `on_behalf_of` 字段 → OBO 在 CLI 侧已有模板。
+- 支持机制:`x-octo-flag`(body 字段提升为干净 flag 名,wire key 不变)、`x-octo-pagination`(--page-all)、`x-octo-risk`、`x-octo-space-header`。
+
+**核心矛盾**:v5 设计里 search/all/files「带 --chat-id 走会话内、不带走 global」= 一个 operationId 两个 path,与 loader 单 path 模型冲突。
+
+---
+
+## 四、解决方案:后端新增 unified 端点(主人拍板)
+
+不在 CLI 做条件路由,而是给需要切换的命令各加一个后端 unified 门面端点,由后端按 body 有无 channel_id 分发。CLI 侧每命令绑一个固定 path,**零改 loader**。
+
+### 4.1 新增 3 个端点
+
+| CLI 命令 | 新增端点 | 有 chat_id → | 无 chat_id → |
+|---|---|---|---|
+| message search | `POST /v1/bot/messages/_search_unified` | _search(纯消息) | _search_global_messages(混合) |
+| message search all | `POST /v1/bot/messages/_search_all_unified` | _search_all | _search_global_messages |
+| message search files | `POST /v1/bot/messages/_search_files_unified` | _search_files | _search_global_files |
+
+不新增(本就单态,绑原端点):media(仅会话内)· around(仅会话内)· groups(仅跨会话)。
+
+### 4.2 门面(facade)落地:不重写检索逻辑
+
+```go
+func (ba *BotAPI) searchUnified(inScope, globalScope wkhttp.HandlerFunc) wkhttp.HandlerFunc {
+    return func(c *wkhttp.Context) {
+        chatID := probeChannelID(c)   // 复读+还原 body,抄 parseSearchOnBehalfOf(search_route.go:157) 模式
+        if strings.TrimSpace(chatID) != "" {
+            inScope(c)                // 现有 _search / _search_all / _search_files handler
+        } else {
+            globalScope(c)            // 现有 _search_global_messages / _search_global_files handler
+        }
+    }
+}
+```
+- 门面挂**同一条中间件链末端**,principal(as-bot/OBO/uk)已解析好,下游 handler 直接读同 context → 三主体天然复用,无需为 unified 单独处理鉴权。
+- 校验下沉到被分发的 handler,门面不做参数校验。
+
+### 4.3 装配(推荐形态 A)
+
+messages_search.Handler 加 `MountUnified(r, prefix, mws...)`,把 3 个 unified 路由用已有内部 handler 组合注册。bot_api / botfather 各调一次 MountUnified → **三入口对称**,分发逻辑单点收在 messages_search 内。
+
+---
+
+## 五、CLI 侧改动
+
+### 5.1 新增 search.json spec
+```
+message.search        → /v1/bot/messages/_search_unified        (--chat-id 可选)
+message.search.all    → /v1/bot/messages/_search_all_unified     (--chat-id 可选)
+message.search.files  → /v1/bot/messages/_search_files_unified   (--chat-id 可选)
+message.search.media  → /v1/bot/messages/_search_media           (--chat-id 必填)
+message.search.around → /v1/bot/messages/_search_around          (--chat-id 必填)
+message.search.groups → /v1/bot/messages/_search_global_groups   (--chat-id 禁用)
+```
+每 operationId 一个固定 path,loader 零改。全部 `x-octo-risk: read`、`x-octo-space-header: true`。
+
+### 5.2 credential 层加 uk_
+token.go 加 `prefixUK = "uk_"`;TokenKind 补 `user_key`;MaskToken 同步;env/file provider 放行 uk_ 加载。
+
+### 5.3 client 按 kind 选前缀
+```
+user_bot (bf_) → /v1/bot/messages
+user_key (uk_) → /v1/user/messages
+app_bot (app_) → fail-fast:提示"App Bot 不支持检索"(server 侧 403)
+```
+
+### 5.4 OBO flag
+search.json 各端点 requestBody 加 `on_behalf_of` + CLI flag `--on-behalf-of <grantorUID>`(抄 message.json 模式),仅 user_bot 可用。
+
+---
+
+## 六、命令树(Agent 友好)
+
+```
+octo search messages   --chat-id <id> --keyword <kw> [--chat-type --page-size --cursor]
+octo search all        --chat-id <id> --keyword <kw>          # 消息+文件混排
+octo search around     --chat-id <id> --anchor-message-id <m> # 上下文窗口
+octo search files      --chat-id <id> [--keyword]
+octo search media      --chat-id <id>                         # keyword 必空
+octo search groups     --keyword <kw>                         # 跨会话聚合概览 L1(--chat-id 禁用)
+# messages/all/files:带 --chat-id 会话内,不带则后端 unified 自动跨会话
+# OBO(bf_ only):任意子命令 + --on-behalf-of <grantorUID>
+# uk:换 uk_ token 自动走 /v1/user 前缀,命令树不变
+```
+两级检索:先 `groups` 看关键词命中哪些会话 → 再对具体会话 `messages`/`all` 拉逐条。
+
+---
+
+## 七、语义提醒(写进接口文档)
+
+- `_search_unified` 无 chat_id 时唯一可落 global 端点是混合版(_search_global_messages)→ 跨会话 search 会带文件命中,语义从「纯消息」变「消息+文件混合」。必须在 description 明示。
+- all/files 无此问题(两态语义本就一致)。
+- 校验差异(后端做,CLI 透传):会话内 keyword+filter 不能同时空、relevance 要 keyword 非空、media keyword 必空;跨会话允许全空(浏览模式)、不支持 relevance。
+- 结果为空可能是越权被静默过滤(存在性隐藏),不可据此推断频道不存在。
+
+---
+
+## 八、实施顺序与改动面
+
+阶段(建议):
+1. 后端:messages_search 加 MountUnified + 3 门面 handler(纯分发)。
+2. 后端:bot_api / botfather search_route.go 各追加 MountUnified(三入口对称)。
+3. 后端:3 unified 端点 OpenAPI 描述 + 语义说明 + 门面分发单测 + 三主体×unified 鉴权回归。
+4. CLI:新增 search.json(先只挂 bf_ 跑通 as-bot)。
+5. CLI:credential 补 uk_ + client 前缀路由。
+6. CLI:--on-behalf-of(OBO)+ App Bot fail-fast。
+
+改动面清单:
+- 后端(octo-server,需授权):messages_search MountUnified + 3 handler;bot_api/botfather 装配;OpenAPI;测试。纯新增,不改老 8 端点,web 前端零影响。
+- CLI(octo-cli,需授权):search.json;token.go uk_;client 前缀路由;OBO flag。
+
+风险/边界:
+- 门面不含检索逻辑 → 不引入新鉴权/可见性风险,判定仍在被分发 handler + principal 链。
+- 老端点全保留(web 在用)。
+- octo-cli upstream push 禁用;两仓远端写均需主人明确授权。

--- a/docs/octo-cli-search-tech-spec.md
+++ b/docs/octo-cli-search-tech-spec.md
@@ -69,6 +69,8 @@ authBot → botActorUID → SharedUIDRateLimiter → resolveSearchPrincipal → 
 
 ## 四、解决方案:后端新增 unified 端点(主人拍板)
 
+> **⚠️ 已废弃(历史方案,最终未采用):** 本节描述的「后端新增 unified 门面端点、由后端按 body 有无 channel_id 分发」方案最终**未采纳**。实际实现为**方案B:CLI 侧** `internal/client/search_route.go` 的 `routeSearchPath` 按 **token 前缀 + chat-id 有无**分流;server 保持原 8 端点不变,无任何 `_search_unified` / `MountUnified`。下文 4.1–4.3、5.1(spec path 部分)、第八节实施顺序均为该废弃方案的记录,仅作历史保留。仍然有效的部分见第二节(server 现状)、5.2/5.3(credential 加 uk_ + 按 kind 选前缀)、5.4(OBO)、第六节(命令树)、第七节(混合语义)。
+
 不在 CLI 做条件路由,而是给需要切换的命令各加一个后端 unified 门面端点,由后端按 body 有无 channel_id 分发。CLI 侧每命令绑一个固定 path,**零改 loader**。
 
 ### 4.1 新增 3 个端点
@@ -107,10 +109,13 @@ messages_search.Handler 加 `MountUnified(r, prefix, mws...)`,把 3 个 unified 
 ## 五、CLI 侧改动
 
 ### 5.1 新增 search.json spec
+
+> **⚠️ 订正:** 下方 path 曾写成 `*_unified`(废弃方案)。实际 spec 每个 operationId 绑真实固定 path(`_search` / `_search_all` / `_search_files`),chat-id→global 的改写由 CLI 侧 `search_route.go` 完成,不存在 unified 端点。已订正如下:
+
 ```
-message.search        → /v1/bot/messages/_search_unified        (--chat-id 可选)
-message.search.all    → /v1/bot/messages/_search_all_unified     (--chat-id 可选)
-message.search.files  → /v1/bot/messages/_search_files_unified   (--chat-id 可选)
+message.search        → /v1/bot/messages/_search        (--chat-id 可选;无则 CLI 改写为 _search_global_messages)
+message.search.all    → /v1/bot/messages/_search_all     (--chat-id 可选;无则 CLI 改写为 _search_global_messages)
+message.search.files  → /v1/bot/messages/_search_files   (--chat-id 可选;无则 CLI 改写为 _search_global_files)
 message.search.media  → /v1/bot/messages/_search_media           (--chat-id 必填)
 message.search.around → /v1/bot/messages/_search_around          (--chat-id 必填)
 message.search.groups → /v1/bot/messages/_search_global_groups   (--chat-id 禁用)
@@ -159,6 +164,8 @@ octo search groups     --keyword <kw>                         # 跨会话聚合�
 ---
 
 ## 八、实施顺序与改动面
+
+> **⚠️ 已废弃:** 本节阶段 1–3(后端 MountUnified + 门面 handler + unified 端点)对应废弃的 unified 方案,**最终未实施**。实际只做了 CLI 侧改动(阶段 4–6:search.json 绑真实 path + `search_route.go` 分流 + credential 加 uk_ + OBO/App Bot 本地拒绝),server 端零改动。下文保留作历史。
 
 阶段(建议):
 1. 后端:messages_search 加 MountUnified + 3 门面 handler(纯分发)。

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -121,6 +121,16 @@ func (c *Client) Do(ctx context.Context, req *Request) ([]byte, error) {
 	if req.Service == "" {
 		req.Service = "default"
 	}
+
+	// Route the message-search family by chat-id scope and token kind
+	// (no channel_id → cross-session global; uk_ → /v1/user; app_ → error).
+	// Non-search paths pass through unchanged.
+	routedPath, err := routeSearchPath(c.cred, req.Path, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Path = routedPath
+
 	base := c.cfg.ServiceURL(req.Service)
 	if base == "" {
 		return nil, output.ErrValidation(

--- a/internal/client/search_route.go
+++ b/internal/client/search_route.go
@@ -1,0 +1,88 @@
+package client
+
+import (
+	"strings"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+// searchBotPrefix is the bot-mounted path prefix for the message-search family.
+// User API keys (uk_) search the same endpoints under a real-person mount, so
+// their requests are rewritten to searchUserPrefix.
+const (
+	searchBotPrefix  = "/v1/bot/messages/"
+	searchUserPrefix = "/v1/user/messages/"
+)
+
+// searchGlobalFallback maps the in-scope search suffixes to their cross-session
+// global counterparts. When a request in this set carries no channel_id in its
+// body, the suffix is rewritten to the global endpoint. Suffixes not listed
+// here (media / around / _search_global_*) are fixed endpoints and never
+// rerouted by chat-id.
+var searchGlobalFallback = map[string]string{
+	"_search":       "_search_global_messages",
+	"_search_all":   "_search_global_messages",
+	"_search_files": "_search_global_files",
+}
+
+// bodyHasChannelID reports whether the assembled request body carries a
+// non-empty channel_id. Used to decide in-scope (has channel_id) vs
+// cross-session global (no channel_id) routing for the search family.
+func bodyHasChannelID(body any) bool {
+	m, ok := body.(map[string]any)
+	if !ok {
+		return false
+	}
+	v, ok := m["channel_id"].(string)
+	return ok && strings.TrimSpace(v) != ""
+}
+
+// routeSearchPath adjusts a message-search request path for chat-id scope and
+// the active token kind. It only touches the search family — paths under
+// /v1/bot/messages/ whose suffix starts with "_search" (message.sync and other
+// non-search ops are left alone).
+//
+// First, chat-id routing: if the suffix is one of the in-scope search endpoints
+// (_search / _search_all / _search_files) and the request body carries no
+// channel_id, the suffix is rewritten to its cross-session global counterpart
+// (_search_global_messages / _search_global_files). Fixed endpoints (media,
+// around, _search_global_*) are never rerouted this way.
+//
+// Then, token-kind routing:
+//
+//   - user_bot (bf_):  unchanged — bot searches under /v1/bot/messages.
+//   - user_key (uk_):  rewritten to /v1/user/messages/_search* (real-person mount).
+//   - app_bot  (app_): rejected — App Bots cannot search.
+//   - anything else (unknown kind, nil credential, empty token): passed through
+//     unchanged, leaving any failure to the backend.
+//
+// Non-search paths are always returned unchanged.
+func routeSearchPath(cred *credential.BotCredential, path string, body any) (string, error) {
+	suffix, ok := strings.CutPrefix(path, searchBotPrefix)
+	if !ok || !strings.HasPrefix(suffix, "_search") {
+		return path, nil
+	}
+
+	// chat-id scope: in-scope search without a channel_id → cross-session global.
+	if global, ok := searchGlobalFallback[suffix]; ok && !bodyHasChannelID(body) {
+		suffix = global
+	}
+	path = searchBotPrefix + suffix
+
+	if cred == nil {
+		return path, nil
+	}
+	switch credential.TokenKind(cred.Token) {
+	case "user_key":
+		return searchUserPrefix + suffix, nil
+	case "app_bot":
+		return "", output.ErrValidation(
+			"App Bot tokens cannot search messages",
+			"use a User Bot (bf_) or user API key (uk_) token",
+		)
+	default:
+		// user_bot, unknown, or empty token: leave the path as-is.
+		return path, nil
+	}
+}

--- a/internal/client/search_route_test.go
+++ b/internal/client/search_route_test.go
@@ -1,0 +1,204 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
+)
+
+func TestRouteSearchPath(t *testing.T) {
+	withChat := map[string]any{"channel_id": "c1"}
+	blankChat := map[string]any{"channel_id": "  "}
+	noChat := map[string]any{"keyword": "hi"}
+
+	tests := []struct {
+		name     string
+		cred     *credential.BotCredential
+		path     string
+		body     any
+		wantPath string
+		wantErr  bool
+	}{
+		// --- chat-id scope, user_bot (bf_) ---
+		{
+			name:     "bf_ _search with channel_id stays in-scope",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     withChat,
+			wantPath: "/v1/bot/messages/_search",
+		},
+		{
+			name:     "bf_ _search without channel_id → global messages",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/_search_global_messages",
+		},
+		{
+			name:     "bf_ _search with blank channel_id → global messages",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     blankChat,
+			wantPath: "/v1/bot/messages/_search_global_messages",
+		},
+		{
+			name:     "bf_ _search_all with channel_id stays in-scope",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search_all",
+			body:     withChat,
+			wantPath: "/v1/bot/messages/_search_all",
+		},
+		{
+			name:     "bf_ _search_all without channel_id → global messages",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search_all",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/_search_global_messages",
+		},
+		{
+			name:     "bf_ _search_files with channel_id stays in-scope",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search_files",
+			body:     withChat,
+			wantPath: "/v1/bot/messages/_search_files",
+		},
+		{
+			name:     "bf_ _search_files without channel_id → global files",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search_files",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/_search_global_files",
+		},
+		{
+			name:     "nil body treated as no channel_id → global",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     nil,
+			wantPath: "/v1/bot/messages/_search_global_messages",
+		},
+
+		// --- chat-id scope + uk_ prefix rewrite ---
+		{
+			name:     "uk_ _search with channel_id → /v1/user in-scope",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     withChat,
+			wantPath: "/v1/user/messages/_search",
+		},
+		{
+			name:     "uk_ _search without channel_id → /v1/user global messages",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     noChat,
+			wantPath: "/v1/user/messages/_search_global_messages",
+		},
+		{
+			name:     "uk_ _search_files without channel_id → /v1/user global files",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/_search_files",
+			body:     noChat,
+			wantPath: "/v1/user/messages/_search_global_files",
+		},
+
+		// --- app_ rejected regardless of chat-id ---
+		{
+			name:    "app_ _search with channel_id rejected",
+			cred:    &credential.BotCredential{Token: "app_abc"},
+			path:    "/v1/bot/messages/_search",
+			body:    withChat,
+			wantErr: true,
+		},
+		{
+			name:    "app_ _search without channel_id rejected",
+			cred:    &credential.BotCredential{Token: "app_abc"},
+			path:    "/v1/bot/messages/_search",
+			body:    noChat,
+			wantErr: true,
+		},
+
+		// --- fixed endpoints unaffected by chat-id ---
+		{
+			name:     "media fixed endpoint, no channel_id, bf_",
+			cred:     &credential.BotCredential{Token: "bf_abc"},
+			path:     "/v1/bot/messages/_search_media",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/_search_media",
+		},
+		{
+			name:     "around fixed endpoint, no channel_id, uk_",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/_search_around",
+			body:     noChat,
+			wantPath: "/v1/user/messages/_search_around",
+		},
+		{
+			name:     "global_groups fixed endpoint preserved (uk_)",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/_search_global_groups",
+			body:     noChat,
+			wantPath: "/v1/user/messages/_search_global_groups",
+		},
+
+		// --- token-kind passthrough branches (unchanged behaviour) ---
+		{
+			name:     "unknown kind passes through",
+			cred:     &credential.BotCredential{Token: "xyz_abc"},
+			path:     "/v1/bot/messages/_search",
+			body:     withChat,
+			wantPath: "/v1/bot/messages/_search",
+		},
+		{
+			name:     "empty token passes through",
+			cred:     &credential.BotCredential{Token: ""},
+			path:     "/v1/bot/messages/_search",
+			body:     withChat,
+			wantPath: "/v1/bot/messages/_search",
+		},
+		{
+			name:     "nil credential passes through (still resolves chat-id scope)",
+			cred:     nil,
+			path:     "/v1/bot/messages/_search",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/_search_global_messages",
+		},
+		{
+			name:     "non-search message path untouched (uk_)",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/messages/sync",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/sync",
+		},
+		{
+			name:     "non-search message path untouched (app_)",
+			cred:     &credential.BotCredential{Token: "app_abc"},
+			path:     "/v1/bot/messages/sync",
+			body:     noChat,
+			wantPath: "/v1/bot/messages/sync",
+		},
+		{
+			name:     "unrelated path untouched (uk_)",
+			cred:     &credential.BotCredential{Token: "uk_abc"},
+			path:     "/v1/bot/sendMessage",
+			body:     withChat,
+			wantPath: "/v1/bot/sendMessage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := routeSearchPath(tt.cred, tt.path, tt.body)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("routeSearchPath(%q) = %q, want error", tt.path, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("routeSearchPath(%q): unexpected error %v", tt.path, err)
+			}
+			if got != tt.wantPath {
+				t.Errorf("routeSearchPath(%q) = %q, want %q", tt.path, got, tt.wantPath)
+			}
+		})
+	}
+}

--- a/internal/credential/env_provider.go
+++ b/internal/credential/env_provider.go
@@ -6,8 +6,8 @@ import (
 )
 
 // EnvProvider reads the bot credential from environment variables.
-// OCTO_BOT_TOKEN is the App Bot token (app_*). OCTO_SPACE_ID is optional and
-// only required for platform-scoped bots.
+// OCTO_BOT_TOKEN holds one of the three token kinds (app_*, bf_*, or uk_*).
+// OCTO_SPACE_ID is optional and only required for platform-scoped bots.
 type EnvProvider struct {
 	// TokenVar is the env var holding the token. Defaults to OCTO_BOT_TOKEN.
 	TokenVar string

--- a/internal/credential/token.go
+++ b/internal/credential/token.go
@@ -1,15 +1,17 @@
 package credential
 
 // Token prefixes route a bot token to its kind. app_* is an App Bot; bf_* is a
-// User Bot. The prefix is the only thing the CLI inspects — routing is otherwise
+// User Bot; uk_* is a user API key (real-person identity, used for message
+// search). The prefix is the only thing the CLI inspects — routing is otherwise
 // server-side.
 const (
-	prefixApp  = "app_"
-	prefixUser = "bf_"
+	prefixApp     = "app_"
+	prefixUser    = "bf_"
+	prefixUserKey = "uk_"
 )
 
-// TokenKind classifies a token by its prefix: "app_bot", "user_bot", or
-// "unknown". An empty token returns "".
+// TokenKind classifies a token by its prefix: "app_bot", "user_bot",
+// "user_key", or "unknown". An empty token returns "".
 func TokenKind(tok string) string {
 	switch {
 	case tok == "":
@@ -18,6 +20,8 @@ func TokenKind(tok string) string {
 		return "app_bot"
 	case hasPrefix(tok, prefixUser):
 		return "user_bot"
+	case hasPrefix(tok, prefixUserKey):
+		return "user_key"
 	}
 	return "unknown"
 }
@@ -47,6 +51,8 @@ func MaskToken(tok string) string {
 		prefix = prefixApp
 	case hasPrefix(tok, prefixUser):
 		prefix = prefixUser
+	case hasPrefix(tok, prefixUserKey):
+		prefix = prefixUserKey
 	default:
 		// Unknown kind: reveal nothing. Without a recognized prefix there is no
 		// way to say what the revealed head/tail belong to, so don't leak it.

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -35,7 +35,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 	r := MustNew()
 	expected := map[string]int{
 		"matter":      14,
-		"message":     4,
+		"message":     10,
 		"group":       9,
 		"thread":      8,
 		"file":        4,

--- a/internal/registry/specs/message.json
+++ b/internal/registry/specs/message.json
@@ -135,6 +135,223 @@
         },
         "responses": { "200": { "description": "Read receipts recorded" } }
       }
+    },
+    "/v1/bot/messages/_search": {
+      "post": {
+        "operationId": "message.search",
+        "summary": "Search messages (in-channel or cross-channel)",
+        "description": "Full-text message search. With --chat-id: pure messages within that channel (payload.type in [1,11,14]). Without --chat-id: the CLI routes to cross-channel _search_global_messages, which is a MIXED feed (messages + files), so cross-channel results may include file hits. --on-behalf-of searches as that user (User Bot only, requires an active OBO grant). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "channel_id": { "type": "string", "x-octo-flag": "chat-id", "description": "channel id to scope the search to; omit to search across all reachable channels (cross-channel mixed feed)" },
+                  "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
+                  "keyword": { "type": "string", "description": "full-text keyword" },
+                  "sort": { "type": "string", "enum": ["time_desc", "time_asc", "relevance"], "description": "sort order; relevance requires a non-empty keyword" },
+                  "page_size": { "type": "integer", "description": "page size" },
+                  "cursor": { "type": "string", "description": "opaque pagination cursor" },
+                  "filters": { "type": "object", "description": "extra filters (sender_ids, member_uids, channel_ids, channel_types, content_types, sent_at_from, sent_at_to, ...). Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    },
+    "/v1/bot/messages/_search_all": {
+      "post": {
+        "operationId": "message.search.all",
+        "summary": "Search messages + files (mixed feed)",
+        "description": "Mixed message+file search (payload.type in [1,8,11,14]; empty keyword also matches media). With --chat-id: within that channel. Without --chat-id: the CLI routes to cross-channel _search_global_messages. --on-behalf-of searches as that user (User Bot only). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "channel_id": { "type": "string", "x-octo-flag": "chat-id", "description": "channel id to scope the search to; omit to search across all reachable channels" },
+                  "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
+                  "keyword": { "type": "string", "description": "full-text keyword" },
+                  "sort": { "type": "string", "enum": ["time_desc", "time_asc", "relevance"], "description": "sort order; relevance requires a non-empty keyword" },
+                  "page_size": { "type": "integer", "description": "page size" },
+                  "cursor": { "type": "string", "description": "opaque pagination cursor" },
+                  "filters": { "type": "object", "description": "extra filters (sender_ids, member_uids, channel_ids, channel_types, content_types, sent_at_from, sent_at_to, ...). Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    },
+    "/v1/bot/messages/_search_files": {
+      "post": {
+        "operationId": "message.search.files",
+        "summary": "Search files (by filename / caption)",
+        "description": "File search (payload.type=8). With --chat-id: within that channel. Without --chat-id: the CLI routes to cross-channel _search_global_files. --on-behalf-of searches as that user (User Bot only). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        },
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "channel_id": { "type": "string", "x-octo-flag": "chat-id", "description": "channel id to scope the search to; omit to search files across all reachable channels" },
+                  "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
+                  "keyword": { "type": "string", "description": "filename / caption keyword" },
+                  "sort": { "type": "string", "enum": ["time_desc", "time_asc", "relevance"], "description": "sort order; relevance requires a non-empty keyword" },
+                  "page_size": { "type": "integer", "description": "page size" },
+                  "cursor": { "type": "string", "description": "opaque pagination cursor" },
+                  "filters": { "type": "object", "description": "extra filters (file_exts, file_size_min, file_size_max, sender_ids, ...). Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    },
+    "/v1/bot/messages/_search_media": {
+      "post": {
+        "operationId": "message.search.media",
+        "summary": "Search images + videos (in-channel only)",
+        "description": "Media search (payload.type in [2,5]). --chat-id is REQUIRED (no cross-channel media endpoint); the backend rejects requests without a channel_id. keyword must be empty (the backend rejects a non-empty keyword). --on-behalf-of searches as that user (User Bot only). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "cursorField": "pagination.next_cursor",
+          "hasMoreField": "pagination.has_more"
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["channel_id"],
+                "properties": {
+                  "channel_id": { "type": "string", "x-octo-flag": "chat-id", "description": "REQUIRED. channel id to search media in (no cross-channel media endpoint)" },
+                  "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
+                  "sort": { "type": "string", "enum": ["time_desc", "time_asc"], "description": "sort order" },
+                  "page_size": { "type": "integer", "description": "page size" },
+                  "cursor": { "type": "string", "description": "opaque pagination cursor" },
+                  "filters": { "type": "object", "description": "extra filters (sender_ids, content_types, sent_at_from, sent_at_to, ...). Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    },
+    "/v1/bot/messages/_search_around": {
+      "post": {
+        "operationId": "message.search.around",
+        "summary": "Fetch the context window around an anchor message (in-channel only)",
+        "description": "Locates the context window (messages before/after) around an anchor message. --chat-id is REQUIRED (a locate needs a single-channel anchor); the backend rejects requests without a channel_id. No pagination. --on-behalf-of searches as that user (User Bot only). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["channel_id", "anchor_message_id"],
+                "properties": {
+                  "channel_id": { "type": "string", "x-octo-flag": "chat-id", "description": "REQUIRED. channel id containing the anchor message" },
+                  "channel_type": { "type": "integer", "description": "1=DM, 2=group, 5=thread" },
+                  "anchor_message_id": { "type": "string", "x-octo-flag": "anchor-message-id", "description": "REQUIRED. the message id to center the context window on" },
+                  "filters": { "type": "object", "description": "extra filters. Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Context window",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
+    },
+    "/v1/bot/messages/_search_global_groups": {
+      "post": {
+        "operationId": "message.search.groups",
+        "summary": "Cross-channel aggregated overview (which channels matched)",
+        "description": "Cross-channel-only aggregated overview (L1): returns which groups/threads/DMs matched a keyword, not individual messages. Use it as the first level of a two-step search (find matching channels, then pull messages per channel with `message search`/`message search all`). --chat-id is not supported (cross-channel only). --on-behalf-of searches as that user (User Bot only). Requires a User Bot (bf_) or user API key (uk_) token; App Bot (app_) tokens are rejected.",
+        "x-octo-risk": "read",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "keyword": { "type": "string", "description": "full-text keyword" },
+                  "filters": { "type": "object", "description": "extra filters (channel_types, member_uids, sent_at_from, sent_at_to, ...). Pass via --data." },
+                  "on_behalf_of": { "type": "string", "description": "OBO: search as this user persona; requires an active OBO grant (User Bot only)" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Aggregated group overview",
+            "content": { "application/json": { "schema": { "type": "object" } } }
+          }
+        }
+      }
     }
   }
 }

--- a/skills/octo-messaging/SKILL.md
+++ b/skills/octo-messaging/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-messaging
 version: 0.4.1
-description: Messaging domain — send/edit/sync messages, read receipts, groups and threads (User Bot), and event polling. Covers App Bot DM-only constraints. Load after octo-shared.
+description: Messaging domain — send/edit/sync messages, read receipts, message search (search/all/files/media/around/groups, in-channel or cross-channel), groups and threads (User Bot), and event polling. Covers App Bot DM-only constraints. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
@@ -10,7 +10,7 @@ metadata:
 
 # octo-messaging — messages, groups, threads, events
 
-Three related domains live here. They all call `$OCTO_API_BASE_URL/v1/bot/*`.
+Three related domains live here. They all call `$OCTO_API_BASE_URL/v1/bot/*` — except the `message search` family under a `uk_` (user API key) token, which the CLI routes to `/v1/user/*` (real-person mount; see the `message search` section).
 
 | Domain    | App Bot           | User Bot |
 |-----------|-------------------|----------|
@@ -19,9 +19,17 @@ Three related domains live here. They all call `$OCTO_API_BASE_URL/v1/bot/*`.
 | `thread`  | **blocked**       | full     |
 | `event`   | yes               | yes      |
 
+Search capability (the `message search` family) is a separate axis by token kind:
+
+| Token   | Can search? | Notes                                                  |
+|---------|-------------|--------------------------------------------------------|
+| `app_*` | **no**      | CLI rejects locally with a `validation` error (not a server `FORBIDDEN`). |
+| `bf_*`  | yes         | Searches as the bot; add `--on-behalf-of <uid>` for a real-person (OBO) view. |
+| `uk_*`  | yes         | Real-person identity; routed to `/v1/user/*`.          |
+
 Before attempting a write, confirm the token type with `octo-cli config show` — App Bot writes outside DM get `FORBIDDEN` from the server ("app bot does not support group operations").
 
-## 1. `message` — 4 commands
+## 1. `message` — 4 core commands (+ 6 search subcommands, see below)
 
 ```bash
 # Send a message. payload is a JSON object (not a flag) — pass it inside --data.
@@ -82,21 +90,70 @@ Chat content types:
 
 `--on-behalf-of <uid>` makes `send`/`typing` act as a user persona (OBO) — requires an active OBO grant + channel scope, else the server returns `OBO not authorized`.
 
-## 2. `group` — 9 commands (5 read + 4 write)
+## message search — 6 subcommands
 
-Read operations (both bot types):
+Full-text search over messages and files. Registered as `message search`, `message search all|files|media|around|groups`.
 
 ```bash
-octo-cli group list    [--space-id <sid>]                 # groups the bot is a member of
-octo-cli group get     <group_no>
-octo-cli group members <group_no>                          # paginated
-octo-cli group md-get  <group_no>                          # group markdown description
+# In-channel message search (payload.type in [1,11,14]).
+octo-cli message search --chat-id <cid> --keyword "quarterly report" [--sort time_desc]
+
+# Cross-channel message search (omit --chat-id). NOTE: without --chat-id the CLI
+# routes to the cross-channel _search_global_messages endpoint, which is a MIXED
+# feed (messages + files), so results may include file hits.
+octo-cli message search --keyword "quarterly report"
+
+# Messages + files (mixed feed) — in-channel or (no --chat-id) cross-channel.
+octo-cli message search all --chat-id <cid> --keyword invoice
+
+# Files only (payload.type=8), by filename / caption.
+octo-cli message search files --chat-id <cid> --keyword "*.pdf"
+
+# Images + videos (payload.type in [2,5]) — IN-CHANNEL ONLY, keyword NOT allowed.
+octo-cli message search media --chat-id <cid> [--sort time_desc]
+
+# Context window around an anchor message — IN-CHANNEL ONLY.
+octo-cli message search around --chat-id <cid> --anchor-message-id <mid>
+
+# Cross-channel aggregated overview (which channels matched) — CROSS-CHANNEL ONLY.
+# Use it as level 1 of a two-step search: find matching channels, then pull
+# messages per channel with `message search` / `message search all`.
+octo-cli message search groups --keyword "quarterly report"
 ```
 
-Write operations (**User Bot only**):
+### `--chat-id` decides in-channel vs cross-channel
+
+- **With `--chat-id`** → scoped to that channel.
+- **Without `--chat-id`** → `search` / `search all` / `search files` route to their cross-channel `_search_global_*` endpoints (CLI-side, in `internal/client/search_route.go` — not backend dispatch). Plain `search` cross-channel degrades to the **mixed messages+files** feed.
+- `media` and `around` **require `--chat-id`** (no cross-channel endpoint; the backend rejects a request without a channel_id). `around` also requires `--anchor-message-id`; `media` does **not** accept `--keyword`.
+- `groups` is **cross-channel only** and does **not** accept `--chat-id`.
+
+### Token subjects
+
+- **`bf_` (User Bot)** — searches as the bot.
+- **`bf_` + `--on-behalf-of <uid>`** — OBO: searches with that real person's visibility; requires an active OBO grant.
+- **`uk_` (user API key)** — real-person identity; the CLI rewrites the path to `/v1/user/*`.
+- **`app_` (App Bot)** — **cannot search.** The CLI rejects this locally (`validation`), before any request — distinct from a server-side `FORBIDDEN`.
+
+### Filters and pagination
+
+Rich filters (`sender_ids`, `member_uids`, `content_types`, `sent_at_from`/`sent_at_to`, `file_exts`, …) go through `--data '{"filters":{…}}'`. All families except `around` and `groups` paginate; the cursor travels in the request **body** (`--page-all` handles this).
+
+## 2. `group` — 9 commands (both 5 / User Bot only 4)
+
+Available to both bot types (5):
 
 ```bash
-octo-cli group md-update     <group_no> --content "# Updated description"
+octo-cli group list      [--space-id <sid>]               # groups the bot is a member of
+octo-cli group get       <group_no>
+octo-cli group members   <group_no>                        # paginated
+octo-cli group md-get    <group_no>                        # group markdown description
+octo-cli group md-update <group_no> --content "# Updated description"  # write, but bot_admin gate — not App-Bot-blocked
+```
+
+User Bot only (4):
+
+```bash
 octo-cli group create        --members u1 --members u2 --name "eng" --creator u0
 octo-cli group update        <group_no> --data '{"name":"new name"}'
 octo-cli group member-add    <group_no> --members u3 --members u4
@@ -162,11 +219,17 @@ done
 | `sync` rejected with `channel-type=2`                  | App Bot cannot sync groups — use User Bot.                     |
 | `VALIDATION_ERROR` on `send`                           | `payload` must be an object, not a string.                     |
 | `event list` returns `data.results: []`                | No events since the cursor; keep the cursor and poll again.    |
+| `validation` on any `message search` with an `app_*` token | App Bots cannot search — use `bf_*` or `uk_*`. (CLI-side reject, before the request.) |
+| `media` search rejected with a non-empty keyword       | `search media` does not accept `--keyword`; drop it.          |
+| `sort=relevance` rejected                              | `relevance` requires a non-empty `--keyword`.                 |
+| `OBO not authorized` on `search --on-behalf-of`        | No active OBO grant for that uid; grant it or drop `--on-behalf-of`. |
 
 ## 6. Schema lookup
 
 ```bash
 octo-cli schema message.send
+octo-cli schema message.search
+octo-cli schema message.search.all
 octo-cli schema group.members
 octo-cli schema thread.create
 octo-cli schema event.list

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -9,13 +9,13 @@ metadata:
 
 # octo-shared — CLI fundamentals for AI Agents
 
-`octo-cli` is a thin REST client that exposes the Octo ecosystem (matters, messaging, groups, threads, files, bot, events) as a single binary. Every service command is auto-generated from an embedded OpenAPI registry; output is a JSON envelope designed to be parsed by agents.
+`octo-cli` is a thin REST client that exposes the Octo ecosystem (matters, messaging, groups, threads, files, bot, events, docs, html) as a single binary. Every service command is auto-generated from an embedded OpenAPI registry; output is a JSON envelope designed to be parsed by agents.
 
 > **The `matter` domain is temporarily withheld** while its backend API stabilizes — `octo-cli matter ...` is not registered and the `octo-matter` skill is not listed. Do not emit `matter` commands until it is re-enabled. The examples below use other domains.
 
 ## 1. Authentication
 
-Bots authenticate with a bearer token. There is no user login. Two ways to supply it:
+Bots authenticate with a bearer token. There is no interactive user login — but besides the two bot tokens (`app_*`, `bf_*`) there is a third kind, a **user API key** (`uk_*`), which carries a real person's identity and is used mainly for `message search`. Two ways to supply any of them:
 
 **Stored profile (recommended).** A human (or provisioning step) logs the token in once; it is encrypted at rest under `~/.octo-cli`, and the raw token never appears in any command line, shell history, or transcript afterward:
 
@@ -23,6 +23,10 @@ Bots authenticate with a bearer token. There is no user login. Two ways to suppl
 # Operator setup (token read from a hidden prompt, or --with-token < file):
 octo-cli auth login --bot-id cli_xxxxxxxx          # robot id you got when creating the bot
 echo "$TOKEN" | octo-cli auth login --bot-id cli_xxxxxxxx --with-token   # non-interactive
+
+# A user API key (uk_) is stored the same way — encrypted profile, bot_kind shows
+# user_key. Use a friendly --profile name since it has no robot id:
+echo "$UK_TOKEN" | octo-cli auth login --profile alice-search --with-token
 ```
 
 Then, at runtime, select which bot to act as — the agent passes its own **robot id**, which it knows:
@@ -39,16 +43,20 @@ With exactly one stored profile, the selector is optional. With **two or more, y
 ```bash
 export OCTO_BOT_TOKEN=app_xxxxxxxxxxxxxxxxxxxx      # App Bot (DM-only)
 export OCTO_BOT_TOKEN=bf_xxxxxxxxxxxxxxxxxxxxx       # User Bot (full access)
+export OCTO_BOT_TOKEN=uk_xxxxxxxxxxxxxxxxxxxxx       # User API key (real person; message search)
 ```
 
 > `OCTO_BOT_ID` is a selector (a robot id), not a secret; `OCTO_BOT_TOKEN` is the secret. If `OCTO_BOT_ID` names no stored profile the command fails — it never falls back to silently using `OCTO_BOT_TOKEN` under that id.
 
-Token prefix determines capability — the CLI does NOT enforce this locally; the backend rejects unsupported operations with `FORBIDDEN`.
+Token prefix determines capability — the CLI does NOT enforce this locally (the backend rejects unsupported operations with `FORBIDDEN`), with **one exception**: an `app_*` token running `message search` is rejected locally with a `validation` error before any request.
 
-| Prefix  | Type     | DM msg | Group read | Group write | Thread | Voice |
-|---------|----------|--------|------------|-------------|--------|-------|
-| `app_*` | App Bot  | yes    | yes        | **no**      | **no** | **no**|
-| `bf_*`  | User Bot | yes    | yes        | yes         | yes    | yes   |
+| Prefix  | Type         | DM msg | Group read | Group write | Thread | Voice | Search |
+|---------|--------------|--------|------------|-------------|--------|-------|--------|
+| `app_*` | App Bot      | yes    | yes        | **no**      | **no** | **no**| **no** |
+| `bf_*`  | User Bot     | yes    | yes        | yes         | yes    | yes   | yes    |
+| `uk_*`  | User API key | —      | —          | —           | —      | —     | yes    |
+
+`uk_*` carries a real person's identity and is meaningful mainly for `message search` (routed to `/v1/user/*`); for other domains use a bot token. `bf_*` can also search on behalf of a person with `--on-behalf-of <uid>`. `identity.bot_kind` reflects the kind: `app_bot`, `user_bot`, or `user_key`.
 
 Before acting, inspect `octo-cli auth status` (or `octo-cli config show`) to confirm the active identity. Every success envelope also echoes it under `identity` (see §3).
 
@@ -149,8 +157,8 @@ The `hint` field is a one-line next action meant for an agent: follow it literal
 Simple top-level body fields auto-promote to typed flags (strings, integers, booleans, `[]string`). For objects, arrays-of-objects, or when sending a large payload, use `--data`:
 
 ```bash
-octo-cli thread create --chat-id chat-1 --name "design review"
-octo-cli message send --data '{"chat_id":"chat-1","text":"hi"}'
+octo-cli thread create group-abc --name "design review"
+octo-cli message send --data '{"channel_id":"chat-1","channel_type":1,"payload":{"type":1,"content":"hi"}}'
 octo-cli message send --data @body.json
 octo-cli some-cmd --data @-            # read JSON from stdin
 ```
@@ -174,7 +182,7 @@ octo-cli group list --page-all --page-limit 20
 ### Dry-run for agent self-verification
 
 ```bash
-octo-cli message send --data '{"chat_id":"chat-1","text":"foo"}' --dry-run
+octo-cli message send --data '{"channel_id":"chat-1","channel_type":1,"payload":{"type":1,"content":"foo"}}' --dry-run
 ```
 
 Prints the exact HTTP request body and URL, emits no side effect.
@@ -206,3 +214,5 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-matter` — matters (todos/tasks), assignees, channels, timeline, AI extract — **temporarily withheld** (backend API stabilizing; not currently loadable)
 - `octo-messaging` — message send/edit/sync/read-receipt, groups, threads, events
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
+- `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
+- `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace


### PR DESCRIPTION
Closes #93

## What

Adds the `octo-cli message` search command family and the routing needed to use it correctly across token kinds and chat-id scopes.

Commands: `search`, `all`, `files`, `media`, `around`, `groups`.

## How

**Routing** (`internal/client/search_route.go`, new)
- Token kind by prefix: `uk_` → `/v1/user/messages/_search*`; `app_` → local validation reject; `bf_`/unknown/empty → passthrough.
- Chat-id scope: in-scope `_search`/`_search_all`/`_search_files` with no `channel_id` fall back to `_search_global_messages`/`_search_global_files`. `media`/`around`/`_search_global_*` are fixed endpoints, never rerouted by chat-id.
- Double guard so nothing else is affected: only paths under `/v1/bot/messages/` whose suffix starts with `_search` are rewritten. `sync`, `sendMessage`, and every other domain pass through unchanged.

**Wiring**
- `client.go` calls `routeSearchPath` inside `Do`, before URL assembly.
- `token.go` recognizes/masks the `uk_` (user_key) kind.
- `run.go` paginates search via a body cursor (POST) vs query cursor (GET), keeping cross-page paths idempotent. `around`/`groups` are non-paginated.
- `message.json` gains the six endpoint specs.

**Docs & skills**
- README / CHANGELOG / CLAUDE.md / design.md: message search, `uk_` identity, OBO semantics; add `octo-html` to skill list; correct pre-existing `message send/edit` and `thread` examples to real spec fields.
- New search design docs; deprecated unified-endpoint approach marked.
- `octo-messaging` skill: search section; group domain regrouped by bot-kind (md-update available to both bot types; App Bot only rejected for create/update/member-add/member-remove).
- `octo-shared` skill: `uk_` subject, docs/html domains, example fixes.

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass

Unit tests cover search routing (with / blank / no / nil chat-id, non-search passthrough) and body-cursor pagination.

## Notes / follow-ups (out of scope here)

- Backfilling `docs`/`html` domains into `octo-cli-design.md` and the command-tree.
- Removing currently-unconsumed `CursorField`/`HasMoreField` in the loader (spec-contract decision).
