### PR TITLE
fix: sync MCP marketplace contract and local routing

### DIFF
--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -22,7 +22,6 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		"skill.mine.list":          {http.MethodGet, "/market/api/v1/skills/mine"},
 		"skill.tag.list":           {http.MethodGet, "/market/api/v1/skills/tags"},
 		"skill.publish":            {http.MethodPost, "/market/api/v1/bot/skills/publish"},
-		"skill.create":             {http.MethodPost, "/market/api/v1/skills"},
 		"skill.get":                {http.MethodGet, "/market/api/v1/skills/{skill_id}"},
 		"skill.update":             {http.MethodPatch, "/market/api/v1/skills/{skill_id}"},
 		"skill.delete":             {http.MethodDelete, "/market/api/v1/skills/{skill_id}"},
@@ -152,30 +151,6 @@ func TestMarketplaceMCPCategoryFiltersRequest(t *testing.T) {
 	}
 }
 
-func TestMarketplaceSkillPublishRequest(t *testing.T) {
-	var gotPath string
-	var gotBody map[string]any
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Errorf("decode body: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"skill_id":"skill-1"}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "skill", "create", "--parse-task-id", "task-1", "--visibility", "space"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if gotPath != "/market/api/v1/skills" {
-		t.Errorf("path = %q", gotPath)
-	}
-	if gotBody["parse_task_id"] != "task-1" || gotBody["visibility"] != "space" {
-		t.Errorf("body = %#v", gotBody)
-	}
-}
-
 func TestMarketplaceBotSkillPublishRequest(t *testing.T) {
 	var gotPath string
 	var gotBody map[string]any
@@ -197,6 +172,22 @@ func TestMarketplaceBotSkillPublishRequest(t *testing.T) {
 	}
 	if gotBody["skill_upload_id"] != "upload-1" || gotBody["visibility"] != "space" || gotBody["changelog"] != "Initial release" {
 		t.Errorf("body = %#v", gotBody)
+	}
+}
+
+func TestMarketplaceHumanSkillCreateIsHidden(t *testing.T) {
+	r := registry.MustNew()
+	if _, ok := r.GetOperation("skill.create"); ok {
+		t.Fatal("skill.create must not be exposed by the Bot-only CLI")
+	}
+
+	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {})
+	skill := findCmd(findCmd(root, "marketplace"), "skill")
+	if skill == nil {
+		t.Fatal("missing marketplace skill command group")
+	}
+	if findCmd(skill, "create") != nil {
+		t.Fatal("marketplace skill create must be hidden; Bots must use skill publish")
 	}
 }
 
