### PR TITLE
fix(marketplace): sync skill tag constraints

### DIFF
--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -259,6 +259,9 @@ func TestMarketplaceSkillTagsAreStrings(t *testing.T) {
 		if !ok || tags.Type != "array" || tags.Items == nil || tags.Items.Type != "string" {
 			t.Errorf("%s tags schema = %+v, want string array", id, tags)
 		}
+		if tags.MaxItems != 10 || tags.Items.MaxLength != 10 {
+			t.Errorf("%s tags limits = maxItems %d, item maxLength %d; want 10 and 10", id, tags.MaxItems, tags.Items.MaxLength)
+		}
 	}
 }
 

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -3891,8 +3891,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           },
@@ -3915,8 +3917,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           },
@@ -3948,8 +3952,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           }
@@ -3984,8 +3990,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           },
@@ -4129,8 +4137,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           },
@@ -4183,8 +4193,10 @@
           },
           "tags": {
             "items": {
+              "maxLength": 10,
               "type": "string"
             },
+            "maxItems": 10,
             "type": "array",
             "uniqueItems": false
           },

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -20,7 +20,8 @@ The category command is non-paginated; normalize it and use each returned
 
 Skill tags are strings normally parsed from `SKILL.md` frontmatter. Use
 `skill tag list` for current-Space and global suggestions; new valid tag values
-may still be submitted when publishing or updating.
+may still be submitted when publishing or updating. A Skill may have at most
+10 tags, and each tag may contain at most 10 characters.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- sync embedded Marketplace Skill schemas to at most 10 tags
- expose a 10-character maximum for each Skill tag
- document the limits for Bot-driven publish and update workflows

## Tests
- go test ./cmd/service ./internal/registry