### PR TITLE
chore(ci): test embedded skill markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches: [main]
     paths-ignore:
-      - '**/*.md'
+      # Root-level Markdown and docs are documentation-only. Markdown under
+      # skills/ is intentionally NOT ignored: skills are embedded in the CLI
+      # binary, so changing them must produce CI evidence for release gates.
+      - '*.md'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
   pull_request:
@@ -32,12 +35,14 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      # code=true when at least one changed file matches the code filter.
+      # code=true when at least one changed file is runtime code or an embedded
+      # Skill Markdown file. Push events always run once the workflow-level
+      # path filter admits them.
       # predicate-quantifier:every + negation patterns (no bare '**'):
       # a file matches 'code' iff ALL negation patterns are satisfied
-      # (file is not a doc/template). code=false only when all changed files
-      # are docs/templates. Push events default to 'true'.
-      code: ${{ github.event_name == 'pull_request' && steps.filter.outputs.code || 'true' }}
+      # (file is not a doc/template). The separate embedded_skills filter
+      # re-includes skills/**/*.md because those files ship in the binary.
+      code: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code == 'true' || steps.filter.outputs.embedded_skills == 'true' }}
     steps:
       # No checkout: on pull_request events dorny/paths-filter lists changed
       # files via the GitHub API (needs only pull-requests: read, granted
@@ -70,6 +75,8 @@ jobs:
               - '!**/*.md'
               - '!docs/**'
               - '!.github/ISSUE_TEMPLATE/**'
+            embedded_skills:
+              - 'skills/**/*.md'
 
   build:
     name: build & test


### PR DESCRIPTION
## Summary

- run push CI when embedded `skills/**/*.md` files change
- treat embedded Skill Markdown as runtime code in pull-request path detection
- keep root documentation, `docs/**`, and issue templates on the lightweight path

## Why

Skill Markdown is embedded into the `octo-cli` binary. PR #92 changed only an embedded Skill file, so the pull-request CI skipped the real test steps and the merged commit received no push CI run. The release gate requires a successful CI run whose SHA exactly matches the release tag, which blocked `v0.9.0-next.2`.

## Verification

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `go test ./...`
- `npm test`
