### PR TITLE
fix(html): add docs-html gateway prefix

### DIFF
--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -95,6 +96,15 @@ func TestGetOperationMatterCreate(t *testing.T) {
 	}
 	if !hasRequired {
 		t.Errorf("request body required: want [title], got %v", op.RequestBody.Required)
+	}
+}
+
+func TestHTMLOperationsUseDocsHTMLGatewayPrefix(t *testing.T) {
+	r := MustNew()
+	for _, op := range r.ListOperations("html") {
+		if want := "/docs-html/v1/"; !strings.HasPrefix(op.Path, want) {
+			t.Errorf("%s: path = %q, want prefix %q", op.ID, op.Path, want)
+		}
 	}
 }
 

--- a/internal/registry/specs/html.json
+++ b/internal/registry/specs/html.json
@@ -3,13 +3,13 @@
   "info": {
     "title": "Octo HTML Docs API",
     "version": "1.0.0",
-    "description": "Agent-facing surface for octo-doc — the self-hosted, prompt-native interactive HTML document service (distinct from the CRDT docs-backend behind the `docs` domain). Covers the document lifecycle (publish/list/get/versions/delete), author drafts, per-doc share codes, media assets, inline comments, and the agent element read/replace + reply paths. All paths are under the `/v1` prefix and return the `{data}/{error}` envelope."
+    "description": "Agent-facing surface for octo-doc — the self-hosted, prompt-native interactive HTML document service (distinct from the CRDT docs-backend behind the `docs` domain). Covers the document lifecycle (publish/list/get/versions/delete), author drafts, per-doc share codes, media assets, inline comments, and the agent element read/replace + reply paths. All paths are under the `/docs-html/v1` prefix and return the `{data}/{error}` envelope."
   },
   "x-octo-service": "html",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
   "paths": {
-    "/v1/docs": {
+    "/docs-html/v1/docs": {
       "get": {
         "operationId": "html.list",
         "summary": "List documents (owner-scoped index)",
@@ -94,11 +94,11 @@
         }
       }
     },
-    "/v1/docs/{slug}": {
+    "/docs-html/v1/docs/{slug}": {
       "get": {
         "operationId": "html.get",
         "summary": "Fetch one document's metadata (needs reader)",
-        "description": "Return a single document's metadata (slug, title, latest version, timestamps). Backend endpoint GET /v1/docs/{slug} — added to octo-doc to back this command.",
+        "description": "Return a single document's metadata (slug, title, latest version, timestamps). Backend endpoint GET /docs-html/v1/docs/{slug} — added to octo-doc to back this command.",
         "x-octo-risk": "read",
         "parameters": [
           { "name": "slug", "in": "path", "required": true, "schema": { "type": "string" } }
@@ -136,7 +136,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/versions": {
+    "/docs-html/v1/docs/{slug}/versions": {
       "get": {
         "operationId": "html.versions",
         "summary": "List a document's versions (needs reader)",
@@ -165,7 +165,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/draft": {
+    "/docs-html/v1/docs/{slug}/draft": {
       "put": {
         "operationId": "html.draft.save",
         "summary": "Save the author draft (author-only)",
@@ -193,7 +193,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/draft/promote": {
+    "/docs-html/v1/docs/{slug}/draft/promote": {
       "post": {
         "operationId": "html.draft.promote",
         "summary": "Promote the author draft to an immutable version (author-only)",
@@ -220,7 +220,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/share": {
+    "/docs-html/v1/docs/{slug}/share": {
       "post": {
         "operationId": "html.share",
         "summary": "Mint / rotate a per-doc read+comment share code (author-only)",
@@ -257,7 +257,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/grants": {
+    "/docs-html/v1/docs/{slug}/grants": {
       "get": {
         "operationId": "html.grant.list",
         "summary": "List a document's per-uid access grants (author-only)",
@@ -314,7 +314,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/grants/{uid}": {
+    "/docs-html/v1/docs/{slug}/grants/{uid}": {
       "delete": {
         "operationId": "html.grant.rm",
         "summary": "Revoke a uid's access grant (author-only)",
@@ -329,7 +329,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/assets": {
+    "/docs-html/v1/docs/{slug}/assets": {
       "get": {
         "operationId": "html.asset.ls",
         "summary": "List a document's media assets (needs reader)",
@@ -400,7 +400,7 @@
         }
       }
     },
-    "/v1/docs/{slug}/assets/{sha256}": {
+    "/docs-html/v1/docs/{slug}/assets/{sha256}": {
       "delete": {
         "operationId": "html.asset.rm",
         "summary": "Delete a media asset (author-only)",
@@ -414,7 +414,7 @@
         }
       }
     },
-    "/v1/comments": {
+    "/docs-html/v1/comments": {
       "get": {
         "operationId": "html.comment.list",
         "summary": "List a document's comments (needs reader)",
@@ -457,7 +457,7 @@
         }
       }
     },
-    "/v1/agent/replies": {
+    "/docs-html/v1/agent/replies": {
       "post": {
         "operationId": "html.reply",
         "summary": "Post an agent reply + verdict to a comment (write-token gated)",
@@ -486,7 +486,7 @@
         }
       }
     },
-    "/v1/agent/element/get": {
+    "/docs-html/v1/agent/element/get": {
       "post": {
         "operationId": "html.element.get",
         "summary": "Read one artifact's outer HTML by aid (write-token gated)",
@@ -527,7 +527,7 @@
         }
       }
     },
-    "/v1/agent/element/replace": {
+    "/docs-html/v1/agent/element/replace": {
       "post": {
         "operationId": "html.element.replace",
         "summary": "Replace one artifact's outer HTML by aid and republish (write-token gated)",

--- a/skills/octo-html/SKILL.md
+++ b/skills/octo-html/SKILL.md
@@ -19,7 +19,7 @@ metadata:
 > single stamped artifact** (located by its content-hash `aid`) which republishes
 > a new version. Pick the domain that matches the backend you are pointed at.
 
-All commands call `$OCTO_API_BASE_URL/v1/*` and return the `{data}/{error}` envelope.
+All commands call `$OCTO_API_BASE_URL/docs-html/v1/*` and return the `{data}/{error}` envelope.
 
 ## Auth & space
 


### PR DESCRIPTION
## Summary

Routes every `octo-cli html` operation through the dedicated Docs HTML gateway prefix:

- changes all registered HTML API paths from `/v1/*` to `/docs-html/v1/*`
- updates the bundled `octo-html` skill to document the same prefix
- adds a registry contract test covering every registered HTML operation

The `docs` domain and published viewer URLs such as `/d/<slug>/v/<n>` are unchanged.

## Linked Spec

- Global engineering standard: `octo-spec@1.2.0`
- Runtime contract: the gateway and Docs HTML backend must serve `/docs-html/v1/*`
- No dedicated issue or product spec is linked to this PR

## COMPREHENSION

### 1. What changes on the load-bearing path?

Before this PR, the CLI registry resolved HTML operations under the generic `/v1/*` path. Because command dispatch uses the registry path verbatim, every `octo-cli html` request was sent through that old route.

After this PR, all 20 registered HTML operations resolve under `/docs-html/v1/*`. The service identifier and `OCTO_API_BASE_URL` handling remain unchanged; only the request path prefix changes. Published document URLs are not rewritten.

### 2. What could break?

- If the gateway or Docs HTML backend does not serve `/docs-html/v1/*` before this client change is deployed, HTML commands will return 404.
- A missed registry path would leave one operation on the old route.
- Accidentally changing viewer URLs such as `/d/<slug>/v/<n>` would break published document links.
- Other CLI domains must not inherit the Docs HTML prefix.

No authentication behavior, request payload, response schema, environment variable, or persisted data format changes.

### 3. How do we know it works?

- The registry contract test iterates every HTML operation and requires the `/docs-html/v1/` prefix.
- Existing operation-count coverage ensures the HTML operation list cannot disappear and make the prefix test pass vacuously.
- The built CLI resolves `html list --dry-run` to a URL under `/docs-html/v1/docs`.
- Repository-wide review confirmed all HTML registry paths and skill documentation use the new prefix, with no bare old paths or double-prefixes.
- CI build, Go tests, npm tests, history, and vulnerability checks pass.

## How verified

- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] CI-pinned `golangci-lint` on the touched Go package
- [x] Registry contract test covers all 20 HTML operations
- [x] Built CLI dry-run resolves the new gateway path
- [x] `git diff --check`
- [x] Independent code review: approved

## Deployment prerequisites / required environment variables

No new environment variables are introduced.

Existing variable:

- `OCTO_API_BASE_URL`: unchanged; the CLI appends `/docs-html/v1/*` to this base URL.

Deployment prerequisite:

- The gateway and Docs HTML backend must serve `/docs-html/v1/*` before this CLI change is released. Keeping the old `/v1/*` route temporarily during rollout is recommended for compatibility.
