### PR TITLE
feat(docs): add unified file import and export commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,15 @@ octo-cli docs create --title "Design notes"
 octo-cli docs list --sort updatedAt:desc
 octo-cli docs get doc-123
 octo-cli docs content get doc-123          # returns the body + base version token
+octo-cli docs import doc-123 --file ./notes.md      # replaces a doc from .md/.markdown/.docx
+octo-cli docs export doc-123 --export-format pdf -o ./notes.pdf
 octo-cli docs members set doc-123 --data '{"uid":"u-1","role":"writer"}'
 octo-cli docs comments add doc-123 --data '{"body":"looks good"}'
 
 # Spreadsheets — read the live cells + base version, then batch-edit under If-Match.
 octo-cli docs sheet get sheet-9                      # whole sheet + base version token
+octo-cli docs import sheet-9 --file ./report.xlsx    # imports the first visible worksheet
+octo-cli docs export sheet-9 --export-format xlsx -o ./report.xlsx
 octo-cli docs sheet get sheet-9 --limit 500          # page a large sheet; follow --cursor <nextCursor>
 octo-cli docs sheet edit sheet-9 --base-version "<token>" \
   --data '{"cells":{"default!0:0":{"v":"hi"},"default!1:0":null}}'
@@ -143,6 +147,9 @@ octo-cli docs sheet edit sheet-9 --base-version "<token>" \
 octo-cli docs scene get board-7                       # elements (z-order) + files + base version token
 octo-cli docs scene edit board-7 --base-version "<token>" \
   --data '{"elements":[{"id":"e1","type":"rectangle","version":4}],"deletedElementIds":["e2"],"files":{}}'
+octo-cli docs import board-7 --file ./board.excalidraw              # merge (default): preserves existing elements
+octo-cli docs import board-7 --file ./board.excalidraw --mode replace # explicit overwrite; backend safety snapshot + concurrency protection
+octo-cli docs export board-7 --export-format png -o ./board.png
 
 # HTML docs (octo-doc) — a SEPARATE backend from `docs`. Publish self-contained
 # interactive HTML as immutable versions, then edit a single stamped artifact.

