### PR TITLE
feat: add read-only summary commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli summary` read-only domain** — `summary list|get|result` lets a
+  personal Agent discover and cite existing summaries visible to its human
+  owner. The embedded spec targets the gateway's `/summary/api/v1/bot/*`
+  mount, suppresses client space headers, and ships with the `octo-summary`
+  Skill. Listing filters title or topic; result reads include citation metadata
+  while the backend omits surrounding-message context for bot requests.
 - **`octo-cli message search` family** (6 subcommands) — full-text message and
   file search: `message search` (messages), `search all` (messages + files),
   `search files`, `search media` (images/videos, in-channel only, no keyword),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mount, suppresses client space headers, and ships with the `octo-summary`
   Skill. Listing filters title or topic; result reads include citation metadata
   while the backend omits surrounding-message context for bot requests.
+  **Currently withheld** behind `x-octo-disabled` (skill `disabled: true`): the
+  commands and skill are not listed by the CLI until the Summary backend
+  (octo-smart-summary#172) is merged and deployed; `octo-cli schema summary.*`
+  still introspects. Flip both flags in a one-line follow-up once the backend is live.
 - **`octo-cli message search` family** (6 subcommands) — full-text message and
   file search: `message search` (messages), `search all` (messages + files),
   `search files`, `search media` (images/videos, in-channel only, no keyword),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary` (withheld — backend pending), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   share codes & per-uid grants, media assets, inline comments, agent element
   read/replace.
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — discover, read, and cite
-  existing summaries visible to the personal Agent's human owner.
+  existing summaries visible to the personal Agent's human owner. **Temporarily
+  withheld** (backend API pending — octo-smart-summary#172; not currently loadable).
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   **separate backend** from `octo-docs`): publish immutable versions, drafts,
   share codes & per-uid grants, media assets, inline comments, agent element
   read/replace.
+- [`octo-summary`](./skills/octo-summary/SKILL.md) — discover, read, and cite
+  existing summaries visible to the personal Agent's human owner.
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -446,6 +446,9 @@ func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
 	if topLevelCmd(root, "matter") != nil {
 		t.Error("disabled service `matter` must not appear in the command tree")
 	}
+	if topLevelCmd(root, "summary") != nil {
+		t.Error("disabled service `summary` must not appear in the command tree")
+	}
 	if topLevelCmd(root, "message") == nil {
 		t.Error("enabled service `message` must still appear")
 	}
@@ -472,11 +475,17 @@ func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
 		if s == "matter" {
 			t.Error("global schema --list must not list disabled service `matter`")
 		}
+		if s == "summary" {
+			t.Error("global schema --list must not list disabled service `summary`")
+		}
 	}
 	for _, op := range data["operations"].([]any) {
 		m, _ := op.(map[string]any)
 		if m["service"] == "matter" {
 			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
+		}
+		if m["service"] == "summary" {
+			t.Errorf("global schema --list leaked a summary op: %v", m["id"])
 		}
 	}
 }
@@ -500,5 +509,10 @@ func TestDisabledServiceStillIntrospectable(t *testing.T) {
 	// Explicit operation lookup still resolves.
 	if _, _, err := execRoot(t, f, "schema", "matter.list"); err != nil {
 		t.Errorf("explicit `schema matter.list` must still resolve: %v", err)
+	}
+
+	// summary is likewise disabled but must stay introspectable.
+	if _, _, err := execRoot(t, f, "schema", "summary.list"); err != nil {
+		t.Errorf("explicit `schema summary.list` must still resolve: %v", err)
 	}
 }

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
+)
+
+func TestSummaryRegistryShape(t *testing.T) {
+	reg := registry.MustNew()
+	wants := map[string]string{
+		"summary.list":   "/summary/api/v1/bot/summaries",
+		"summary.get":    "/summary/api/v1/bot/summaries/{id}",
+		"summary.result": "/summary/api/v1/bot/summaries/{id}/result",
+	}
+	for id, path := range wants {
+		op, ok := reg.GetOperation(id)
+		if !ok {
+			t.Fatalf("missing %s", id)
+		}
+		if op.Method != http.MethodGet || op.Path != path || op.SpaceHeader || op.Risk != "read" || op.BaseURLEnv != "OCTO_API_BASE_URL" {
+			t.Errorf("%s: got method=%s path=%s space=%v risk=%s base=%s", id, op.Method, op.Path, op.SpaceHeader, op.Risk, op.BaseURLEnv)
+		}
+	}
+	if op, _ := reg.GetOperation("summary.list"); op.Pagination != nil {
+		t.Error("summary.list uses a backend {total,items} page, so generic --page-all must stay disabled")
+	}
+}
+
+func TestSummaryTreeShape(t *testing.T) {
+	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {})
+	summary := findCmd(root, "summary")
+	if summary == nil {
+		t.Fatal("missing summary service command")
+	}
+	for _, leaf := range []string{"list", "get", "result"} {
+		if !contains(childNames(summary), leaf) {
+			t.Errorf("summary: missing %q; got %v", leaf, childNames(summary))
+		}
+	}
+	if list := findCmd(summary, "list"); list == nil || list.Flags().Lookup("page-all") != nil {
+		t.Error("summary list must exist without --page-all")
+	}
+}
+
+func TestSummaryListSendsBearerWithoutSpaceHeader(t *testing.T) {
+	var gotPath, gotQuery, gotAuth, gotSpace string
+	root, _, _ := rootWithServiceSpaced(t, "spoofed-space", func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		gotAuth, gotSpace = r.Header.Get("Authorization"), r.Header.Get("X-Space-Id")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"total":0,"items":[]}}`))
+	})
+	root.SetArgs([]string{"summary", "list", "--keyword", "review", "--page-size", "10"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/summary/api/v1/bot/summaries" || !strings.Contains(gotQuery, "keyword=review") || !strings.Contains(gotQuery, "page_size=10") {
+		t.Errorf("request = %s?%s", gotPath, gotQuery)
+	}
+	if gotAuth == "" || gotSpace != "" {
+		t.Errorf("auth=%q space=%q", gotAuth, gotSpace)
+	}
+}
+
+func TestSummaryResultPath(t *testing.T) {
+	var gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"data":{"content":"done"}}`))
+	})
+	root.SetArgs([]string{"summary", "result", "42"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/summary/api/v1/bot/summaries/42/result" {
+		t.Fatalf("path=%s", gotPath)
+	}
+}
+
+func TestSummaryGetPath(t *testing.T) {
+	var gotPath string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"code":0,"data":{"task_id":42}}`))
+	})
+	root.SetArgs([]string{"summary", "get", "42"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/summary/api/v1/bot/summaries/42" {
+		t.Fatalf("path=%s", gotPath)
+	}
+}

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -40,8 +40,11 @@ func TestSummaryTreeShape(t *testing.T) {
 			t.Errorf("summary: missing %q; got %v", leaf, childNames(summary))
 		}
 	}
-	if list := findCmd(summary, "list"); list == nil || list.Flags().Lookup("page-all") != nil {
-		t.Error("summary list must exist without --page-all")
+	list := findCmd(summary, "list")
+	if list == nil {
+		t.Fatal("summary list command must exist")
+	} else if list.Flags().Lookup("page-all") != nil {
+		t.Error("summary list must not expose --page-all (backend returns a {total, items} page, no cursor)")
 	}
 }
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -77,8 +77,14 @@ func TestLoadSkillsExcludesDisabled(t *testing.T) {
 	if hasSkill(entries, "octo-matter") {
 		t.Error("disabled skill `octo-matter` must not be listed")
 	}
+	if hasSkill(entries, "octo-summary") {
+		t.Error("disabled skill `octo-summary` must not be listed")
+	}
 	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
 		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)
+	}
+	if _, err := skills.FS.ReadFile("octo-summary/SKILL.md"); err != nil {
+		t.Errorf("octo-summary/SKILL.md must stay embedded (only the listing filters it): %v", err)
 	}
 }
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -11,7 +11,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "docs", "event", "file", "group", "html", "marketplace", "matter", "message", "thread"}
+	want := []string{"bot", "docs", "event", "file", "group", "html", "marketplace", "matter", "message", "summary", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -45,6 +45,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"docs":        31,
 		"html":        20,
 		"marketplace": 25,
+		"summary":     3,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -173,6 +173,7 @@ func TestServiceSpaceHeaderContract(t *testing.T) {
 		{"message", "message.send", true},
 		{"matter", "matter.create", true},
 		{"marketplace", "skill.get", true},
+		{"summary", "summary.list", false},
 		{"docs", "docs.create", false},
 		{"bot", "bot.register", false},
 		{"thread", "thread.create", false},

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -9,7 +9,7 @@
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
   "x-octo-disabled": true,
-  "x-octo-status-values": ["pending(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
+  "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {
       "get": {
@@ -19,9 +19,9 @@
         "x-octo-risk": "read",
         "parameters": [
           { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1, "minimum": 1 }, "description": "1-based page number." },
-          { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }, "description": "Items per page (1-100)." },
+          { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }, "description": "Items per page (1-100); values >100 are silently reset to 20 server-side." },
           { "name": "keyword", "in": "query", "schema": { "type": "string" }, "description": "Substring matched against summary title OR topic." },
-          { "name": "status", "in": "query", "schema": { "type": "integer", "enum": [0, 1, 2, 3, 4, 5] }, "description": "Task status filter: 0=pending, 1=waiting_confirm, 2=processing, 3=completed, 4=failed, 5=cancelled." },
+          { "name": "status", "in": "query", "schema": { "type": "integer", "enum": [0, 1, 2, 3, 4, 5] }, "description": "Task status filter. 0=waiting (caller-specific aggregate: status 0, OR a pending participant/schedule invitation, OR an unsubmitted personal result on a multi-participant task — so status-0 rows may not have status field 0), 1=waiting_confirm, 2=processing, 3=completed, 4=failed, 5=cancelled." },
           { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer", "enum": [1, 2, 3] }, "description": "How the summary was triggered: 1=manual, 2=scheduled, 3=agent." },
           { "name": "origin_channel_id", "in": "query", "x-octo-flag": "origin-channel-id", "schema": { "type": "string" }, "description": "Filter to summaries whose origin channel matches this id." },
           { "name": "created_after", "in": "query", "x-octo-flag": "created-after", "schema": { "type": "string", "format": "date-time" }, "description": "RFC3339 timestamp, e.g. 2026-07-01T00:00:00Z. Malformed values are silently ignored by the server (filter not applied)." },
@@ -31,26 +31,44 @@
         ],
         "responses": {
           "200": {
-            "description": "Summary page",
+            "description": "Summary page (wrapped in the backend {code, message, data} envelope; via octo-cli the jq path is .data.data.items[]).",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "Backend envelope. octo-cli nests this under its own `data`, so the effective jq path is `.data.data.*`.",
                   "properties": {
-                    "total": { "type": "integer", "description": "Total matching summaries (not just this page)." },
-                    "items": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "task_id": { "type": "integer" },
-                          "task_no": { "type": "string" },
-                          "title": { "type": "string" },
-                          "status": { "type": "integer", "description": "0=pending,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
-                          "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
-                          "origin_channel_id": { "type": "string" },
-                          "created_at": { "type": "string", "description": "RFC3339 timestamp" },
-                          "updated_at": { "type": "string", "description": "RFC3339 timestamp" }
+                    "code": { "type": "integer", "description": "0 on success." },
+                    "message": { "type": "string" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "total": { "type": "integer", "description": "Total matching summaries (not just this page)." },
+                        "items": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "task_id": { "type": "integer" },
+                              "task_no": { "type": "string" },
+                              "title": { "type": "string" },
+                              "topic": { "type": "string", "description": "Free-text topic; keyword also matches this." },
+                              "status": { "type": "integer", "description": "0=waiting,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
+                              "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                              "summary_mode": { "type": "integer" },
+                              "origin_channel_id": { "type": "string" },
+                              "sources": { "type": "array", "description": "Source channels/scopes the summary was built from." },
+                              "participants": { "type": "array", "description": "Participants of a multi-person summary." },
+                              "creator_name": { "type": "string" },
+                              "total_msg_count": { "type": "integer" },
+                              "created_at": { "type": "string", "description": "RFC3339 timestamp" },
+                              "completed_at": { "type": "string", "description": "RFC3339 timestamp; empty until completed." },
+                              "activity_at": { "type": "string", "description": "RFC3339 timestamp of last activity." },
+                              "is_unread": { "type": "boolean" },
+                              "needs_attention": { "type": "boolean" },
+                              "schedule_id": { "type": "integer", "description": "Present for scheduled summaries." }
+                            }
+                          }
                         }
                       }
                     }
@@ -72,25 +90,33 @@
         ],
         "responses": {
           "200": {
-            "description": "Summary detail",
+            "description": "Summary detail (wrapped in the backend {code, message, data} envelope; via octo-cli the jq path is .data.data.*).",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "task_id": { "type": "integer" },
-                    "task_no": { "type": "string" },
-                    "title": { "type": "string" },
-                    "status": { "type": "integer", "description": "0=pending,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
-                    "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
-                    "origin_channel_id": { "type": "string" },
-                    "created_at": { "type": "string", "description": "RFC3339 timestamp" },
-                    "updated_at": { "type": "string", "description": "RFC3339 timestamp" },
-                    "result": {
+                    "code": { "type": "integer" },
+                    "message": { "type": "string" },
+                    "data": {
                       "type": "object",
-                      "description": "Current visible result; null until the task completes.",
                       "properties": {
-                        "content": { "type": "string", "description": "Summary body (markdown)." }
+                        "task_id": { "type": "integer" },
+                        "task_no": { "type": "string" },
+                        "title": { "type": "string" },
+                        "topic": { "type": "string" },
+                        "status": { "type": "integer", "description": "0=waiting,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
+                        "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                        "origin_channel_id": { "type": "string" },
+                        "created_at": { "type": "string", "description": "RFC3339 timestamp" },
+                        "updated_at": { "type": "string", "description": "RFC3339 timestamp" },
+                        "result": {
+                          "type": ["object", "null"],
+                          "description": "Current visible result; null until the task completes.",
+                          "properties": {
+                            "content": { "type": "string", "description": "Summary body (markdown)." }
+                          }
+                        }
                       }
                     }
                   }
@@ -104,33 +130,46 @@
     "/summary/api/v1/bot/summaries/{id}/result": {
       "get": {
         "operationId": "summary.result",
-        "summary": "Get the current summary body and citation metadata. Citation context_before/context_after is omitted on bot routes.",
-        "description": "Citation context_before/context_after is omitted on bot routes.",
+        "summary": "Get the current summary body and citation metadata. Citation context_before/context_after is omitted on bot routes; for a by-person summary the caller does not own, plain `citations` is returned empty while `team_citations` still carries the index→author mapping.",
+        "description": "Citation context_before/context_after is omitted on bot routes. For SummaryMode=by-person, plain `citations` is empty unless the caller owns the producing personal result (`team_citations` still populated).",
         "x-octo-risk": "read",
         "parameters": [
           { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Summary task_id." }
         ],
         "responses": {
           "200": {
-            "description": "Current summary result",
+            "description": "Current summary result (wrapped in the backend {code, message, data} envelope; via octo-cli the jq path is .data.data.*).",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "task_id": { "type": "integer" },
-                    "content": { "type": "string", "description": "Summary body (markdown), with [n] citation markers." },
-                    "citations": {
-                      "type": "array",
-                      "description": "Grounding messages for [n] markers. context_before/context_after are omitted on bot routes.",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "index": { "type": "integer", "description": "The [n] marker this entry grounds." },
-                          "sender": { "type": "string" },
-                          "sent_at": { "type": "string", "description": "RFC3339 timestamp" },
-                          "source": { "type": "string", "description": "Origin channel/source label." },
-                          "message_seq": { "type": "integer", "description": "Message sequence in the source channel." }
+                    "code": { "type": "integer" },
+                    "message": { "type": "string" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "content": { "type": "string", "description": "Summary body (markdown), with [n] citation markers." },
+                        "citations": {
+                          "type": "array",
+                          "description": "Grounding messages for [n] markers. context_before/context_after are omitted on bot routes; empty for a by-person summary the caller does not own.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "index": { "type": "integer", "description": "The [n] marker this entry grounds." },
+                              "sender": { "type": "string" },
+                              "sent_at": { "type": "string", "description": "RFC3339 timestamp" },
+                              "source": { "type": "string", "description": "Origin channel/source label." },
+                              "message_seq": { "type": "integer", "description": "Message sequence in the source channel." },
+                              "content": { "type": "string", "description": "Quoted message text (not stripped on bot routes; use this to attribute claims)." },
+                              "channel_id": { "type": "string" },
+                              "channel_type": { "type": "integer" }
+                            }
+                          }
+                        },
+                        "team_citations": {
+                          "type": "array",
+                          "description": "Index→author mapping for by-person / team summaries; always returned."
                         }
                       }
                     }

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Octo Summary Bot Read API",
+    "version": "1.0.0",
+    "description": "Read-only access to summaries visible to the bot owner's identity. The backend resolves owner and space from the bot token."
+  },
+  "x-octo-service": "summary",
+  "x-octo-base-url": "OCTO_API_BASE_URL",
+  "x-octo-space-header": false,
+  "paths": {
+    "/summary/api/v1/bot/summaries": {
+      "get": {
+        "operationId": "summary.list",
+        "summary": "List summaries visible to the bot owner",
+        "description": "Returns a page in {total, items}. keyword matches title or topic. Space and effective reader are resolved server-side from the bot token.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1, "minimum": 1 } },
+          { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 } },
+          { "name": "keyword", "in": "query", "schema": { "type": "string" }, "description": "title or topic substring" },
+          { "name": "status", "in": "query", "schema": { "type": "integer" } },
+          { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer" } },
+          { "name": "origin_channel_id", "in": "query", "x-octo-flag": "origin-channel-id", "schema": { "type": "string" } },
+          { "name": "created_after", "in": "query", "x-octo-flag": "created-after", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "created_before", "in": "query", "x-octo-flag": "created-before", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "sort_by", "in": "query", "x-octo-flag": "sort-by", "schema": { "type": "string", "enum": ["created_at", "updated_at"], "default": "created_at" } },
+          { "name": "sort_order", "in": "query", "x-octo-flag": "sort-order", "schema": { "type": "string", "enum": ["asc", "desc"], "default": "desc" } }
+        ],
+        "responses": { "200": { "description": "Summary page" } }
+      }
+    },
+    "/summary/api/v1/bot/summaries/{id}": {
+      "get": {
+        "operationId": "summary.get",
+        "summary": "Get summary metadata and current visible result",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Summary detail" } }
+      }
+    },
+    "/summary/api/v1/bot/summaries/{id}/result": {
+      "get": {
+        "operationId": "summary.result",
+        "summary": "Get the current summary body and citation metadata",
+        "description": "Citation context_before/context_after is omitted on bot routes.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": { "200": { "description": "Current summary result" } }
+      }
+    }
+  }
+}

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -8,49 +8,138 @@
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
+  "x-octo-disabled": true,
+  "x-octo-status-values": ["pending(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {
       "get": {
         "operationId": "summary.list",
-        "summary": "List summaries visible to the bot owner",
+        "summary": "List summaries visible to the bot owner. Returns a page {total, items}; keyword matches title OR topic; space and effective reader are resolved server-side from the bot token.",
         "description": "Returns a page in {total, items}. keyword matches title or topic. Space and effective reader are resolved server-side from the bot token.",
         "x-octo-risk": "read",
         "parameters": [
-          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1, "minimum": 1 } },
-          { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 } },
-          { "name": "keyword", "in": "query", "schema": { "type": "string" }, "description": "title or topic substring" },
-          { "name": "status", "in": "query", "schema": { "type": "integer" } },
-          { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer" } },
-          { "name": "origin_channel_id", "in": "query", "x-octo-flag": "origin-channel-id", "schema": { "type": "string" } },
-          { "name": "created_after", "in": "query", "x-octo-flag": "created-after", "schema": { "type": "string", "format": "date-time" } },
-          { "name": "created_before", "in": "query", "x-octo-flag": "created-before", "schema": { "type": "string", "format": "date-time" } },
-          { "name": "sort_by", "in": "query", "x-octo-flag": "sort-by", "schema": { "type": "string", "enum": ["created_at", "updated_at"], "default": "created_at" } },
-          { "name": "sort_order", "in": "query", "x-octo-flag": "sort-order", "schema": { "type": "string", "enum": ["asc", "desc"], "default": "desc" } }
+          { "name": "page", "in": "query", "schema": { "type": "integer", "default": 1, "minimum": 1 }, "description": "1-based page number." },
+          { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }, "description": "Items per page (1-100)." },
+          { "name": "keyword", "in": "query", "schema": { "type": "string" }, "description": "Substring matched against summary title OR topic." },
+          { "name": "status", "in": "query", "schema": { "type": "integer", "enum": [0, 1, 2, 3, 4, 5] }, "description": "Task status filter: 0=pending, 1=waiting_confirm, 2=processing, 3=completed, 4=failed, 5=cancelled." },
+          { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer", "enum": [1, 2, 3] }, "description": "How the summary was triggered: 1=manual, 2=scheduled, 3=agent." },
+          { "name": "origin_channel_id", "in": "query", "x-octo-flag": "origin-channel-id", "schema": { "type": "string" }, "description": "Filter to summaries whose origin channel matches this id." },
+          { "name": "created_after", "in": "query", "x-octo-flag": "created-after", "schema": { "type": "string", "format": "date-time" }, "description": "RFC3339 timestamp, e.g. 2026-07-01T00:00:00Z. Malformed values are silently ignored by the server (filter not applied)." },
+          { "name": "created_before", "in": "query", "x-octo-flag": "created-before", "schema": { "type": "string", "format": "date-time" }, "description": "RFC3339 timestamp, e.g. 2026-07-31T23:59:59Z. Malformed values are silently ignored by the server (filter not applied)." },
+          { "name": "sort_by", "in": "query", "x-octo-flag": "sort-by", "schema": { "type": "string", "enum": ["created_at", "updated_at"], "default": "created_at" }, "description": "Sort field." },
+          { "name": "sort_order", "in": "query", "x-octo-flag": "sort-order", "schema": { "type": "string", "enum": ["asc", "desc"], "default": "desc" }, "description": "Sort direction." }
         ],
-        "responses": { "200": { "description": "Summary page" } }
+        "responses": {
+          "200": {
+            "description": "Summary page",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": { "type": "integer", "description": "Total matching summaries (not just this page)." },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "task_id": { "type": "integer" },
+                          "task_no": { "type": "string" },
+                          "title": { "type": "string" },
+                          "status": { "type": "integer", "description": "0=pending,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
+                          "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                          "origin_channel_id": { "type": "string" },
+                          "created_at": { "type": "string", "description": "RFC3339 timestamp" },
+                          "updated_at": { "type": "string", "description": "RFC3339 timestamp" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/summary/api/v1/bot/summaries/{id}": {
       "get": {
         "operationId": "summary.get",
-        "summary": "Get summary metadata and current visible result",
+        "summary": "Get summary metadata and the current visible result for one task.",
         "x-octo-risk": "read",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Summary task_id." }
         ],
-        "responses": { "200": { "description": "Summary detail" } }
+        "responses": {
+          "200": {
+            "description": "Summary detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "task_id": { "type": "integer" },
+                    "task_no": { "type": "string" },
+                    "title": { "type": "string" },
+                    "status": { "type": "integer", "description": "0=pending,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
+                    "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                    "origin_channel_id": { "type": "string" },
+                    "created_at": { "type": "string", "description": "RFC3339 timestamp" },
+                    "updated_at": { "type": "string", "description": "RFC3339 timestamp" },
+                    "result": {
+                      "type": "object",
+                      "description": "Current visible result; null until the task completes.",
+                      "properties": {
+                        "content": { "type": "string", "description": "Summary body (markdown)." }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/summary/api/v1/bot/summaries/{id}/result": {
       "get": {
         "operationId": "summary.result",
-        "summary": "Get the current summary body and citation metadata",
+        "summary": "Get the current summary body and citation metadata. Citation context_before/context_after is omitted on bot routes.",
         "description": "Citation context_before/context_after is omitted on bot routes.",
         "x-octo-risk": "read",
         "parameters": [
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } }
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Summary task_id." }
         ],
-        "responses": { "200": { "description": "Current summary result" } }
+        "responses": {
+          "200": {
+            "description": "Current summary result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "task_id": { "type": "integer" },
+                    "content": { "type": "string", "description": "Summary body (markdown), with [n] citation markers." },
+                    "citations": {
+                      "type": "array",
+                      "description": "Grounding messages for [n] markers. context_before/context_after are omitted on bot routes.",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "index": { "type": "integer", "description": "The [n] marker this entry grounds." },
+                          "sender": { "type": "string" },
+                          "sent_at": { "type": "string", "description": "RFC3339 timestamp" },
+                          "source": { "type": "string", "description": "Origin channel/source label." },
+                          "message_seq": { "type": "integer", "description": "Message sequence in the source channel." }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,3 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
+- `octo-summary` — read and cite existing summaries visible to the personal Agent's human owner

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,4 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
-- `octo-summary` — read and cite existing summaries visible to the personal Agent's human owner
+- `octo-summary` — read and cite existing summaries visible to the personal Agent's human owner — **temporarily withheld** (backend API pending; not currently loadable)

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: octo-summary
+description: Read, find, and cite existing Octo summaries through octo-cli. Use when an agent needs to discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
+---
+
+# Octo Summary
+
+Use this skill only for existing summaries. It does not create, edit, regenerate, publish, or delete summaries.
+
+## Authentication and scope
+
+Authenticate with the owner's `bf_*` personal Agent token through a stored profile or `OCTO_BOT_TOKEN`. Do not pass or rely on `--space`: the Summary service resolves both the human owner and Space from the bot token and applies the owner's existing Summary permissions.
+
+## Discover summaries
+
+```bash
+octo-cli summary list
+octo-cli summary list --keyword "launch review" --page 1 --page-size 20
+octo-cli summary list --status 3 --created-after 2026-07-01T00:00:00Z
+```
+
+`--keyword` matches the summary title or topic. Results are page-based `{total, items}`; increment `--page` manually because `--page-all` is not available.
+
+Choose a candidate using its title, topic, sources, participants, time range, and `task_id`. Do not assume a title match alone proves relevance.
+
+## Read and cite
+
+```bash
+octo-cli summary get <task-id>
+octo-cli summary result <task-id>
+```
+
+Use `get` for metadata plus the current visible result. Use `result` when the full current body and citations are needed.
+
+When answering from a summary:
+
+1. Identify the summary by title and `task_id`.
+2. Attribute claims to the returned citation entry using its index, sender, sent time, source, and message sequence.
+3. Preserve the summary's citation marker such as `[1]` or `[P1]` when useful.
+4. Never invent missing surrounding conversation. Bot responses intentionally omit `context_before` and `context_after`.
+
+Treat `401` as an invalid/ineligible bot identity. Treat `403` or `404` as unavailable or not visible; do not infer the contents of a hidden summary.
+
+Inspect exact flags and schemas when needed:
+
+```bash
+octo-cli schema summary.list
+octo-cli schema summary.get
+octo-cli schema summary.result
+```

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: octo-summary
+disabled: true
 description: Read, find, and cite existing Octo summaries through octo-cli. Use when an agent needs to discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
 ---
 

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -67,6 +67,19 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 	}
 }
 
+func TestOctoSummarySkillEmbedded(t *testing.T) {
+	b, err := FS.ReadFile("octo-summary/SKILL.md")
+	if err != nil {
+		t.Fatalf("octo-summary/SKILL.md not embedded: %v", err)
+	}
+	content := string(b)
+	for _, want := range []string{"name: octo-summary", "summary list", "summary get", "summary result", "context_before", "bf_*"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("octo-summary skill missing %q", want)
+		}
+	}
+}
+
 func TestOctoMarketplaceReferencesEmbedded(t *testing.T) {
 	b, err := FS.ReadFile("octo-marketplace/SKILL.md")
 	if err != nil {


### PR DESCRIPTION
## Summary

- add `summary list`, `summary get`, and `summary result` commands
- use the owner-scoped bot Summary API with Bearer authentication and no client-supplied Space header
- add the `octo-summary` skill and update shared skill guidance and CLI documentation
- cover command registration, authentication headers, request paths, queries, and pagination with tests

## Dependency

Depends on Mininglamp-OSS/octo-smart-summary#172. Merge and deploy the Summary backend API before releasing these CLI commands.

## Validation

- `go test ./...`
- `go vet ./...`
- `python3 /home/mlamp/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/octo-summary`