@@ -233,7 +224,7 @@ func TestMarketplaceCommandTree(t *testing.T) {
 	domains := map[string][]string{
 		"skill-category":    {"list"},
 		"mcp-category":      {"list"},
-		"skill":             {"list", "mine", "tag", "publish", "create", "get", "update", "delete", "download", "reupload", "version", "skillmd"},
+		"skill":             {"list", "mine", "tag", "publish", "get", "update", "delete", "download", "reupload", "version", "skillmd"},
 		"skill-upload":      {"create", "parse"},
 		"skill-parse-task":  {"get"},
 		"skill-icon-upload": {"create"},
@@ -259,7 +250,7 @@ func TestMarketplaceCommandTree(t *testing.T) {
 
 func TestMarketplaceSkillTagsAreStrings(t *testing.T) {
 	r := registry.MustNew()
-	for _, id := range []string{"skill.publish", "skill.create", "skill.update"} {
+	for _, id := range []string{"skill.publish", "skill.update"} {
 		op, ok := r.GetOperation(id)
 		if !ok || op.RequestBody == nil {
 			t.Fatalf("%s request body not found", id)
@@ -277,7 +268,6 @@ func TestMarketplaceVisibilityEnumsMatchBackend(t *testing.T) {
 		id   string
 		want []string
 	}{
-		{"skill.create", []string{"public", "private", "space"}},
 		{"skill.update", []string{"public", "private", "space"}},
 		{"skill.publish", []string{"public", "private", "space"}},
 		{"mcp.create", []string{"public", "private"}},

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -115,6 +115,24 @@ func TestMarketplaceMCPSearchFiltersRequest(t *testing.T) {
 	}
 }
 
+func TestMarketplaceLocalPrefixOverride(t *testing.T) {
+	t.Setenv("OCTO_MARKETPLACE_API_PREFIX", "")
+	var gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "mcp", "list"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/api/v1/mcps" {
+		t.Fatalf("path = %q, want /api/v1/mcps", gotPath)
+	}
+}
+
 func TestMarketplaceMCPCategoryFiltersRequest(t *testing.T) {
 	var gotQuery string
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -23,7 +24,7 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 	d := rt.detail
 
 	// Path substitution. cobra.ExactArgs already ensured count.
-	urlPath := d.Path
+	urlPath := marketplacePath(d.Service, d.Path)
 	for i, pname := range rt.pathParams {
 		placeholder := "{" + pname + "}"
 		urlPath = strings.ReplaceAll(urlPath, placeholder, url.PathEscape(args[i]))
@@ -89,6 +90,25 @@ func runOperation(cobraCmd *cobra.Command, f *cmdutil.Factory, rt *operationRunt
 	}
 
 	return emitOnce(ctx, f, &req)
+}
+
+// marketplacePath lets local development bypass the production /market
+// gateway mount. When OCTO_MARKETPLACE_API_PREFIX is present, its value
+// replaces the leading /market segment; setting it to an empty string maps
+// /market/api/v1/... to the standalone service's /api/v1/... routes.
+func marketplacePath(service, path string) string {
+	if service != "marketplace" || !strings.HasPrefix(path, "/market/") {
+		return path
+	}
+	prefix, ok := os.LookupEnv("OCTO_MARKETPLACE_API_PREFIX")
+	if !ok {
+		return path
+	}
+	prefix = strings.TrimSpace(prefix)
+	if prefix != "" && !strings.HasPrefix(prefix, "/") {
+		prefix = "/" + prefix
+	}
+	return strings.TrimSuffix(prefix, "/") + strings.TrimPrefix(path, "/market")
 }
 
 // buildQuery assembles the URL query from flags the user explicitly set, so

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -237,6 +237,9 @@ func (r *Registry) ListOperations(service string) []OperationInfo {
 	}
 	out := []OperationInfo{}
 	walkOperations(doc, func(pathStr, method string, op map[string]any) {
+		if truthy(op["x-octo-cli-hidden"]) {
+			return
+		}
 		id, _ := op["operationId"].(string)
 		if id == "" {
 			return
@@ -271,6 +274,9 @@ func (r *Registry) GetOperation(operationID string) (*OperationDetail, bool) {
 		var found *OperationDetail
 		walkOperations(doc, func(pathStr, method string, op map[string]any) {
 			if found != nil {
+				return
+			}
+			if truthy(op["x-octo-cli-hidden"]) {
 				return
 			}
 			id, _ := op["operationId"].(string)

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -29,9 +29,9 @@ func TestGetSpecReturnsNilForUnknown(t *testing.T) {
 }
 
 func TestAllDomainOperationCounts(t *testing.T) {
-	// Backend route counts per service. The user-facing CLI has more commands
-	// than backend ops for matter (close/reopen/archive are aliases over
-	// matter.transition) — the spec tracks actual routes, not CLI surface.
+	// Caller-facing operation counts per service. Operations marked
+	// x-octo-cli-hidden remain in the embedded backend spec but are excluded
+	// here; marketplace skill.create is one such Web-only operation.
 	r := MustNew()
 	expected := map[string]int{
 		"matter":      14,
@@ -43,7 +43,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"event":       2,
 		"docs":        31,
 		"html":        20,
-		"marketplace": 26,
+		"marketplace": 25,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -1736,6 +1736,7 @@
       "post": {
         "description": "Publish a parsed Skill archive for the authenticated user and current Space.",
         "operationId": "skill.create",
+        "x-octo-cli-hidden": true,
         "requestBody": {
           "content": {
             "application/json": {

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -2981,6 +2981,14 @@
             },
             "type": "object"
           },
+          "env_user_supplied": {
+            "description": "EnvUserSupplied lists env keys whose value must be filled locally by each consumer. Values are owner-visible and blanked to non-owners.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
           "faqs": {
             "items": {
               "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
@@ -2993,6 +3001,14 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "headers_user_supplied": {
+            "description": "HeadersUserSupplied has the same semantics as env_user_supplied for headers.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
           },
           "icon": {
             "type": "string"
@@ -3249,6 +3265,14 @@
             },
             "type": "object"
           },
+          "env_user_supplied": {
+            "description": "A supplied array replaces the persisted env user-supplied key list; omission leaves it unchanged.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
           "faqs": {
             "items": {
               "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
@@ -3261,6 +3285,13 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "headers_user_supplied": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
           },
           "icon": {
             "type": "string"
@@ -3340,11 +3371,27 @@
             },
             "type": "object"
           },
+          "env_user_supplied": {
+            "description": "Environment keys each consumer must fill locally.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
+          },
           "headers": {
             "additionalProperties": {
               "type": "string"
             },
             "type": "object"
+          },
+          "headers_user_supplied": {
+            "description": "Header keys each consumer must fill locally.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "uniqueItems": false
           },
           "server_name": {
             "type": "string"

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -39,9 +39,11 @@ Before writing configuration, show:
 
 After confirmation, preserve existing entries unless replacement was approved.
 Use `quick_start.slug` as the `mcpServers` key. Map stdio to
-`command`/`args`/`env`, and HTTP/SSE to `url`/`headers`. Ask for required
-secrets; never invent, echo, or persist them outside the runtime's approved
-secret mechanism. Reload the runtime and verify the server connects.
+`command`/`args`/`env`, and HTTP/SSE to `url`/`headers`. Treat keys listed in
+`quick_start.env_user_supplied` and `quick_start.headers_user_supplied` as
+consumer-provided secrets: ask for them locally, never invent or echo them, and
+persist them only through the runtime's approved secret mechanism. Reload the
+runtime and verify the server connects.
 
 ## Validate a connection
 
@@ -50,6 +52,12 @@ For `streamable-http` and `sse`, probe without persisting:
 ```bash
 octo-cli marketplace mcp probe --data @connection.json
 ```
+
+Build `connection.json` with only the probe fields: `transport`, `url`,
+`command`, `args`, `env`, and `headers`. The probe endpoint rejects catalog
+fields and `env_user_supplied` / `headers_user_supplied` as unknown fields.
+Use empty values for consumer-supplied secrets; do not send real secrets just
+to validate a public connection.
 
 Normalize the response and continue only when `is_ok=true`.
 
@@ -67,10 +75,12 @@ octo-cli marketplace mcp create --data @mcp.json
 ```
 
 The body is flat: catalog metadata plus `transport`, and either
-`command`/`args`/`env` for stdio or `url`/`headers` for HTTP/SSE. Never submit
-real secret values; use `__OCTO_SECRET_PLACEHOLDER__` where the Marketplace
-contract requires a secret placeholder. `category` must be a key returned by
-`mcp-category list`; `tags` is a free-form string array.
+`command`/`args`/`env` for stdio or `url`/`headers` for HTTP/SSE. Put every key
+that each consumer must fill locally in `env_user_supplied` or
+`headers_user_supplied`; submit an empty value for those keys instead of a real
+secret. The owner can round-trip submitted values, while non-owner detail reads
+blank them. `category` must be a key returned by `mcp-category list`; `tags` is
+a free-form string array.
 
 ## Update
 
@@ -88,8 +98,10 @@ Category and tag changes use the same `category` key and free-form `tags`
 string array as create.
 
 For stdio connection changes, use the local handshake instead of backend probe.
-Re-read with `marketplace mcp get <mcp-id>` and verify the quick-start remains
-secret-redacted and contains no `version` field.
+When changing `env` or `headers`, update the matching `*_user_supplied` list in
+the same request. Re-read with `marketplace mcp get <mcp-id>` and verify those
+lists round-trip and `quick_start` contains no `version` field. Do not print
+owner-visible secret values.
 
 Use `marketplace mcp delete <mcp-id>` only after showing the selected owned
 record and obtaining explicit confirmation. MCP icon uploads use the presigned

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -91,9 +91,10 @@ Optional metadata may override parsed values, including `category_id` and a
 JSON string array `tags`, but do not silently replace a package version. Only
 default a missing version to `1.0.0`.
 
-`skill-upload parse`, `skill-parse-task get`, and `skill create` remain exposed
-for Web/legacy compatibility and diagnosis. They are not an alternative Agent
-workflow and must not be used unless the Bot publish endpoint is unavailable.
+`skill create` is intentionally hidden from octo-cli because it records a human
+publisher and is reserved for the Web workflow. `skill-upload parse` and
+`skill-parse-task get` remain available for diagnosis, but they are not an
+alternative Agent workflow. Bots must publish with `skill publish`.
 If parsing returns `RATE_LIMITED`, wait and retry within the user's timeout. If
 Bot publish returns a gateway timeout, query `skill mine list` before retrying
 so an already-created Skill is never duplicated.


### PR DESCRIPTION
## Summary

- sync the embedded Marketplace OpenAPI with `env_user_supplied` and `headers_user_supplied`
- update the MCP Skill for supplied-secret handling and strict probe payloads
- implement `OCTO_MARKETPLACE_API_PREFIX` so the CLI can target the standalone local Marketplace service
- add coverage for the local path override

## Validation

- `make fmt`
- `make vet`
- `go test ./...`
- `make build`
- local Marketplace E2E: category/list/mine/create/get/update/probe/delete

Closes #99