### PR TITLE
fix(release): pin GoReleaser to requested tag

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -90,6 +90,10 @@ jobs:
           version: "~> v2"
           args: release --clean --skip=publish,announce
         env:
+          # A stable tag may promote the exact commit used by a prerelease tag.
+          # GoReleaser otherwise chooses one of the colocated tags itself and
+          # can embed/archive the prerelease version during a stable release.
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Run-scoped artifact consumed by both release-upload and publish-npm in


### PR DESCRIPTION
## What

Promoting a commit from `v0.9.0-next.3` to `v0.9.0` leaves both tags on the
same commit. GoReleaser selected the prerelease tag, so the stable release
workflow produced prerelease-named archives and embedded the prerelease
version. npm packaging then correctly refused to publish the mismatched files.

## How

- Pass the requested workflow tag through `GORELEASER_CURRENT_TAG`.
- Keep the existing single-build release graph and CI evidence gate unchanged.

## Testing

- `actionlint .github/workflows/release-publish.yml`
- `git diff --check`
- Reproduced locally with both tags on commit `29ec0bc`; GoReleaser generated
  all six `octo-cli_0.9.0_*` archives with `version=0.9.0`.