--- a/cmd/docs_export.go
+++ b/cmd/docs_export.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+var docsExportFormats = map[string]bool{
+	"md": true, "docx": true, "pdf": true, "xlsx": true, "png": true, "svg": true,
+}
+
+// registerDocsExportCmd adds the unified file export workflow. It is handwritten
+// because the output path and its extension have cross-field validation, and
+// because the wire endpoint differs between document files and board images.
+func registerDocsExportCmd(root *cobra.Command, f *cmdutil.Factory) {
+	var docs *cobra.Command
+	for _, child := range root.Commands() {
+		if child.Name() == "docs" {
+			docs = child
+			break
+		}
+	}
+	if docs == nil {
+		return
+	}
+
+	var exportFormat, outputPath string
+	cmd := &cobra.Command{
+		Use:   "export <docId>",
+		Short: "Export a document to a local file",
+		Long: `Export an Octo document to a local file.
+
+Use --export-format (rather than the global --format, which controls the output
+envelope). The destination extension must match the selected export format.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDocsExport(cmd, f, args[0], exportFormat, outputPath)
+		},
+	}
+	cmd.Flags().StringVar(&exportFormat, "export-format", "", "file format: md | docx | pdf | xlsx | png | svg (required)")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "destination file path (required)")
+	docs.AddCommand(cmd)
+}
+
+func validateDocsExport(format, outputPath string) (string, error) {
+	format = strings.ToLower(strings.TrimSpace(format))
+	if !docsExportFormats[format] {
+		return "", output.ErrValidation("unsupported --export-format", "use md, docx, pdf, xlsx, png, or svg")
+	}
+	if outputPath == "" {
+		return "", output.ErrValidation("--output is required", "pass -o with a destination file path")
+	}
+	gotExt := strings.ToLower(filepath.Ext(outputPath))
+	wantExt := "." + format
+	if gotExt != wantExt {
+		return "", output.ErrValidation("output extension does not match --export-format", "use a "+wantExt+" destination path")
+	}
+	return format, nil
+}
+
+func runDocsExport(cmd *cobra.Command, f *cmdutil.Factory, docID, format, outputPath string) error {
+	format, err := validateDocsExport(format, outputPath)
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // best-effort structured error
+		return err
+	}
+
+	path := "/v1/bot/docs/" + url.PathEscape(docID) + "/export"
+	if format == "md" || format == "docx" || format == "pdf" || format == "xlsx" {
+		path += "/file"
+	}
+	query := url.Values{"format": []string{format}}
+
+	if f.Globals != nil && f.Globals.DryRun {
+		dryRun, marshalErr := json.Marshal(map[string]any{
+			"dry_run":       true,
+			"method":        http.MethodGet,
+			"path":          path,
+			"query":         map[string]string{"format": format},
+			"output":        outputPath,
+			"export_format": format,
+		})
+		if marshalErr != nil {
+			return marshalErr
+		}
+		return f.EmitSuccess(dryRun)
+	}
+
+	cli, err := f.Client()
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return err
+	}
+	result, err := cli.Do(cmd.Context(), &client.Request{
+		Method:              http.MethodGet,
+		Path:                path,
+		Query:               query,
+		BinaryResponse:      true,
+		OutputPath:          outputPath,
+		SuppressSpaceHeader: true,
+	})
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return err
+	}
+	return f.EmitSuccess(result)
+}

--- a/cmd/docs_export_test.go
+++ b/cmd/docs_export_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDocsExport_AllFormatsUseExpectedEndpointAndWriteBytes(t *testing.T) {
+	formats := []string{"md", "docx", "pdf", "xlsx", "png", "svg"}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			const payload = "exported bytes"
+			tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+				wantPath := "/v1/bot/docs/d%2F1/export"
+				if format != "png" && format != "svg" {
+					wantPath += "/file"
+				}
+				if r.Method != http.MethodGet || r.URL.EscapedPath() != wantPath {
+					t.Errorf("request = %s %s, want GET %s", r.Method, r.URL.EscapedPath(), wantPath)
+				}
+				if got := r.URL.Query().Get("format"); got != format {
+					t.Errorf("format query = %q, want %q", got, format)
+				}
+				_, _ = io.WriteString(w, payload)
+			})
+			dst := filepath.Join(t.TempDir(), "result."+format)
+			out, _, err := execRoot(t, tf, "docs", "export", "d/1", "--export-format", format, "-o", dst)
+			if err != nil {
+				t.Fatalf("export: %v", err)
+			}
+			got, err := os.ReadFile(dst)
+			if err != nil || string(got) != payload {
+				t.Fatalf("output file = %q, %v", got, err)
+			}
+			var env struct {
+				OK   bool `json:"ok"`
+				Data struct {
+					Output string `json:"output"`
+					Size   int    `json:"size"`
+				} `json:"data"`
+			}
+			if err := json.Unmarshal([]byte(out), &env); err != nil {
+				t.Fatal(err)
+			}
+			if !env.OK || env.Data.Output != dst || env.Data.Size != len(payload) {
+				t.Errorf("envelope = %+v", env)
+			}
+		})
+	}
+}
+
+func TestDocsExport_ValidatesRequiredFlagsAndExtensionBeforeRequest(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+
+	cases := [][]string{
+		{"docs", "export", "d1", "--export-format", "pdf", "-o", "report.docx"},
+		{"docs", "export", "d1", "--export-format", "zip", "-o", "report.zip"},
+		{"docs", "export", "d1", "--export-format", "pdf"},
+		{"docs", "export", "d1", "-o", "report.pdf"},
+	}
+	for _, args := range cases {
+		tf.Out.Reset()
+		tf.ErrOut.Reset()
+		if _, _, err := execRoot(t, tf, args...); err == nil {
+			t.Errorf("args %v: expected validation error", args)
+		}
+	}
+	if called {
+		t.Error("server must not be called for invalid input")
+	}
+}
+
+func TestDocsExport_DryRunDoesNotWriteOrRequest(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	dst := filepath.Join(t.TempDir(), "report.pdf")
+	out, _, err := execRoot(t, tf, "--dry-run", "docs", "export", "d1", "--export-format", "pdf", "-o", dst)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if called {
+		t.Error("server must not be called")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("dry run wrote destination: %v", err)
+	}
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("invalid JSON envelope: %s", out)
+	}
+}
+
+func TestDocsExport_ErrorResponsePreservesExistingTarget(t *testing.T) {
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"code":"export_failed","message":"nope"}`)
+	})
+	dst := filepath.Join(t.TempDir(), "report.pdf")
+	const old = "keep me"
+	if err := os.WriteFile(dst, []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := execRoot(t, tf, "docs", "export", "d1", "--export-format", "pdf", "-o", dst); err == nil {
+		t.Fatal("expected backend error")
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != old {
+		t.Fatalf("existing target changed: %q, %v", got, err)
+	}
+}
+
+func TestDocsExport_DoesNotShadowGlobalFormat(t *testing.T) {
+	tf := newTestFactoryWithReg()
+	root := NewRootCmd(tf.Factory)
+	docs, _, err := root.Find([]string{"docs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	export, _, err := docs.Find([]string{"export"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if export.LocalFlags().Lookup("export-format") == nil {
+		t.Fatal("missing local --export-format")
+	}
+	if export.LocalFlags().Lookup("format") != nil {
+		t.Fatal("local --format shadows global envelope format")
+	}
+}

--- a/cmd/docs_import.go
+++ b/cmd/docs_import.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+const maxDocsImportBytes int64 = 25 * 1024 * 1024
+
+type docsImportFormat struct {
+	name        string
+	contentType string
+	excalidraw  bool
+}
+
+// registerDocsImportCmd adds the file-oriented import workflow after the
+// metadata-driven docs tree is built. The backend parses and applies each file
+// atomically so a large converted document never has to pass through the generic
+// JSON edit-body limit.
+func registerDocsImportCmd(root *cobra.Command, f *cmdutil.Factory) {
+	var docs *cobra.Command
+	for _, child := range root.Commands() {
+		if child.Name() == "docs" {
+			docs = child
+			break
+		}
+	}
+	if docs == nil {
+		return
+	}
+
+	var filePath string
+	var mode string
+	cmd := &cobra.Command{
+		Use:   "import <docId>",
+		Short: "Import a document, spreadsheet, or Excalidraw file",
+		Long: `Import a local file into an existing Octo document.
+
+The file extension selects the importer: .docx and .md/.markdown target a doc;
+.xlsx targets a sheet; .excalidraw targets a board. Document and sheet imports
+atomically replace existing content. Excalidraw imports default to merge, which
+preserves existing board elements. --mode replace explicitly overwrites the board;
+the backend creates a safety snapshot and applies concurrency protection.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDocsImport(cmd, f, args[0], filePath, mode, cmd.Flags().Changed("mode"))
+		},
+	}
+	cmd.Flags().StringVar(&filePath, "file", "", "path to the .docx, .md, .markdown, .xlsx, or .excalidraw file (required)")
+	cmd.Flags().StringVar(&mode, "mode", "merge", "Excalidraw import mode: merge preserves existing elements; replace explicitly overwrites with backend safety snapshot and concurrency protection")
+	_ = cmd.MarkFlagRequired("file") //nolint:errcheck // static flag name
+	docs.AddCommand(cmd)
+}
+
+func docsImportFormatForPath(path string) (docsImportFormat, error) {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".docx":
+		return docsImportFormat{name: "docx", contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"}, nil
+	case ".md", ".markdown":
+		return docsImportFormat{name: "markdown", contentType: "text/markdown"}, nil
+	case ".xlsx":
+		return docsImportFormat{name: "xlsx", contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"}, nil
+	case ".excalidraw":
+		return docsImportFormat{name: "excalidraw", contentType: "application/json", excalidraw: true}, nil
+	default:
+		return docsImportFormat{}, output.ErrValidation("unsupported import file type", "use a .docx, .md, .markdown, .xlsx, or .excalidraw file")
+	}
+}
+
+// Import validation, dry-run rendering, file loading, and the request are kept in one orchestrator.
+//
+//nolint:gocyclo // each branch returns a distinct structured CLI error and is covered independently
+func runDocsImport(cmd *cobra.Command, f *cmdutil.Factory, docID, filePath, mode string, modeChanged bool) error {
+	format, err := docsImportFormatForPath(filePath)
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
+		return err
+	}
+	if modeChanged && !format.excalidraw {
+		ee := output.ErrValidation("--mode is only available for .excalidraw imports", "remove --mode or use an .excalidraw file")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	if format.excalidraw && mode != "merge" && mode != "replace" {
+		ee := output.ErrValidation("--mode must be merge or replace", "use --mode merge to preserve existing elements, or --mode replace to explicitly overwrite the board")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	info, err := os.Stat(filePath)
+	if err != nil {
+		ee := output.ErrValidation(fmt.Sprintf("--file: %v", err), "check path and permissions")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	if !info.Mode().IsRegular() {
+		ee := output.ErrValidation("--file must point to a regular file", "pass a local .docx, .md, .markdown, .xlsx, or .excalidraw file")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	if info.Size() == 0 {
+		ee := output.ErrValidation("--file is empty", "pass a non-empty import file")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	if info.Size() > maxDocsImportBytes {
+		ee := output.ErrValidation("--file exceeds the 25 MiB import limit", "use a smaller import file")
+		_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return ee
+	}
+	var bytes []byte
+	if format.excalidraw {
+		bytes, err = os.ReadFile(filePath)
+		if err != nil {
+			ee := output.ErrValidation(fmt.Sprintf("--file: %v", err), "check path and permissions")
+			_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+			return ee
+		}
+		if err := validateExcalidrawEnvelope(bytes); err != nil {
+			_ = f.EmitError(err) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+			return err
+		}
+	}
+	if f.Globals != nil && f.Globals.DryRun {
+		path := "/v1/bot/docs/" + url.PathEscape(docID) + "/import/" + format.name
+		details := map[string]any{
+			"dry_run":      true,
+			"method":       http.MethodPost,
+			"path":         path,
+			"file":         filePath,
+			"size":         info.Size(),
+			"content_type": format.contentType,
+		}
+		if format.excalidraw {
+			path += "?mode=" + url.QueryEscape(mode)
+			details["path"] = path
+			details["mode"] = mode
+			details["semantics"] = map[string]any{
+				"preserves_existing":  mode == "merge",
+				"explicit_overwrite":  mode == "replace",
+				"safety_snapshot":     mode == "replace",
+				"concurrency_guarded": true,
+			}
+		}
+		dryRun, marshalErr := json.Marshal(details)
+		if marshalErr != nil {
+			return marshalErr
+		}
+		return f.EmitSuccess(dryRun)
+	}
+	if bytes == nil {
+		bytes, err = os.ReadFile(filePath)
+		if err != nil {
+			ee := output.ErrValidation(fmt.Sprintf("--file: %v", err), "check path and permissions")
+			_ = f.EmitError(ee) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+			return ee
+		}
+	}
+
+	cli, err := f.Client()
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return err
+	}
+	basePath := "/v1/bot/docs/" + url.PathEscape(docID)
+	importPath := basePath + "/import/" + format.name
+	var query url.Values
+	if format.excalidraw {
+		query = url.Values{"mode": []string{mode}}
+	}
+	parsedRaw, err := cli.Do(cmd.Context(), &client.Request{
+		Method:              http.MethodPost,
+		Path:                importPath,
+		Query:               query,
+		Headers:             map[string]string{"X-Octo-Import-Apply": "true"},
+		RawBody:             bytes,
+		ContentType:         format.contentType,
+		SuppressSpaceHeader: true,
+	})
+	if err != nil {
+		_ = f.EmitError(err) //nolint:errcheck // the original error remains authoritative if rendering it also fails
+		return err
+	}
+	var applied map[string]any
+	if err := json.Unmarshal(parsedRaw, &applied); err != nil {
+		return f.EmitSuccess(parsedRaw)
+	}
+	applied["format"] = format.name
+	out, err := json.Marshal(applied)
+	if err != nil {
+		return err
+	}
+	return f.EmitSuccess(out)
+}
+
+func validateExcalidrawEnvelope(data []byte) error {
+	var envelope struct {
+		Type     json.RawMessage `json:"type"`
+		Version  json.RawMessage `json:"version"`
+		Elements json.RawMessage `json:"elements"`
+		Files    json.RawMessage `json:"files"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return output.ErrValidation("invalid .excalidraw JSON", "pass a JSON Excalidraw envelope")
+	}
+	var kind string
+	if err := json.Unmarshal(envelope.Type, &kind); err != nil || kind != "excalidraw" {
+		return output.ErrValidation("invalid .excalidraw envelope: type must be excalidraw", "export the file from Excalidraw and try again")
+	}
+	var version int
+	if err := json.Unmarshal(envelope.Version, &version); err != nil || version != 2 {
+		return output.ErrValidation("invalid .excalidraw envelope: version must be 2", "export the file from Excalidraw and try again")
+	}
+	var elements []json.RawMessage
+	if err := json.Unmarshal(envelope.Elements, &elements); err != nil || elements == nil {
+		return output.ErrValidation("invalid .excalidraw envelope: elements must be an array", "export the file from Excalidraw and try again")
+	}
+	var files map[string]json.RawMessage
+	if err := json.Unmarshal(envelope.Files, &files); err != nil || files == nil {
+		return output.ErrValidation("invalid .excalidraw envelope: files must be an object", "export the file from Excalidraw and try again")
+	}
+	return nil
+}

--- a/cmd/docs_import_test.go
+++ b/cmd/docs_import_test.go
@@ -1,0 +1,267 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
+)
+
+func importTestRoot(t *testing.T, handler http.HandlerFunc) (*cmdutil.TestFactory, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	tf := newTestFactoryWithReg()
+	cfg := &config.Config{APIBaseURL: srv.URL, BotToken: "app_test", Format: "json"}
+	cred := &credential.BotCredential{Token: "app_test", Source: "test"}
+	tf.SetConfig(cfg)
+	tf.SetCredential(cred)
+	tf.SetClient(client.New(cfg, cred, client.Options{ErrOut: io.Discard, NoRetry: true}))
+	return tf, srv
+}
+
+func writeImportFixture(t *testing.T, ext string, body []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "input"+ext)
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDocsImportMarkdown_AppliesAtomically(t *testing.T) {
+	var steps []string
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+		steps = append(steps, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Content-Type"); got != "text/markdown" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if got := r.Header.Get("X-Octo-Import-Apply"); got != "true" {
+			t.Errorf("apply header = %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != "# Imported\n" {
+			t.Errorf("body = %q", body)
+		}
+		_, _ = w.Write([]byte(`{"docId":"d1","baseVersion":"BV_NEW==","newDocVersionSeq":2,"warnings":["note"]}`))
+	})
+	file := writeImportFixture(t, ".md", []byte("# Imported\n"))
+	out, _, err := execRoot(t, tf, "docs", "import", "d1", "--file", file)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	wantSteps := []string{"POST /v1/bot/docs/d1/import/markdown"}
+	if len(steps) != len(wantSteps) || steps[0] != wantSteps[0] {
+		t.Fatalf("steps = %v, want %v", steps, wantSteps)
+	}
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Format   string   `json:"format"`
+			Warnings []string `json:"warnings"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatal(err)
+	}
+	if !env.OK || env.Data.Format != "markdown" || len(env.Data.Warnings) != 1 {
+		t.Errorf("envelope = %+v", env)
+	}
+}
+
+func TestDocsImportXlsx_WritesInSingleRequest(t *testing.T) {
+	calls := 0
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/bot/docs/s1/import/xlsx" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"baseVersion":"BV2","warnings":[]}`))
+	})
+	file := writeImportFixture(t, ".xlsx", []byte("xlsx bytes"))
+	if _, _, err := execRoot(t, tf, "docs", "import", "s1", "--file", file); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}
+
+func TestDocsImport_RejectsUnsupportedExtensionBeforeRequest(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	file := writeImportFixture(t, ".pdf", []byte("pdf"))
+	if _, _, err := execRoot(t, tf, "docs", "import", "d1", "--file", file); err == nil {
+		t.Fatal("expected unsupported extension error")
+	}
+	if called {
+		t.Error("server must not be called")
+	}
+}
+
+func TestDocsImport_DryRunDoesNotReadOrUploadFile(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	file := writeImportFixture(t, ".docx", []byte("not a real docx"))
+	out, _, err := execRoot(t, tf, "--dry-run", "docs", "import", "d1", "--file", file)
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if called {
+		t.Error("server must not be called during --dry-run")
+	}
+	var env struct {
+		Data struct {
+			DryRun      bool   `json:"dry_run"`
+			Path        string `json:"path"`
+			ContentType string `json:"content_type"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatal(err)
+	}
+	if !env.Data.DryRun || env.Data.Path != "/v1/bot/docs/d1/import/docx" {
+		t.Errorf("dry-run envelope = %+v", env)
+	}
+	if env.Data.ContentType != "application/vnd.openxmlformats-officedocument.wordprocessingml.document" {
+		t.Errorf("content type = %q", env.Data.ContentType)
+	}
+}
+
+func TestDocsImportExcalidraw_DefaultMerge(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/bot/docs/b1/import/excalidraw" {
+			t.Errorf("got %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.URL.Query().Get("mode"); got != "merge" {
+			t.Errorf("mode = %q, want merge", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if got := r.Header.Get("X-Octo-Import-Apply"); got != "true" {
+			t.Errorf("apply header = %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"baseVersion":"BV3"}`))
+	})
+	file := writeImportFixture(t, ".excalidraw", []byte(`{"type":"excalidraw","version":2,"elements":[],"files":{}}`))
+	out, _, err := execRoot(t, tf, "docs", "import", "b1", "--file", file)
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if !called {
+		t.Fatal("server was not called")
+	}
+	var env struct {
+		Data struct {
+			Format string `json:"format"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Data.Format != "excalidraw" {
+		t.Errorf("format = %q", env.Data.Format)
+	}
+}
+
+func TestDocsImportExcalidraw_ReplaceDryRunDescribesSafety(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	file := writeImportFixture(t, ".excalidraw", []byte(`{"type":"excalidraw","version":2,"elements":[],"files":{}}`))
+	out, _, err := execRoot(t, tf, "--dry-run", "docs", "import", "b1", "--file", file, "--mode", "replace")
+	if err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+	if called {
+		t.Fatal("server must not be called during --dry-run")
+	}
+	var env struct {
+		Data struct {
+			Path      string `json:"path"`
+			Mode      string `json:"mode"`
+			Semantics struct {
+				PreservesExisting bool `json:"preserves_existing"`
+				ExplicitOverwrite bool `json:"explicit_overwrite"`
+				SafetySnapshot    bool `json:"safety_snapshot"`
+				ConcurrencyGuard  bool `json:"concurrency_guarded"`
+			} `json:"semantics"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Data.Path != "/v1/bot/docs/b1/import/excalidraw?mode=replace" || env.Data.Mode != "replace" {
+		t.Errorf("dry-run data = %+v", env.Data)
+	}
+	if env.Data.Semantics.PreservesExisting || !env.Data.Semantics.ExplicitOverwrite || !env.Data.Semantics.SafetySnapshot || !env.Data.Semantics.ConcurrencyGuard {
+		t.Errorf("semantics = %+v", env.Data.Semantics)
+	}
+}
+
+func TestDocsImportExcalidraw_ValidatesEnvelopeBeforeRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"type", `{"type":"other","version":2,"elements":[],"files":{}}`},
+		{"version-missing", `{"type":"excalidraw","elements":[],"files":{}}`},
+		{"version-unsupported", `{"type":"excalidraw","version":1,"elements":[],"files":{}}`},
+		{"elements", `{"type":"excalidraw","version":2,"elements":{},"files":{}}`},
+		{"files", `{"type":"excalidraw","version":2,"elements":[],"files":[]}`},
+		{"json", `{`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+			file := writeImportFixture(t, ".excalidraw", []byte(tt.body))
+			if _, _, err := execRoot(t, tf, "docs", "import", "b1", "--file", file); err == nil {
+				t.Fatal("expected validation error")
+			}
+			if called {
+				t.Fatal("server must not be called")
+			}
+		})
+	}
+}
+
+func TestDocsImport_ModeOnlyAppliesToExcalidraw(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	file := writeImportFixture(t, ".md", []byte("# doc\n"))
+	if _, _, err := execRoot(t, tf, "docs", "import", "d1", "--file", file, "--mode", "replace"); err == nil {
+		t.Fatal("expected validation error")
+	}
+	if called {
+		t.Fatal("server must not be called")
+	}
+}
+
+func TestDocsImportExcalidraw_RejectsUnknownMode(t *testing.T) {
+	called := false
+	tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+	file := writeImportFixture(t, ".excalidraw", []byte(`{"type":"excalidraw","version":2,"elements":[],"files":{}}`))
+	if _, _, err := execRoot(t, tf, "docs", "import", "b1", "--file", file, "--mode", "append"); err == nil {
+		t.Fatal("expected validation error")
+	}
+	if called {
+		t.Fatal("server must not be called")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,6 +55,8 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	root.AddCommand(newAuthCmd(f))
 	root.AddCommand(newSheetCellCmd(f))
 	service.RegisterServiceCommands(root, f)
+	registerDocsImportCmd(root, f)
+	registerDocsExportCmd(root, f)
 	withholdDisabledServices(root, f)
 
 	return root

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -57,6 +57,16 @@ octo-cli docs create [--title "Runbook"] [--folderId f_123] [--docType doc|sheet
 octo-cli docs list [--folderId f_123] [--page 1] [--pageSize 20] [--sort updatedAt:desc]
 
 octo-cli docs get    <docId>                 # metadata + doc_type + your role
+
+# Import a local file into an existing target. .md/.markdown/.docx require a doc;
+# .xlsx requires a sheet and imports its first visible worksheet.
+octo-cli docs import <docId> --file ./input.md
+
+# Export to a local file. -o is required and its extension must match.
+# --export-format is distinct from global --format (the envelope renderer).
+octo-cli docs export <docId> --export-format pdf -o ./output.pdf
+# Other accepted matching pairs: md/.md, docx/.docx, xlsx/.xlsx, png/.png, svg/.svg
+
 octo-cli docs rename <docId> --title "New title"
 octo-cli docs delete <docId>                 # soft delete (admin)
 ```

--- a/skills/octo-docs/board.md
+++ b/skills/octo-docs/board.md
@@ -38,6 +38,26 @@ are touched (the rest of the board is left as-is). On a key collision the elemen
 with the higher `version` (then smaller `versionNonce`) wins, and a delete is a
 soft-delete tombstone with a superseding version so it converges under CAS.
 
+## Excalidraw file import
+
+Import a standard `.excalidraw` JSON envelope (maximum 25 MiB) directly into an
+existing board. The CLI validates `type: "excalidraw"`, a positive integer
+`version`, an `elements` array, and a `files` object before sending the request.
+
+```bash
+# Safe default: merge imported elements while preserving the existing board.
+octo-cli docs import <docId> --file ./diagram.excalidraw
+
+# Explicit overwrite: replace the board with the imported scene.
+octo-cli docs import <docId> --file ./diagram.excalidraw --mode replace
+```
+
+`--mode` is only valid for `.excalidraw` imports and accepts `merge` (default) or
+`replace`. Merge preserves existing board elements. Replace explicitly overwrites
+the board; the backend first creates a safety snapshot and enforces concurrency
+protection. Use `--dry-run` to inspect the mode, endpoint, and these safety
+semantics without applying the import.
+
 **Concurrency / errors.** The base version is optimistic-concurrency: if the scene
 changed since your `docs scene get`, an edit is rejected with
 `412 base_version_stale` — re-read for a fresh token. Other gates:
@@ -51,19 +71,19 @@ caps), `400 invalid_body` (missing base version or malformed shape),
 ## Whiteboard image export
 
 Render a whiteboard's **live** Excalidraw scene to an image on the server. The
-response body is binary, so pass `--output`/`-o` to save it to a file; without
-`-o` the command only reports the response `{status, content_type, size}`.
+response body is binary, so `--output`/`-o` is required and saves it atomically
+to the matching `.png` or `.svg` destination.
 
 ```bash
-# PNG (default). -o writes the bytes to disk and the envelope echoes the saved path.
-octo-cli docs scene export <docId> --image-format png -o board.png
+# PNG. -o writes the bytes to disk and the envelope echoes the saved path.
+octo-cli docs export <docId> --export-format png -o board.png
 
 # SVG (vector).
-octo-cli docs scene export <docId> --image-format svg -o board.svg
+octo-cli docs export <docId> --export-format svg -o board.svg
 ```
 
-> `--image-format` is `png` (default) or `svg`; any other value returns 400
-> `invalid_format`. (The flag is named `--image-format`, not `--format`, so it
+> `--export-format` is `png` or `svg`; any other value is rejected locally.
+> (The flag is named `--export-format`, not `--format`, so it
 > does not collide with the global `--format` output-envelope flag; the wire
 > query parameter is still `format`.) The export reflects the scene as it is live
 > right now (shapes, text, and embedded images), not a persisted snapshot.

--- a/skills/octo-docs/doc.md
+++ b/skills/octo-docs/doc.md
@@ -17,6 +17,11 @@ octo-cli docs content get <docId>
 # Apply an incremental edit (writer). --base-version is REQUIRED and is sent as
 # the If-Match header; the ops batch goes through --data as a JSON array.
 octo-cli docs content edit <docId> --base-version "<token>" --data '<ops JSON>'
+
+# Export the rendered document. The output extension must match the format.
+octo-cli docs export <docId> --export-format md -o document.md
+octo-cli docs export <docId> --export-format docx -o document.docx
+octo-cli docs export <docId> --export-format pdf -o document.pdf
 ```
 
 Ops are addressed by **block path** (child indices from the doc root) and come

--- a/skills/octo-docs/sheet.md
+++ b/skills/octo-docs/sheet.md
@@ -6,6 +6,12 @@ merged ranges, sheet tabs, or export it.
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`. Auth & space rules are in
 `SKILL.md`.
 
+Export a sheet to XLSX with a required, matching destination extension:
+
+```bash
+octo-cli docs export <docId> --export-format xlsx -o spreadsheet.xlsx
+```
+
 A spreadsheet stores a flat cell map on the Y.Doc, keyed `sheetId!row:col` (e.g.
 `default!0:0`), with values `{v,f,s}` — `v` a string/number/boolean/null, `f` an
 optional formula, `s` an opaque resolved style object. (Cells authored in the web


### PR DESCRIPTION
## Summary
- add Docs file import for DOCX, Markdown, XLSX, and Excalidraw
- add file export for MD, DOCX, PDF, XLSX, PNG, and SVG
- validate Excalidraw envelopes and mode combinations before sending requests
- update CLI help and embedded Docs skill guidance

## Linked Spec
Closes #102

## How verified
- `git diff --check upstream/main...HEAD`
- one-commit diff reviewed against latest `upstream/main`
- Go tests were not runnable on this host because the Go toolchain is not installed

## COMPREHENSION
1. **How is the importer selected?** By the local file extension, with document, sheet, and board types mapped to backend endpoints.
2. **What prevents accidental board replacement?** Excalidraw input is envelope-validated locally and requires an explicit supported merge/replace mode.
3. **Does the CLI reimplement document conversion?** No. It validates request inputs and delegates authoritative conversion to the Docs backend.