### PR TITLE
fix(ci): run for embedded skill markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
+    paths:
+      - '**'
+      - '!**/*.md'
+      - 'skills/**/*.md'
+      - '!docs/**'
+      - '!.github/ISSUE_TEMPLATE/**'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
     branches: [main]


### PR DESCRIPTION
## Summary

- run CI when embedded `skills/**/*.md` files change
- continue skipping ordinary Markdown, docs, and issue-template-only pushes

## Validation

- `git diff --check`

This ensures changes embedded into the CLI release artifact satisfy the release CI gate.