### PR TITLE
feat(summary): add bot summary create command (withheld)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backend omits surrounding-message context for bot requests.
   **Currently withheld** behind `x-octo-disabled` (skill `disabled: true`):
   the commands and skill are not listed by the CLI **until the Summary
-  backend (Mininglamp-OSS/octo-smart-summary#172 for read-only routes and
-  #181 for the create route) is merged and deployed, and the create feature
+  backend create route (Mininglamp-OSS/octo-smart-summary#181) is merged and
+  deployed, and the create feature
   is switched on via `BOT_SUMMARY_CREATE_ENABLED=1`**; `octo-cli schema
   summary.*` still introspects. Flip both flags in a one-line follow-up
   once the backend is live.
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--role` flags front the `shareScope` / `shareRole` wire keys.
 
 ### Changed
+- **Generated service commands now reject incomplete JSON bodies locally** —
+  request-schema `required` fields and nested `minItems` constraints are
+  validated after merging `--data` with promoted body flags, before any HTTP
+  request is sent. Optional request bodies remain optional.
 - **Renamed the binary and CLI command from `octo` to `octo-cli`** for
   consistency with the repository and Go module name. This affects every
   install path: release archives are now `octo-cli_<version>_<os>_<arch>`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   personal Agent create owner-only summaries from explicit authorized sources,
   then discover and cite summaries visible to its human owner. The embedded
   spec targets the gateway's `/summary/api/v1/bot/*` mount, suppresses client
-  space headers, and ships with the `octo-summary` Skill. Listing
+  space headers, and ships with the enabled `octo-summary` Skill. Listing
   filters title or topic; result reads include citation metadata while the
   backend omits surrounding-message context for bot requests.
-  **Currently withheld** behind `x-octo-disabled` (skill `disabled: true`):
-  the commands and skill are not listed by the CLI **until the Summary
-  backend (Mininglamp-OSS/octo-smart-summary#172 for read-only routes and
-  #181 for the create route) is merged and deployed, and the create feature
-  is switched on via `BOT_SUMMARY_CREATE_ENABLED=1`**; `octo-cli schema
-  summary.*` still introspects. Flip both flags in a one-line follow-up
-  once the backend is live.
 - **`octo-cli message search` family** (6 subcommands) — full-text message and
   file search: `message search` (messages), `search all` (messages + files),
   `search files`, `search media` (images/videos, in-channel only, no keyword),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   personal Agent create owner-only summaries from explicit authorized sources,
   then discover and cite summaries visible to its human owner. The embedded
   spec targets the gateway's `/summary/api/v1/bot/*` mount, suppresses client
-  space headers, and ships with the enabled `octo-summary` Skill. Listing
+  space headers, and ships with the `octo-summary` Skill. Listing
   filters title or topic; result reads include citation metadata while the
   backend omits surrounding-message context for bot requests.
+  **Currently withheld** behind `x-octo-disabled` (skill `disabled: true`):
+  the commands and skill are not listed by the CLI **until the Summary
+  backend (Mininglamp-OSS/octo-smart-summary#172 for read-only routes and
+  #181 for the create route) is merged and deployed, and the create feature
+  is switched on via `BOT_SUMMARY_CREATE_ENABLED=1`**; `octo-cli schema
+  summary.*` still introspects. Flip both flags in a one-line follow-up
+  once the backend is live.
 - **`octo-cli message search` family** (6 subcommands) — full-text message and
   file search: `message search` (messages), `search all` (messages + files),
   `search files`, `search media` (images/videos, in-channel only, no keyword),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`octo-cli summary` read-only domain** — `summary list|get|result` lets a
-  personal Agent discover and cite existing summaries visible to its human
-  owner. The embedded spec targets the gateway's `/summary/api/v1/bot/*`
-  mount, suppresses client space headers, and ships with the `octo-summary`
-  Skill. Listing filters title or topic; result reads include citation metadata
-  while the backend omits surrounding-message context for bot requests.
-  **Currently withheld** behind `x-octo-disabled` (skill `disabled: true`): the
-  commands and skill are not listed by the CLI until the Summary backend
-  (octo-smart-summary#172) is merged and deployed; `octo-cli schema summary.*`
-  still introspects. Flip both flags in a one-line follow-up once the backend is live.
+- **`octo-cli summary` domain** — `summary create|list|get|result` lets a
+  personal Agent create owner-only summaries from explicit authorized sources,
+  then discover and cite summaries visible to its human owner. The embedded
+  spec targets the gateway's `/summary/api/v1/bot/*` mount, suppresses client
+  space headers, and ships with the enabled `octo-summary` Skill. Listing
+  filters title or topic; result reads include citation metadata while the
+  backend omits surrounding-message context for bot requests.
 - **`octo-cli message search` family** (6 subcommands) — full-text message and
   file search: `message search` (messages), `search all` (messages + files),
   `search files`, `search media` (images/videos, in-channel only, no keyword),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary` (withheld — backend pending), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary`, `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary` (withheld — see CHANGELOG "Currently withheld" note), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary`, `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ octo-cli version
 
 `octo-cli auth login` stores a bot token (read from a hidden prompt, `--with-token` stdin, or `--token-file` — never argv) under a profile keyed by `--bot-id`/`--profile`. `status`/`list` show metadata only (tokens always masked); `logout` removes a profile.
 
-Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary`, `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
+Bot-type capability and per-command flags are in `docs/octo-cli-design.md`. Agent-facing usage lives under `skills/` (`octo-shared`, `octo-matter` (withheld — see above), `octo-summary` (withheld — see CHANGELOG "Currently withheld" note), `octo-messaging`, `octo-files`, `octo-docs`, `octo-html`, `octo-marketplace`) — keep those in sync when command shapes change.
 
 ## Environment
 

--- a/README.md
+++ b/README.md
@@ -291,8 +291,8 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   read/replace.
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
   from explicit sources, then discover, read, and cite summaries visible to the
-  personal Agent's human owner. **Temporarily withheld** while the backend
-  create backend (Mininglamp-OSS/octo-smart-summary#181) is merged and deployed
+  personal Agent's human owner. **Temporarily withheld** while the create
+  backend (Mininglamp-OSS/octo-smart-summary#181) is merged, deployed, and enabled
   (not listed by `octo-cli skills`).
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:

--- a/README.md
+++ b/README.md
@@ -288,9 +288,9 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   **separate backend** from `octo-docs`): publish immutable versions, drafts,
   share codes & per-uid grants, media assets, inline comments, agent element
   read/replace.
-- [`octo-summary`](./skills/octo-summary/SKILL.md) — discover, read, and cite
-  existing summaries visible to the personal Agent's human owner. **Temporarily
-  withheld** (backend API pending — octo-smart-summary#172; not currently loadable).
+- [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
+  from explicit sources, then discover, read, and cite summaries visible to the
+  personal Agent's human owner.
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Key properties:
 | `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
-| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite |
+| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the backend (Mininglamp-OSS/octo-smart-summary#172, #181) is merged and deployed |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
@@ -291,7 +291,9 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   read/replace.
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
   from explicit sources, then discover, read, and cite summaries visible to the
-  personal Agent's human owner.
+  personal Agent's human owner. **Temporarily withheld** while the backend
+  (Mininglamp-OSS/octo-smart-summary#172 and #181) is merged and deployed
+  (not listed by `octo-cli skills`).
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Key properties:
 | `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
-| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the backend (Mininglamp-OSS/octo-smart-summary#172, #181) is merged and deployed |
+| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the create backend (Mininglamp-OSS/octo-smart-summary#181) is merged, deployed, and enabled |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
@@ -292,7 +292,7 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
   from explicit sources, then discover, read, and cite summaries visible to the
   personal Agent's human owner. **Temporarily withheld** while the backend
-  (Mininglamp-OSS/octo-smart-summary#172 and #181) is merged and deployed
+  create backend (Mininglamp-OSS/octo-smart-summary#181) is merged and deployed
   (not listed by `octo-cli skills`).
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Key properties:
 | `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
+| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the backend (Mininglamp-OSS/octo-smart-summary#172, #181) is merged and deployed |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
@@ -290,7 +291,9 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   read/replace.
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
   from explicit sources, then discover, read, and cite summaries visible to the
-  personal Agent's human owner.
+  personal Agent's human owner. **Temporarily withheld** while the backend
+  (Mininglamp-OSS/octo-smart-summary#172 and #181) is merged and deployed
+  (not listed by `octo-cli skills`).
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Key properties:
 | `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
-| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the backend (Mininglamp-OSS/octo-smart-summary#172, #181) is merged and deployed |
+| `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite |
 | `group`   | 9   | Groups — list, get, members, metadata; create/update (User Bot)|
 | `thread`  | 8   | Threads — create, list, get, members, join/leave, metadata     |
 | `bot`     | 6   | Bot lifecycle — register, user-info, space-members, heartbeat  |
@@ -291,9 +291,7 @@ Machine-readable usage docs for AI Agents live under [`skills/`](./skills/):
   read/replace.
 - [`octo-summary`](./skills/octo-summary/SKILL.md) — create owner-only summaries
   from explicit sources, then discover, read, and cite summaries visible to the
-  personal Agent's human owner. **Temporarily withheld** while the backend
-  (Mininglamp-OSS/octo-smart-summary#172 and #181) is merged and deployed
-  (not listed by `octo-cli skills`).
+  personal Agent's human owner.
 
 These docs are also **embedded in the binary**, so a released `octo-cli` ships them:
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -475,33 +475,46 @@ func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
 		if s == "matter" {
 			t.Error("global schema --list must not list disabled service `matter`")
 		}
+		if s == "summary" {
+			t.Error("global schema --list must not list disabled service `summary`")
+		}
 	}
 	for _, op := range data["operations"].([]any) {
 		m, _ := op.(map[string]any)
 		if m["service"] == "matter" {
 			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
 		}
+		if m["service"] == "summary" {
+			t.Errorf("global schema --list leaked a summary op: %v", m["id"])
+		}
 	}
 }
 
 func TestDisabledServiceStillIntrospectable(t *testing.T) {
-	f := newTestFactoryWithReg()
-	f.SetConfig(&config.Config{Format: "json"})
+	// Both disabled services must remain introspectable — the schema
+	// surface is deliberately independent of the runtime command tree.
+	// Uses a fresh factory per iteration because TestFactory.Out is an
+	// accumulating buffer: reusing one factory would leave iter 2's
+	// unmarshal parsing two concatenated JSON envelopes and error out.
+	for _, svc := range []string{"matter", "summary"} {
+		f := newTestFactoryWithReg()
+		f.SetConfig(&config.Config{Format: "json"})
 
-	// Explicit domain listing still resolves.
-	out, _, err := execRoot(t, f, "schema", "--list", "matter")
-	if err != nil {
-		t.Fatalf("schema --list matter: %v", err)
-	}
-	var env map[string]any
-	_ = json.Unmarshal([]byte(out), &env)
-	data, _ := env["data"].(map[string]any)
-	if ops, _ := data["operations"].([]any); len(ops) == 0 {
-		t.Error("explicit `schema --list matter` must still return operations")
-	}
+		// Explicit domain listing still resolves.
+		out, _, err := execRoot(t, f, "schema", "--list", svc)
+		if err != nil {
+			t.Fatalf("schema --list %s: %v", svc, err)
+		}
+		var env map[string]any
+		_ = json.Unmarshal([]byte(out), &env)
+		data, _ := env["data"].(map[string]any)
+		if ops, _ := data["operations"].([]any); len(ops) == 0 {
+			t.Errorf("explicit `schema --list %s` must still return operations", svc)
+		}
 
-	// Explicit operation lookup still resolves.
-	if _, _, err := execRoot(t, f, "schema", "matter.list"); err != nil {
-		t.Errorf("explicit `schema matter.list` must still resolve: %v", err)
+		// Explicit operation lookup still resolves.
+		if _, _, err := execRoot(t, f, "schema", svc+".list"); err != nil {
+			t.Errorf("explicit `schema %s.list` must still resolve: %v", svc, err)
+		}
 	}
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -446,8 +446,8 @@ func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
 	if topLevelCmd(root, "matter") != nil {
 		t.Error("disabled service `matter` must not appear in the command tree")
 	}
-	if topLevelCmd(root, "summary") == nil {
-		t.Error("enabled service `summary` must appear in the command tree")
+	if topLevelCmd(root, "summary") != nil {
+		t.Error("disabled service `summary` must not appear in the command tree (see CHANGELOG withhold note)")
 	}
 	if topLevelCmd(root, "message") == nil {
 		t.Error("enabled service `message` must still appear")

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -446,8 +446,8 @@ func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
 	if topLevelCmd(root, "matter") != nil {
 		t.Error("disabled service `matter` must not appear in the command tree")
 	}
-	if topLevelCmd(root, "summary") == nil {
-		t.Error("enabled service `summary` must appear in the command tree")
+	if topLevelCmd(root, "summary") != nil {
+		t.Error("disabled service `summary` must not appear in the command tree (see CHANGELOG withhold note)")
 	}
 	if topLevelCmd(root, "message") == nil {
 		t.Error("enabled service `message` must still appear")
@@ -475,19 +475,28 @@ func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
 		if s == "matter" {
 			t.Error("global schema --list must not list disabled service `matter`")
 		}
+		if s == "summary" {
+			t.Error("global schema --list must not list disabled service `summary`")
+		}
 	}
 	for _, op := range data["operations"].([]any) {
 		m, _ := op.(map[string]any)
 		if m["service"] == "matter" {
 			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
 		}
+		if m["service"] == "summary" {
+			t.Errorf("global schema --list leaked a summary op: %v", m["id"])
+		}
 	}
 }
 
 func TestDisabledServiceStillIntrospectable(t *testing.T) {
-	// Disabled services remain introspectable — the schema surface is
-	// deliberately independent of the runtime command tree.
-	for _, svc := range []string{"matter"} {
+	// Both disabled services must remain introspectable — the schema
+	// surface is deliberately independent of the runtime command tree.
+	// Uses a fresh factory per iteration because TestFactory.Out is an
+	// accumulating buffer: reusing one factory would leave iter 2's
+	// unmarshal parsing two concatenated JSON envelopes and error out.
+	for _, svc := range []string{"matter", "summary"} {
 		f := newTestFactoryWithReg()
 		f.SetConfig(&config.Config{Format: "json"})
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -446,8 +446,8 @@ func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
 	if topLevelCmd(root, "matter") != nil {
 		t.Error("disabled service `matter` must not appear in the command tree")
 	}
-	if topLevelCmd(root, "summary") != nil {
-		t.Error("disabled service `summary` must not appear in the command tree")
+	if topLevelCmd(root, "summary") == nil {
+		t.Error("enabled service `summary` must appear in the command tree")
 	}
 	if topLevelCmd(root, "message") == nil {
 		t.Error("enabled service `message` must still appear")
@@ -475,17 +475,11 @@ func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
 		if s == "matter" {
 			t.Error("global schema --list must not list disabled service `matter`")
 		}
-		if s == "summary" {
-			t.Error("global schema --list must not list disabled service `summary`")
-		}
 	}
 	for _, op := range data["operations"].([]any) {
 		m, _ := op.(map[string]any)
 		if m["service"] == "matter" {
 			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
-		}
-		if m["service"] == "summary" {
-			t.Errorf("global schema --list leaked a summary op: %v", m["id"])
 		}
 	}
 }
@@ -509,10 +503,5 @@ func TestDisabledServiceStillIntrospectable(t *testing.T) {
 	// Explicit operation lookup still resolves.
 	if _, _, err := execRoot(t, f, "schema", "matter.list"); err != nil {
 		t.Errorf("explicit `schema matter.list` must still resolve: %v", err)
-	}
-
-	// summary is likewise disabled but must stay introspectable.
-	if _, _, err := execRoot(t, f, "schema", "summary.list"); err != nil {
-		t.Errorf("explicit `schema summary.list` must still resolve: %v", err)
 	}
 }

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -446,8 +446,8 @@ func TestDisabledServiceWithheldFromCommandTree(t *testing.T) {
 	if topLevelCmd(root, "matter") != nil {
 		t.Error("disabled service `matter` must not appear in the command tree")
 	}
-	if topLevelCmd(root, "summary") != nil {
-		t.Error("disabled service `summary` must not appear in the command tree (see CHANGELOG withhold note)")
+	if topLevelCmd(root, "summary") == nil {
+		t.Error("enabled service `summary` must appear in the command tree")
 	}
 	if topLevelCmd(root, "message") == nil {
 		t.Error("enabled service `message` must still appear")
@@ -475,28 +475,19 @@ func TestDisabledServiceHiddenFromGlobalSchemaList(t *testing.T) {
 		if s == "matter" {
 			t.Error("global schema --list must not list disabled service `matter`")
 		}
-		if s == "summary" {
-			t.Error("global schema --list must not list disabled service `summary`")
-		}
 	}
 	for _, op := range data["operations"].([]any) {
 		m, _ := op.(map[string]any)
 		if m["service"] == "matter" {
 			t.Errorf("global schema --list leaked a matter op: %v", m["id"])
 		}
-		if m["service"] == "summary" {
-			t.Errorf("global schema --list leaked a summary op: %v", m["id"])
-		}
 	}
 }
 
 func TestDisabledServiceStillIntrospectable(t *testing.T) {
-	// Both disabled services must remain introspectable — the schema
-	// surface is deliberately independent of the runtime command tree.
-	// Uses a fresh factory per iteration because TestFactory.Out is an
-	// accumulating buffer: reusing one factory would leave iter 2's
-	// unmarshal parsing two concatenated JSON envelopes and error out.
-	for _, svc := range []string{"matter", "summary"} {
+	// Disabled services remain introspectable — the schema surface is
+	// deliberately independent of the runtime command tree.
+	for _, svc := range []string{"matter"} {
 		f := newTestFactoryWithReg()
 		f.SetConfig(&config.Config{Format: "json"})
 

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -232,7 +232,7 @@ func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error
 	if len(base) == 0 && !rt.detail.RequestBodyRequired {
 		return nil
 	}
-	if issue := validateBodySchema(*rt.detail.RequestBody, base, ""); issue != "" {
+	if issue := validateBodySchema(rt.detail.RequestBody, base, ""); issue != "" {
 		return output.ErrValidation(
 			fmt.Sprintf("request body %s", issue),
 			"pass values that satisfy the operation schema via --data JSON or matching body flags")
@@ -240,7 +240,7 @@ func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error
 	return nil
 }
 
-func validateBodySchema(schema registry.SchemaInfo, value any, path string) string {
+func validateBodySchema(schema *registry.SchemaInfo, value any, path string) string {
 	switch schema.Type {
 	case "object":
 		return validateObjectSchema(schema, value, path)
@@ -250,7 +250,7 @@ func validateBodySchema(schema registry.SchemaInfo, value any, path string) stri
 	return ""
 }
 
-func validateObjectSchema(schema registry.SchemaInfo, value any, path string) string {
+func validateObjectSchema(schema *registry.SchemaInfo, value any, path string) string {
 	obj, ok := value.(map[string]any)
 	if !ok || obj == nil {
 		return fmt.Sprintf("field %s must be an object", bodyPath(path))
@@ -267,7 +267,8 @@ func validateObjectSchema(schema registry.SchemaInfo, value any, path string) st
 	}
 	for name := range schema.Properties {
 		if child, exists := obj[name]; exists && child != nil {
-			if issue := validateBodySchema(schema.Properties[name], child, joinBodyPath(path, name)); issue != "" {
+			childSchema := schema.Properties[name]
+			if issue := validateBodySchema(&childSchema, child, joinBodyPath(path, name)); issue != "" {
 				return issue
 			}
 		}
@@ -275,7 +276,7 @@ func validateObjectSchema(schema registry.SchemaInfo, value any, path string) st
 	return ""
 }
 
-func validateArraySchema(schema registry.SchemaInfo, value any, path string) string {
+func validateArraySchema(schema *registry.SchemaInfo, value any, path string) string {
 	items, ok := bodyArray(value)
 	if !ok {
 		return fmt.Sprintf("field %s must be an array", bodyPath(path))
@@ -285,7 +286,7 @@ func validateArraySchema(schema registry.SchemaInfo, value any, path string) str
 	}
 	if schema.Items != nil {
 		for i, item := range items {
-			if issue := validateBodySchema(*schema.Items, item, fmt.Sprintf("%s[%d]", path, i)); issue != "" {
+			if issue := validateBodySchema(schema.Items, item, fmt.Sprintf("%s[%d]", path, i)); issue != "" {
 				return issue
 			}
 		}

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -200,14 +200,15 @@ func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRunti
 		}
 	}
 
-	if len(base) == 0 {
-		return nil, nil
-	}
-
 	// Spec-driven required-field validation. Object/array required fields are
 	// not eligible for flag promotion (promotableKind rejects them), so they
-	// can slip through as absent unless we check here. Primitive requireds are
-	// double-covered by cobra's MarkFlagRequired plus this check — harmless.
+	// can slip through as absent unless we check here. This must run BEFORE
+	// the len(base) == 0 return below: a caller who supplies no --data and
+	// no promoted flags on a POST/PUT with required body fields is exactly
+	// the case we need to catch (round-1 review: `octo-cli summary create
+	// --idempotency-key k` with no body used to reach the backend as an
+	// empty write). Primitive requireds are double-covered by cobra's
+	// MarkFlagRequired plus this check — harmless.
 	if rt.detail != nil && rt.detail.RequestBody != nil {
 		var missing []string
 		for _, name := range rt.detail.RequestBody.Required {
@@ -220,6 +221,10 @@ func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRunti
 				fmt.Sprintf("--data is missing required field(s): %s", strings.Join(missing, ", ")),
 				"pass the missing fields via --data JSON (or a matching flag when the field is a primitive)")
 		}
+	}
+
+	if len(base) == 0 {
+		return nil, nil
 	}
 	return base, nil
 }

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -154,6 +154,17 @@ func buildHeaders(cobraCmd *cobra.Command, rt *operationRuntime) map[string]stri
 
 // resolveBody constructs the JSON body. Empty when the op has neither --data
 // nor any promoted fields. Explicit flags override --data fields.
+//
+// After merging --data with promoted flag values, this checks the resolved
+// map against the operation's declared `required` list from the spec. Any
+// required field that neither --data nor a flag supplied fails locally with
+// a validation error rather than being forwarded as a partial write. The
+// primitive-required contract (a required *primitive* body property gets a
+// cobra MarkFlagRequired in registerBodyFlags) is unchanged; this closes the
+// gap left by required *object/array* properties like `time_range` and
+// `sources`, which cannot be promoted to flags and previously reached the
+// backend as an empty or partial payload (see summary.create + octo-cli
+// PR #113 review).
 func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRuntime) (any, error) {
 	if rt.bodyData == nil && len(rt.bodyFlags) == 0 {
 		return nil, nil
@@ -191,6 +202,24 @@ func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRunti
 
 	if len(base) == 0 {
 		return nil, nil
+	}
+
+	// Spec-driven required-field validation. Object/array required fields are
+	// not eligible for flag promotion (promotableKind rejects them), so they
+	// can slip through as absent unless we check here. Primitive requireds are
+	// double-covered by cobra's MarkFlagRequired plus this check — harmless.
+	if rt.detail != nil && rt.detail.RequestBody != nil {
+		var missing []string
+		for _, name := range rt.detail.RequestBody.Required {
+			if _, ok := base[name]; !ok {
+				missing = append(missing, name)
+			}
+		}
+		if len(missing) > 0 {
+			return nil, output.ErrValidation(
+				fmt.Sprintf("--data is missing required field(s): %s", strings.Join(missing, ", ")),
+				"pass the missing fields via --data JSON (or a matching flag when the field is a primitive)")
+		}
 	}
 	return base, nil
 }

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -184,6 +184,22 @@ func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRunti
 		}
 	}
 
+	applyBodyFlags(cobraCmd, rt, base)
+
+	if err := validateRequiredBodyFields(rt, base); err != nil {
+		return nil, err
+	}
+
+	if len(base) == 0 {
+		return nil, nil
+	}
+	return base, nil
+}
+
+// applyBodyFlags merges body-flag values (--foo, --bar) into base, following the
+// promotable-primitive kinds registered on the operation. Only Changed flags are
+// applied so unset flags do not overwrite --data-supplied values with zero.
+func applyBodyFlags(cobraCmd *cobra.Command, rt *operationRuntime, base map[string]any) {
 	for flagName, bf := range rt.bodyFlags {
 		if !cobraCmd.Flags().Changed(flagName) {
 			continue
@@ -199,34 +215,33 @@ func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRunti
 			base[bf.apiName] = *bf.strVal
 		}
 	}
+}
 
-	// Spec-driven required-field validation. Object/array required fields are
-	// not eligible for flag promotion (promotableKind rejects them), so they
-	// can slip through as absent unless we check here. This must run BEFORE
-	// the len(base) == 0 return below: a caller who supplies no --data and
-	// no promoted flags on a POST/PUT with required body fields is exactly
-	// the case we need to catch (round-1 review: `octo-cli summary create
-	// --idempotency-key k` with no body used to reach the backend as an
-	// empty write). Primitive requireds are double-covered by cobra's
-	// MarkFlagRequired plus this check — harmless.
-	if rt.detail != nil && rt.detail.RequestBody != nil {
-		var missing []string
-		for _, name := range rt.detail.RequestBody.Required {
-			if _, ok := base[name]; !ok {
-				missing = append(missing, name)
-			}
-		}
-		if len(missing) > 0 {
-			return nil, output.ErrValidation(
-				fmt.Sprintf("--data is missing required field(s): %s", strings.Join(missing, ", ")),
-				"pass the missing fields via --data JSON (or a matching flag when the field is a primitive)")
+// validateRequiredBodyFields enforces spec-driven RequestBody.Required against
+// the merged base map. Object/array required fields are not eligible for flag
+// promotion (promotableKind rejects them), so they can slip through as absent
+// unless we check here. This must run before the empty-base short-circuit in
+// resolveBody: a caller who supplies no --data and no promoted flags on a
+// POST/PUT with required body fields is exactly the case we need to catch
+// (round-1 review: `octo-cli summary create --idempotency-key k` with no body
+// used to reach the backend as an empty write). Primitive requireds are
+// double-covered by cobra's MarkFlagRequired plus this check — harmless.
+func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error {
+	if rt.detail == nil || rt.detail.RequestBody == nil {
+		return nil
+	}
+	var missing []string
+	for _, name := range rt.detail.RequestBody.Required {
+		if _, ok := base[name]; !ok {
+			missing = append(missing, name)
 		}
 	}
-
-	if len(base) == 0 {
-		return nil, nil
+	if len(missing) > 0 {
+		return output.ErrValidation(
+			fmt.Sprintf("--data is missing required field(s): %s", strings.Join(missing, ", ")),
+			"pass the missing fields via --data JSON (or a matching flag when the field is a primitive)")
 	}
-	return base, nil
+	return nil
 }
 
 // emitOnce runs one request and emits the envelope. Returns the same error

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mininglamp-OSS/octo-cli/internal/client"
 	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
 	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
 )
 
 // runOperation is the RunE body for every auto-registered operation.
@@ -158,13 +159,10 @@ func buildHeaders(cobraCmd *cobra.Command, rt *operationRuntime) map[string]stri
 // After merging --data with promoted flag values, this checks the resolved
 // map against the operation's declared `required` list from the spec. Any
 // required field that neither --data nor a flag supplied fails locally with
-// a validation error rather than being forwarded as a partial write. The
-// primitive-required contract (a required *primitive* body property gets a
-// cobra MarkFlagRequired in registerBodyFlags) is unchanged; this closes the
-// gap left by required *object/array* properties like `time_range` and
-// `sources`, which cannot be promoted to flags and previously reached the
-// backend as an empty or partial payload (see summary.create + octo-cli
-// PR #113 review).
+// a validation error rather than being forwarded as a partial write. This is
+// the enforcement layer for both promoted primitives and object/array fields;
+// registerBodyFlags only marks required fields in help text. Nested object and
+// array requirements are validated recursively as well.
 func resolveBody(f *cmdutil.Factory, cobraCmd *cobra.Command, rt *operationRuntime) (any, error) {
 	if rt.bodyData == nil && len(rt.bodyFlags) == 0 {
 		return nil, nil
@@ -217,31 +215,95 @@ func applyBodyFlags(cobraCmd *cobra.Command, rt *operationRuntime, base map[stri
 	}
 }
 
-// validateRequiredBodyFields enforces spec-driven RequestBody.Required against
-// the merged base map. Object/array required fields are not eligible for flag
-// promotion (promotableKind rejects them), so they can slip through as absent
-// unless we check here. This must run before the empty-base short-circuit in
-// resolveBody: a caller who supplies no --data and no promoted flags on a
-// POST/PUT with required body fields is exactly the case we need to catch
-// (round-1 review: `octo-cli summary create --idempotency-key k` with no body
-// used to reach the backend as an empty write). Primitive requireds are
-// double-covered by cobra's MarkFlagRequired plus this check — harmless.
+// validateRequiredBodyFields enforces the request schema against the merged
+// body. It runs before the empty-body short-circuit so required request bodies
+// cannot be dispatched empty. Optional request bodies remain optional, but if
+// supplied their nested required fields and minItems constraints still apply.
 func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error {
 	if rt.detail == nil || rt.detail.RequestBody == nil {
 		return nil
 	}
-	var missing []string
-	for _, name := range rt.detail.RequestBody.Required {
-		if _, ok := base[name]; !ok {
-			missing = append(missing, name)
-		}
+	if len(base) == 0 && !rt.detail.RequestBodyRequired {
+		return nil
 	}
-	if len(missing) > 0 {
+	if issue := validateBodySchema(*rt.detail.RequestBody, base, ""); issue != "" {
 		return output.ErrValidation(
-			fmt.Sprintf("--data is missing required field(s): %s", strings.Join(missing, ", ")),
-			"pass the missing fields via --data JSON (or a matching flag when the field is a primitive)")
+			fmt.Sprintf("request body %s", issue),
+			"pass values that satisfy the operation schema via --data JSON or matching body flags")
 	}
 	return nil
+}
+
+func validateBodySchema(schema registry.SchemaInfo, value any, path string) string {
+	switch schema.Type {
+	case "object":
+		obj, ok := value.(map[string]any)
+		if !ok || obj == nil {
+			return fmt.Sprintf("field %s must be an object", bodyPath(path))
+		}
+		var missing []string
+		for _, name := range schema.Required {
+			child, exists := obj[name]
+			if !exists || child == nil {
+				missing = append(missing, joinBodyPath(path, name))
+			}
+		}
+		if len(missing) > 0 {
+			return fmt.Sprintf("is missing required field(s): %s", strings.Join(missing, ", "))
+		}
+		for name, childSchema := range schema.Properties {
+			if child, exists := obj[name]; exists && child != nil {
+				if issue := validateBodySchema(childSchema, child, joinBodyPath(path, name)); issue != "" {
+					return issue
+				}
+			}
+		}
+	case "array":
+		items, ok := bodyArray(value)
+		if !ok {
+			return fmt.Sprintf("field %s must be an array", bodyPath(path))
+		}
+		if schema.MinItems > 0 && len(items) < schema.MinItems {
+			return fmt.Sprintf("field %s must contain at least %d item(s)", bodyPath(path), schema.MinItems)
+		}
+		if schema.Items != nil {
+			for i, item := range items {
+				if issue := validateBodySchema(*schema.Items, item, fmt.Sprintf("%s[%d]", path, i)); issue != "" {
+					return issue
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func bodyArray(value any) ([]any, bool) {
+	switch items := value.(type) {
+	case []any:
+		return items, true
+	case []string:
+		out := make([]any, len(items))
+		for i := range items {
+			out[i] = items[i]
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+func joinBodyPath(parent, child string) string {
+	if parent == "" {
+		return child
+	}
+	return parent + "." + child
+}
+
+func bodyPath(path string) string {
+	if path == "" {
+		return "<root>"
+	}
+	return path
 }
 
 // emitOnce runs one request and emits the envelope. Returns the same error

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -216,11 +216,17 @@ func applyBodyFlags(cobraCmd *cobra.Command, rt *operationRuntime, base map[stri
 }
 
 // validateRequiredBodyFields enforces the request schema against the merged
-// body. It runs before the empty-body short-circuit so required request bodies
-// cannot be dispatched empty. Optional request bodies remain optional, but if
-// supplied their nested required fields and minItems constraints still apply.
+// body. It runs before the empty-body short-circuit so schema-required fields
+// are checked even when no body values were supplied. Optional request bodies
+// remain optional, but if supplied their nested required fields and minItems
+// constraints still apply.
 func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error {
 	if rt.detail == nil || rt.detail.RequestBody == nil {
+		return nil
+	}
+	// Multipart bodies are assembled separately from base. Their required
+	// binary part is validated by buildMultipartBody.
+	if rt.detail.Multipart {
 		return nil
 	}
 	if len(base) == 0 && !rt.detail.RequestBodyRequired {
@@ -237,40 +243,50 @@ func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error
 func validateBodySchema(schema registry.SchemaInfo, value any, path string) string {
 	switch schema.Type {
 	case "object":
-		obj, ok := value.(map[string]any)
-		if !ok || obj == nil {
-			return fmt.Sprintf("field %s must be an object", bodyPath(path))
-		}
-		var missing []string
-		for _, name := range schema.Required {
-			child, exists := obj[name]
-			if !exists || child == nil {
-				missing = append(missing, joinBodyPath(path, name))
-			}
-		}
-		if len(missing) > 0 {
-			return fmt.Sprintf("is missing required field(s): %s", strings.Join(missing, ", "))
-		}
-		for name, childSchema := range schema.Properties {
-			if child, exists := obj[name]; exists && child != nil {
-				if issue := validateBodySchema(childSchema, child, joinBodyPath(path, name)); issue != "" {
-					return issue
-				}
-			}
-		}
+		return validateObjectSchema(schema, value, path)
 	case "array":
-		items, ok := bodyArray(value)
-		if !ok {
-			return fmt.Sprintf("field %s must be an array", bodyPath(path))
+		return validateArraySchema(schema, value, path)
+	}
+	return ""
+}
+
+func validateObjectSchema(schema registry.SchemaInfo, value any, path string) string {
+	obj, ok := value.(map[string]any)
+	if !ok || obj == nil {
+		return fmt.Sprintf("field %s must be an object", bodyPath(path))
+	}
+	var missing []string
+	for _, name := range schema.Required {
+		child, exists := obj[name]
+		if !exists || child == nil {
+			missing = append(missing, joinBodyPath(path, name))
 		}
-		if schema.MinItems > 0 && len(items) < schema.MinItems {
-			return fmt.Sprintf("field %s must contain at least %d item(s)", bodyPath(path), schema.MinItems)
+	}
+	if len(missing) > 0 {
+		return fmt.Sprintf("is missing required field(s): %s", strings.Join(missing, ", "))
+	}
+	for name := range schema.Properties {
+		if child, exists := obj[name]; exists && child != nil {
+			if issue := validateBodySchema(schema.Properties[name], child, joinBodyPath(path, name)); issue != "" {
+				return issue
+			}
 		}
-		if schema.Items != nil {
-			for i, item := range items {
-				if issue := validateBodySchema(*schema.Items, item, fmt.Sprintf("%s[%d]", path, i)); issue != "" {
-					return issue
-				}
+	}
+	return ""
+}
+
+func validateArraySchema(schema registry.SchemaInfo, value any, path string) string {
+	items, ok := bodyArray(value)
+	if !ok {
+		return fmt.Sprintf("field %s must be an array", bodyPath(path))
+	}
+	if schema.MinItems > 0 && len(items) < schema.MinItems {
+		return fmt.Sprintf("field %s must contain at least %d item(s)", bodyPath(path), schema.MinItems)
+	}
+	if schema.Items != nil {
+		for i, item := range items {
+			if issue := validateBodySchema(*schema.Items, item, fmt.Sprintf("%s[%d]", path, i)); issue != "" {
+				return issue
 			}
 		}
 	}

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -676,6 +676,20 @@ func TestBuildMultipartBody_FormTextFields(t *testing.T) {
 	}
 }
 
+func TestValidateRequiredBodyFields_SkipsMultipartBinaryProperty(t *testing.T) {
+	rt := &operationRuntime{detail: &registry.OperationDetail{
+		Multipart: true,
+		RequestBody: &registry.SchemaInfo{
+			Type:       "object",
+			Required:   []string{"file", "label"},
+			Properties: map[string]registry.SchemaInfo{"file": {Type: "string", Format: "binary"}, "label": {Type: "string"}},
+		},
+	}}
+	if err := validateRequiredBodyFields(rt, map[string]any{"label": "report"}); err != nil {
+		t.Fatalf("multipart validation must be handled by buildMultipartBody: %v", err)
+	}
+}
+
 // TestBuildMultipartBody_MissingFile confirms the validation error surfaces
 // when --file is empty.
 func TestBuildMultipartBody_MissingFile(t *testing.T) {

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
@@ -32,6 +33,17 @@ func TestSummaryRegistryShape(t *testing.T) {
 	}
 	if op, _ := reg.GetOperation("summary.list"); op.Pagination != nil {
 		t.Error("summary.list uses a backend {total,items} page, so generic --page-all must stay disabled")
+	}
+	create, _ := reg.GetOperation("summary.create")
+	if !create.RequestBodyRequired || create.RequestBody == nil {
+		t.Fatal("summary.create must preserve the required request-body contract")
+	}
+	if sources := create.RequestBody.Properties["sources"]; sources.MinItems != 1 || sources.MaxItems != 30 {
+		t.Errorf("sources item bounds = %d..%d, want 1..30", sources.MinItems, sources.MaxItems)
+	}
+	key := create.Parameters[0]
+	if key.MinLength != 1 || key.MaxLength != 128 || key.Pattern == "" {
+		t.Errorf("idempotency key constraints not preserved: %+v", key)
 	}
 }
 
@@ -77,9 +89,8 @@ func TestSummaryCreateSendsIdempotencyHeaderAndBody(t *testing.T) {
 func TestSummaryCreateRejectsMissingTimeRangeAndSources(t *testing.T) {
 	// Jerry-Xin's P1 on octo-cli PR #113: `summary create` must fail locally
 	// when --data omits the required `time_range`/`sources` object/array
-	// properties. cobra's MarkFlagRequired only covers promoted primitives,
-	// so the gap is closed in resolveBody by walking the spec's
-	// requestBody.required list.
+	// properties. registerBodyFlags only marks promoted required primitives in
+	// help text, so resolveBody is the enforcement layer for all body fields.
 	cases := []struct {
 		name string
 		data string
@@ -88,11 +99,16 @@ func TestSummaryCreateRejectsMissingTimeRangeAndSources(t *testing.T) {
 		{"only title", `{"title":"weekly"}`},
 		{"time_range without sources", `{"time_range":{"start":"2026-07-21T00:00:00Z","end":"2026-07-28T00:00:00Z"}}`},
 		{"sources without time_range", `{"sources":[{"source_type":1,"source_id":"g1"}]}`},
+		{"null time_range", `{"time_range":null,"sources":[{"source_type":1,"source_id":"g1"}]}`},
+		{"empty time_range", `{"time_range":{},"sources":[{"source_type":1,"source_id":"g1"}]}`},
+		{"empty sources", `{"time_range":{"start":"2026-07-21T00:00:00Z","end":"2026-07-28T00:00:00Z"},"sources":[]}`},
+		{"source missing id", `{"time_range":{"start":"2026-07-21T00:00:00Z","end":"2026-07-28T00:00:00Z"},"sources":[{"source_type":1}]}`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			var backendHits atomic.Int32
 			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-				t.Fatalf("request should not have reached the backend (data=%q)", tc.data)
+				backendHits.Add(1)
 			})
 			args := []string{"summary", "create", "--idempotency-key", "k"}
 			if tc.data != "" {
@@ -102,6 +118,9 @@ func TestSummaryCreateRejectsMissingTimeRangeAndSources(t *testing.T) {
 			err := root.Execute()
 			if err == nil {
 				t.Fatalf("summary create with data=%q must fail validation locally", tc.data)
+			}
+			if hits := backendHits.Load(); hits != 0 {
+				t.Fatalf("request reached backend %d time(s) (data=%q)", hits, tc.data)
 			}
 			// Sanity check the error text mentions at least one required field,
 			// so an agent gets an actionable message instead of a bare 400.

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -41,7 +41,16 @@ func TestSummaryRegistryShape(t *testing.T) {
 	if sources := create.RequestBody.Properties["sources"]; sources.MinItems != 1 || sources.MaxItems != 30 {
 		t.Errorf("sources item bounds = %d..%d, want 1..30", sources.MinItems, sources.MaxItems)
 	}
-	key := create.Parameters[0]
+	var key registry.ParamInfo
+	for _, parameter := range create.Parameters {
+		if parameter.Name == "Idempotency-Key" {
+			key = parameter
+			break
+		}
+	}
+	if key.Name == "" {
+		t.Fatal("summary.create missing Idempotency-Key parameter")
+	}
 	if key.MinLength != 1 || key.MaxLength != 128 || key.Pattern == "" {
 		t.Errorf("idempotency key constraints not preserved: %+v", key)
 	}

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -74,6 +74,45 @@ func TestSummaryCreateSendsIdempotencyHeaderAndBody(t *testing.T) {
 	}
 }
 
+func TestSummaryCreateRejectsMissingTimeRangeAndSources(t *testing.T) {
+	// Jerry-Xin's P1 on octo-cli PR #113: `summary create` must fail locally
+	// when --data omits the required `time_range`/`sources` object/array
+	// properties. cobra's MarkFlagRequired only covers promoted primitives,
+	// so the gap is closed in resolveBody by walking the spec's
+	// requestBody.required list.
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"empty body", ""},
+		{"only title", `{"title":"weekly"}`},
+		{"time_range without sources", `{"time_range":{"start":"2026-07-21T00:00:00Z","end":"2026-07-28T00:00:00Z"}}`},
+		{"sources without time_range", `{"sources":[{"source_type":1,"source_id":"g1"}]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Fatalf("request should not have reached the backend (data=%q)", tc.data)
+			})
+			args := []string{"summary", "create", "--idempotency-key", "k"}
+			if tc.data != "" {
+				args = append(args, "--data", tc.data)
+			}
+			root.SetArgs(args)
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("summary create with data=%q must fail validation locally", tc.data)
+			}
+			// Sanity check the error text mentions at least one required field,
+			// so an agent gets an actionable message instead of a bare 400.
+			msg := err.Error()
+			if !strings.Contains(msg, "time_range") && !strings.Contains(msg, "sources") {
+				t.Errorf("expected error to name the missing required field(s), got %q", msg)
+			}
+		})
+	}
+}
+
 func TestSummaryListSendsBearerWithoutSpaceHeader(t *testing.T) {
 	var gotPath, gotQuery, gotAuth, gotSpace string
 	root, _, _ := rootWithServiceSpaced(t, "spoofed-space", func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/service/summary_test.go
+++ b/cmd/service/summary_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -11,6 +12,7 @@ import (
 func TestSummaryRegistryShape(t *testing.T) {
 	reg := registry.MustNew()
 	wants := map[string]string{
+		"summary.create": "/summary/api/v1/bot/summaries",
 		"summary.list":   "/summary/api/v1/bot/summaries",
 		"summary.get":    "/summary/api/v1/bot/summaries/{id}",
 		"summary.result": "/summary/api/v1/bot/summaries/{id}/result",
@@ -20,7 +22,11 @@ func TestSummaryRegistryShape(t *testing.T) {
 		if !ok {
 			t.Fatalf("missing %s", id)
 		}
-		if op.Method != http.MethodGet || op.Path != path || op.SpaceHeader || op.Risk != "read" || op.BaseURLEnv != "OCTO_API_BASE_URL" {
+		wantMethod, wantRisk := http.MethodGet, "read"
+		if id == "summary.create" {
+			wantMethod, wantRisk = http.MethodPost, "write"
+		}
+		if op.Method != wantMethod || op.Path != path || op.SpaceHeader || op.Risk != wantRisk || op.BaseURLEnv != "OCTO_API_BASE_URL" {
 			t.Errorf("%s: got method=%s path=%s space=%v risk=%s base=%s", id, op.Method, op.Path, op.SpaceHeader, op.Risk, op.BaseURLEnv)
 		}
 	}
@@ -35,7 +41,7 @@ func TestSummaryTreeShape(t *testing.T) {
 	if summary == nil {
 		t.Fatal("missing summary service command")
 	}
-	for _, leaf := range []string{"list", "get", "result"} {
+	for _, leaf := range []string{"create", "list", "get", "result"} {
 		if !contains(childNames(summary), leaf) {
 			t.Errorf("summary: missing %q; got %v", leaf, childNames(summary))
 		}
@@ -45,6 +51,26 @@ func TestSummaryTreeShape(t *testing.T) {
 		t.Fatal("summary list command must exist")
 	} else if list.Flags().Lookup("page-all") != nil {
 		t.Error("summary list must not expose --page-all (backend returns a {total, items} page, no cursor)")
+	}
+}
+
+func TestSummaryCreateSendsIdempotencyHeaderAndBody(t *testing.T) {
+	var gotPath, gotKey, gotSpace, gotBody string
+	root, _, _ := rootWithServiceSpaced(t, "spoofed-space", func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotKey, gotSpace = r.URL.Path, r.Header.Get("Idempotency-Key"), r.Header.Get("X-Space-Id")
+		bodyBytes, _ := io.ReadAll(r.Body)
+		gotBody = string(bodyBytes)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"code":0,"message":"ok","data":{"task_id":42,"status":0,"trigger_type":4}}`))
+	})
+	body := `{"title":"weekly","time_range":{"start":"2026-07-21T00:00:00Z","end":"2026-07-28T00:00:00Z"},"sources":[{"source_type":1,"source_id":"group-a"}]}`
+	root.SetArgs([]string{"summary", "create", "--idempotency-key", "weekly-2026w31", "--data", body})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotPath != "/summary/api/v1/bot/summaries" || gotKey != "weekly-2026w31" || gotSpace != "" || !strings.Contains(gotBody, `"group-a"`) {
+		t.Fatalf("path=%q key=%q space=%q body=%s", gotPath, gotKey, gotSpace, gotBody)
 	}
 }
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -77,11 +77,14 @@ func TestLoadSkillsExcludesDisabled(t *testing.T) {
 	if hasSkill(entries, "octo-matter") {
 		t.Error("disabled skill `octo-matter` must not be listed")
 	}
-	if !hasSkill(entries, "octo-summary") {
-		t.Error("enabled skill `octo-summary` must be listed")
+	if hasSkill(entries, "octo-summary") {
+		t.Error("disabled skill `octo-summary` must not be listed (see CHANGELOG withhold note)")
 	}
 	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
 		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)
+	}
+	if _, err := skills.FS.ReadFile("octo-summary/SKILL.md"); err != nil {
+		t.Errorf("octo-summary/SKILL.md must stay embedded (only the listing filters it): %v", err)
 	}
 }
 

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -77,8 +77,8 @@ func TestLoadSkillsExcludesDisabled(t *testing.T) {
 	if hasSkill(entries, "octo-matter") {
 		t.Error("disabled skill `octo-matter` must not be listed")
 	}
-	if hasSkill(entries, "octo-summary") {
-		t.Error("disabled skill `octo-summary` must not be listed (see CHANGELOG withhold note)")
+	if !hasSkill(entries, "octo-summary") {
+		t.Error("enabled skill `octo-summary` must be listed")
 	}
 	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
 		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -77,8 +77,8 @@ func TestLoadSkillsExcludesDisabled(t *testing.T) {
 	if hasSkill(entries, "octo-matter") {
 		t.Error("disabled skill `octo-matter` must not be listed")
 	}
-	if !hasSkill(entries, "octo-summary") {
-		t.Error("enabled skill `octo-summary` must be listed")
+	if hasSkill(entries, "octo-summary") {
+		t.Error("disabled skill `octo-summary` must not be listed (see CHANGELOG withhold note)")
 	}
 	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
 		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)

--- a/cmd/skills_test.go
+++ b/cmd/skills_test.go
@@ -77,14 +77,11 @@ func TestLoadSkillsExcludesDisabled(t *testing.T) {
 	if hasSkill(entries, "octo-matter") {
 		t.Error("disabled skill `octo-matter` must not be listed")
 	}
-	if hasSkill(entries, "octo-summary") {
-		t.Error("disabled skill `octo-summary` must not be listed")
+	if !hasSkill(entries, "octo-summary") {
+		t.Error("enabled skill `octo-summary` must be listed")
 	}
 	if _, err := skills.FS.ReadFile("octo-matter/SKILL.md"); err != nil {
 		t.Errorf("octo-matter/SKILL.md must stay embedded (only the listing filters it): %v", err)
-	}
-	if _, err := skills.FS.ReadFile("octo-summary/SKILL.md"); err != nil {
-		t.Errorf("octo-summary/SKILL.md must stay embedded (only the listing filters it): %v", err)
 	}
 }
 

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -148,9 +148,11 @@ type ParamInfo struct {
 	Description string      `json:"description,omitempty"`
 	Default     any         `json:"default,omitempty"`
 	Enum        []any       `json:"enum,omitempty"`
-	MinLength   int         `json:"min_length,omitempty"`
-	MaxLength   int         `json:"max_length,omitempty"`
-	Pattern     string      `json:"pattern,omitempty"`
+	// String constraints are exposed as schema metadata for callers; request
+	// validation remains the responsibility of the service backend.
+	MinLength int    `json:"min_length,omitempty"`
+	MaxLength int    `json:"max_length,omitempty"`
+	Pattern   string `json:"pattern,omitempty"`
 	// FlagName is the optional CLI flag override from the x-octo-flag
 	// extension on the parameter. It lets a spec expose a header/query param
 	// whose wire name is awkward as a flag (e.g. the `If-Match` header) under a
@@ -173,12 +175,14 @@ type SchemaInfo struct {
 	Enum        []any                 `json:"enum,omitempty"`
 	Format      string                `json:"format,omitempty"`
 	Description string                `json:"description,omitempty"`
-	MinLength   int                   `json:"min_length,omitempty"`
-	MaxLength   int                   `json:"max_length,omitempty"`
-	MinItems    int                   `json:"min_items,omitempty"`
-	MaxItems    int                   `json:"max_items,omitempty"`
-	Pattern     string                `json:"pattern,omitempty"`
-	Ref         string                `json:"$ref,omitempty"`
+	// These constraints are surfaced for schema introspection. The generic CLI
+	// validator currently enforces required and MinItems only.
+	MinLength int    `json:"min_length,omitempty"`
+	MaxLength int    `json:"max_length,omitempty"`
+	MinItems  int    `json:"min_items,omitempty"`
+	MaxItems  int    `json:"max_items,omitempty"`
+	Pattern   string `json:"pattern,omitempty"`
+	Ref       string `json:"$ref,omitempty"`
 	// FlagName is the optional CLI flag override from the x-octo-flag extension
 	// on a request-body property, mirroring ParamInfo.FlagName for query/header
 	// params. It lets a promoted body field expose a clean flag name (e.g.
@@ -521,7 +525,7 @@ func resolveSchema(doc, s map[string]any) SchemaInfo {
 	return resolveSchemaWithDepth(doc, s, 0)
 }
 
-func resolveSchemaWithDepth(doc, s map[string]any, depth int) SchemaInfo { //nolint:gocyclo // recursive schema resolver, branching is inherent to OpenAPI
+func resolveSchemaWithDepth(doc, s map[string]any, depth int) SchemaInfo {
 	if s == nil {
 		return SchemaInfo{}
 	}

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -148,6 +148,9 @@ type ParamInfo struct {
 	Description string      `json:"description,omitempty"`
 	Default     any         `json:"default,omitempty"`
 	Enum        []any       `json:"enum,omitempty"`
+	MinLength   int         `json:"min_length,omitempty"`
+	MaxLength   int         `json:"max_length,omitempty"`
+	Pattern     string      `json:"pattern,omitempty"`
 	// FlagName is the optional CLI flag override from the x-octo-flag
 	// extension on the parameter. It lets a spec expose a header/query param
 	// whose wire name is awkward as a flag (e.g. the `If-Match` header) under a
@@ -170,8 +173,11 @@ type SchemaInfo struct {
 	Enum        []any                 `json:"enum,omitempty"`
 	Format      string                `json:"format,omitempty"`
 	Description string                `json:"description,omitempty"`
+	MinLength   int                   `json:"min_length,omitempty"`
 	MaxLength   int                   `json:"max_length,omitempty"`
+	MinItems    int                   `json:"min_items,omitempty"`
 	MaxItems    int                   `json:"max_items,omitempty"`
+	Pattern     string                `json:"pattern,omitempty"`
 	Ref         string                `json:"$ref,omitempty"`
 	// FlagName is the optional CLI flag override from the x-octo-flag extension
 	// on a request-body property, mirroring ParamInfo.FlagName for query/header
@@ -201,12 +207,13 @@ type PaginationInfo struct {
 // binary response).
 type OperationDetail struct {
 	OperationInfo
-	Parameters     []ParamInfo     `json:"parameters,omitempty"`
-	RequestBody    *SchemaInfo     `json:"request_body,omitempty"`
-	ResponseSchema *SchemaInfo     `json:"response_schema,omitempty"`
-	Pagination     *PaginationInfo `json:"pagination,omitempty"`
-	BaseURLEnv     string          `json:"base_url_env,omitempty"`
-	SpaceHeader    bool            `json:"space_header,omitempty"`
+	Parameters          []ParamInfo     `json:"parameters,omitempty"`
+	RequestBody         *SchemaInfo     `json:"request_body,omitempty"`
+	RequestBodyRequired bool            `json:"request_body_required,omitempty"`
+	ResponseSchema      *SchemaInfo     `json:"response_schema,omitempty"`
+	Pagination          *PaginationInfo `json:"pagination,omitempty"`
+	BaseURLEnv          string          `json:"base_url_env,omitempty"`
+	SpaceHeader         bool            `json:"space_header,omitempty"`
 	// SpaceHeaderSet records whether the spec declared x-octo-space-header at
 	// all. It lets the transport distinguish an explicit `false` (suppress the
 	// X-Space-Id header) from an omitted flag (keep the default behaviour of
@@ -369,12 +376,16 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 				if enum, ok := sch["enum"].([]any); ok {
 					pi.Enum = enum
 				}
+				pi.MinLength = intOf(sch["minLength"])
+				pi.MaxLength = intOf(sch["maxLength"])
+				pi.Pattern = stringOf(sch["pattern"])
 			}
 			d.Parameters = append(d.Parameters, pi)
 		}
 	}
 
 	if body, ok := op["requestBody"].(map[string]any); ok {
+		d.RequestBodyRequired = boolOf(body["required"])
 		if s := extractJSONSchema(body); s != nil {
 			resolved := resolveSchema(doc, s)
 			d.RequestBody = &resolved
@@ -483,7 +494,10 @@ func firstSuccessSchema(doc, resps map[string]any) *SchemaInfo {
 				resolved := resolveSchema(doc, s)
 				return &resolved
 			}
-			return nil
+			// A valid success status may document only a description (for
+			// example an idempotent 200 replay). Keep looking for another 2xx
+			// response that carries the shared success schema.
+			continue
 		}
 	}
 	for code, r := range resps {
@@ -525,6 +539,11 @@ func resolveSchemaWithDepth(doc, s map[string]any, depth int) SchemaInfo { //nol
 		Format:      stringOf(s["format"]),
 		Description: stringOf(s["description"]),
 		FlagName:    stringOf(s["x-octo-flag"]),
+		MinLength:   intOf(s["minLength"]),
+		MaxLength:   intOf(s["maxLength"]),
+		MinItems:    intOf(s["minItems"]),
+		MaxItems:    intOf(s["maxItems"]),
+		Pattern:     stringOf(s["pattern"]),
 	}
 	if req, ok := s["required"].([]any); ok {
 		for _, x := range req {
@@ -535,12 +554,6 @@ func resolveSchemaWithDepth(doc, s map[string]any, depth int) SchemaInfo { //nol
 	}
 	if enum, ok := s["enum"].([]any); ok {
 		info.Enum = enum
-	}
-	if ml, ok := s["maxLength"].(float64); ok {
-		info.MaxLength = int(ml)
-	}
-	if mi, ok := s["maxItems"].(float64); ok {
-		info.MaxItems = int(mi)
 	}
 	if props, ok := s["properties"].(map[string]any); ok {
 		info.Properties = map[string]SchemaInfo{}
@@ -590,6 +603,11 @@ func stringOf(v any) string {
 func boolOf(v any) bool {
 	b, _ := v.(bool)
 	return b
+}
+
+func intOf(v any) int {
+	n, _ := v.(float64)
+	return int(n)
 }
 
 // truthy accepts a JSON value that may be a boolean `true` or the string

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -45,7 +45,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"docs":        31,
 		"html":        20,
 		"marketplace": 25,
-		"summary":     3,
+		"summary":     4,
 	}
 	totalWant := 0
 	for svc, want := range expected {

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -8,7 +8,7 @@
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
-  "x-octo-disabled": false,
+  "x-octo-disabled": true,
   "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -8,7 +8,6 @@
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
-  "x-octo-disabled": true,
   "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -24,7 +24,7 @@
             "required": true,
             "x-octo-flag": "idempotency-key",
             "schema": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$" },
-            "description": "Stable caller-generated key. Retries with the same bot, space and key return the original task."
+            "description": "Stable caller-generated key (1-128 chars, pattern ^[A-Za-z0-9][A-Za-z0-9._:-]*$). Reuse it only for an identical request body; changing the body requires a new key."
           }
         ],
         "requestBody": {
@@ -40,6 +40,7 @@
                   "topic": { "type": "string", "maxLength": 2300 },
                   "time_range": {
                     "type": "object",
+                    "description": "Required. RFC3339 start/end with start before end and a maximum range of 31 days.",
                     "additionalProperties": false,
                     "required": ["start", "end"],
                     "properties": {
@@ -49,6 +50,7 @@
                   },
                   "sources": {
                     "type": "array",
+                    "description": "Required. One to 30 explicitly authorized group, thread, or DM sources.",
                     "minItems": 1,
                     "maxItems": 30,
                     "items": {
@@ -61,8 +63,8 @@
                       }
                     }
                   },
-                  "origin_channel_id": { "type": "string", "description": "Optional; must be one of sources." },
-                  "origin_channel_type": { "type": "integer", "enum": [1, 2, 3] },
+                  "origin_channel_id": { "type": "string", "description": "Optional; must be one of sources and requires origin_channel_type." },
+                  "origin_channel_type": { "type": "integer", "enum": [1, 2, 3], "description": "Required when origin_channel_id is set; origin_channel_id is required when this field is set." },
                   "include_archived": { "type": "boolean", "default": false }
                 }
               }
@@ -70,8 +72,11 @@
           }
         },
         "responses": {
+          "200": {
+            "description": "Idempotent replay of an unchanged request; returns the original task envelope."
+          },
           "201": {
-            "description": "Created. A replay returns the same envelope with HTTP 200.",
+            "description": "Created.",
             "content": {
               "application/json": {
                 "schema": {
@@ -95,6 +100,9 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Idempotency conflict (backend code 40009): the same key was already used with a different request body; data.existing_task_id identifies the original task."
           }
         }
       },
@@ -140,7 +148,7 @@
                               "title": { "type": "string" },
                               "topic": { "type": "string", "description": "Free-text topic; keyword also matches this." },
                               "status": { "type": "integer", "description": "0=waiting,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
-                              "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                              "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent,4=bot" },
                               "summary_mode": { "type": "integer" },
                               "origin_channel_id": { "type": "string" },
                               "sources": { "type": "array", "description": "Source channels/scopes the summary was built from." },
@@ -192,7 +200,7 @@
                         "title": { "type": "string" },
                         "topic": { "type": "string" },
                         "status": { "type": "integer", "description": "0=waiting,1=waiting_confirm,2=processing,3=completed,4=failed,5=cancelled" },
-                        "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent" },
+                        "trigger_type": { "type": "integer", "description": "1=manual,2=scheduled,3=agent,4=bot" },
                         "origin_channel_id": { "type": "string" },
                         "created_at": { "type": "string", "description": "RFC3339 timestamp" },
                         "updated_at": { "type": "string", "description": "RFC3339 timestamp" },

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.1.0",
   "info": {
-    "title": "Octo Summary Bot Read API",
+    "title": "Octo Summary Bot API",
     "version": "1.0.0",
-    "description": "Read-only access to summaries visible to the bot owner's identity. The backend resolves owner and space from the bot token."
+    "description": "Read summaries and create owner-only summaries through a personal bot. The backend resolves owner and space from the bot token."
   },
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
@@ -12,6 +12,92 @@
   "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {
+      "post": {
+        "operationId": "summary.create",
+        "summary": "Create an asynchronous owner-only summary from explicitly authorized sources.",
+        "description": "Requires a stable Idempotency-Key. Owner, bot and space come from the bf_* token. Complex time_range and sources values must be supplied through --data.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "x-octo-flag": "idempotency-key",
+            "schema": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]*$" },
+            "description": "Stable caller-generated key. Retries with the same bot, space and key return the original task."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["time_range", "sources"],
+                "properties": {
+                  "title": { "type": "string", "maxLength": 2300 },
+                  "topic": { "type": "string", "maxLength": 2300 },
+                  "time_range": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["start", "end"],
+                    "properties": {
+                      "start": { "type": "string", "format": "date-time" },
+                      "end": { "type": "string", "format": "date-time" }
+                    }
+                  },
+                  "sources": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 30,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["source_type", "source_id"],
+                      "properties": {
+                        "source_type": { "type": "integer", "enum": [1, 2, 3], "description": "1=group, 2=thread, 3=DM" },
+                        "source_id": { "type": "string", "minLength": 1 }
+                      }
+                    }
+                  },
+                  "origin_channel_id": { "type": "string", "description": "Optional; must be one of sources." },
+                  "origin_channel_type": { "type": "integer", "enum": [1, 2, 3] },
+                  "include_archived": { "type": "boolean", "default": false }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created. A replay returns the same envelope with HTTP 200.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "code": { "type": "integer" },
+                    "message": { "type": "string" },
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "task_id": { "type": "integer" },
+                        "task_no": { "type": "string" },
+                        "status": { "type": "integer" },
+                        "trigger_type": { "type": "integer", "enum": [4] },
+                        "creator_id": { "type": "string" },
+                        "creator_bot_id": { "type": "string" },
+                        "created_at": { "type": "string", "format": "date-time" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "operationId": "summary.list",
         "summary": "List summaries visible to the bot owner. Returns a page {total, items}; keyword matches title OR topic; space and effective reader are resolved server-side from the bot token.",
@@ -22,7 +108,7 @@
           { "name": "page_size", "in": "query", "x-octo-flag": "page-size", "schema": { "type": "integer", "default": 20, "minimum": 1, "maximum": 100 }, "description": "Items per page (1-100); values >100 are silently reset to 20 server-side." },
           { "name": "keyword", "in": "query", "schema": { "type": "string" }, "description": "Substring matched against summary title OR topic." },
           { "name": "status", "in": "query", "schema": { "type": "integer", "enum": [0, 1, 2, 3, 4, 5] }, "description": "Task status filter. 0=waiting (caller-specific aggregate: status 0, OR a pending participant/schedule invitation, OR an unsubmitted personal result on a multi-participant task — so status-0 rows may not have status field 0), 1=waiting_confirm, 2=processing, 3=completed, 4=failed, 5=cancelled." },
-          { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer", "enum": [1, 2, 3] }, "description": "How the summary was triggered: 1=manual, 2=scheduled, 3=agent." },
+          { "name": "trigger_type", "in": "query", "x-octo-flag": "trigger-type", "schema": { "type": "integer", "enum": [1, 2, 3, 4] }, "description": "How the summary was triggered: 1=manual, 2=scheduled, 3=agent, 4=bot." },
           { "name": "origin_channel_id", "in": "query", "x-octo-flag": "origin-channel-id", "schema": { "type": "string" }, "description": "Filter to summaries whose origin channel matches this id." },
           { "name": "created_after", "in": "query", "x-octo-flag": "created-after", "schema": { "type": "string", "format": "date-time" }, "description": "RFC3339 timestamp, e.g. 2026-07-01T00:00:00Z. Malformed values are silently ignored by the server (filter not applied)." },
           { "name": "created_before", "in": "query", "x-octo-flag": "created-before", "schema": { "type": "string", "format": "date-time" }, "description": "RFC3339 timestamp, e.g. 2026-07-31T23:59:59Z. Malformed values are silently ignored by the server (filter not applied)." },

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -8,6 +8,7 @@
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
+  "x-octo-disabled": true,
   "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {

--- a/internal/registry/specs/summary.json
+++ b/internal/registry/specs/summary.json
@@ -8,7 +8,7 @@
   "x-octo-service": "summary",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": false,
-  "x-octo-disabled": true,
+  "x-octo-disabled": false,
   "x-octo-status-values": ["waiting(0)", "waiting_confirm(1)", "processing(2)", "completed(3)", "failed(4)", "cancelled(5)"],
   "paths": {
     "/summary/api/v1/bot/summaries": {

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,4 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
-- `octo-summary` — read and cite existing summaries visible to the personal Agent's human owner — **temporarily withheld** (backend API pending; not currently loadable)
+- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,4 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
-- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner — **temporarily withheld** (backend at Mininglamp-OSS/octo-smart-summary#172 and #181 not yet merged/deployed; not currently loadable)
+- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,4 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
-- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner — **temporarily withheld** (backend at Mininglamp-OSS/octo-smart-summary#172 and #181 not yet merged/deployed; not currently loadable)
+- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner — **temporarily withheld** (create backend at Mininglamp-OSS/octo-smart-summary#181 not yet merged/deployed/enabled; not currently loadable)

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -216,4 +216,4 @@ Once these fundamentals are understood, load the skill for the domain you need:
 - `octo-files` — file upload/download, presigned credentials, bot housekeeping
 - `octo-docs` — docs domain (CRDT/Yjs): documents, spreadsheets, whiteboard scenes, members/sharing, comments, versions, attachments
 - `octo-html` — HTML docs domain (octo-doc, a DIFFERENT backend from octo-docs): self-contained interactive HTML documents, share codes, media assets, comments, agent element read/replace
-- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner
+- `octo-summary` — create owner-only summaries from explicit sources, then discover, read, and cite summaries visible to the personal Agent's human owner — **temporarily withheld** (backend at Mininglamp-OSS/octo-smart-summary#172 and #181 not yet merged/deployed; not currently loadable)

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,16 +1,36 @@
 ---
 name: octo-summary
 disabled: true
-description: Read, find, and cite existing Octo summaries through octo-cli. Use when an agent needs to discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
+description: Read, create, find, and cite Octo summaries through octo-cli. Use when an agent needs to create an owner-only summary from explicit channels, discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
 ---
 
 # Octo Summary
 
-Use this skill only for existing summaries. It does not create, edit, regenerate, publish, or delete summaries.
+This skill can read summaries and create an owner-only asynchronous summary. It does not edit, regenerate, publish, or delete summaries.
 
 ## Authentication and scope
 
 Authenticate with the owner's `bf_*` personal Agent token through a stored profile or `OCTO_BOT_TOKEN`. Do not pass or rely on `--space`: the Summary service resolves both the human owner and Space from the bot token and applies the owner's existing Summary permissions.
+
+## Create a summary
+
+Creation is a write operation. Confirm the requested channels and time range with the user before calling it. Only explicit sources are accepted; the service does not let the model search all owner channels implicitly.
+
+Pass `time_range` and `sources` through `--data`, and always provide a stable idempotency key:
+
+```bash
+octo-cli summary create \
+  --idempotency-key project-weekly-2026w31 \
+  --data '{"title":"本周项目进展","topic":"整理决策、进展和风险","time_range":{"start":"2026-07-21T00:00:00+08:00","end":"2026-07-28T00:00:00+08:00"},"sources":[{"source_type":1,"source_id":"group-id"}]}'
+```
+
+Use the same key when retrying an uncertain request. A different key creates a different task. Never generate a fresh key merely because the first response timed out.
+
+Source types are `1=group`, `2=thread`, and `3=DM`. `include_archived` defaults to false. An optional origin channel must also be present in `sources`. Owner, bot identity, Space, source names, and participants are server-controlled; do not send `uid`, `participants`, `source_name`, or `confirm_timeout_hours`.
+
+The result contains `task_id` with an initial pending status. Poll with `summary get <task-id>` until status is completed (`3`), failed (`4`), or cancelled (`5`), then use `summary result <task-id>`. Do not poll indefinitely.
+
+Treat `40301/40302` as a source authorization or Space mismatch. Treat `50301` as the create feature being disabled. Do not retry either with altered identity or broader sources.
 
 ## Discover summaries
 

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-summary
 description: Read, create, find, and cite Octo summaries through octo-cli. Use when an agent needs to create an owner-only summary from explicit channels, discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
-disabled: true
+disabled: false
 ---
 
 # Octo Summary

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: octo-summary
 description: Read, create, find, and cite Octo summaries through octo-cli. Use when an agent needs to create an owner-only summary from explicit channels, discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
+disabled: true
 ---
 
 # Octo Summary

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: octo-summary
-disabled: true
 description: Read, create, find, and cite Octo summaries through octo-cli. Use when an agent needs to create an owner-only summary from explicit channels, discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
 ---
 

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -24,13 +24,13 @@ octo-cli summary create \
   --data '{"title":"本周项目进展","topic":"整理决策、进展和风险","time_range":{"start":"2026-07-21T00:00:00+08:00","end":"2026-07-28T00:00:00+08:00"},"sources":[{"source_type":1,"source_id":"group-id"}]}'
 ```
 
-Use the same key when retrying an uncertain request. A different key creates a different task. Never generate a fresh key merely because the first response timed out.
+Reuse the same key only when retrying the exact same request body after an uncertain outcome. If any body field changes, generate a new key; reusing the old key with a changed body returns `409/40009`. Never generate a fresh key merely because an otherwise unchanged first request timed out.
 
 Source types are `1=group`, `2=thread`, and `3=DM`. `include_archived` defaults to false. An optional origin channel must also be present in `sources`. Owner, bot identity, Space, source names, and participants are server-controlled; do not send `uid`, `participants`, `source_name`, or `confirm_timeout_hours`.
 
-The result contains `task_id` with an initial pending status. Poll with `summary get <task-id>` until status is completed (`3`), failed (`4`), or cancelled (`5`), then use `summary result <task-id>`. Do not poll indefinitely.
+The result contains `task_id` with an initial pending status. Poll with `summary get <task-id>` until status is completed (`3`), failed (`4`), or cancelled (`5`), then use `summary result <task-id>`. Poll at most 60 times with a 5-second interval; if it is still pending after 5 minutes, report the task id and current status instead of continuing.
 
-Treat `40301/40302` as a source authorization or Space mismatch. Treat `50301` as the create feature being disabled. Do not retry either with altered identity or broader sources.
+Treat `40301/40302` as a source authorization or Space mismatch. Treat `50301` as the create feature being disabled. Treat `409/40009` as key reuse with a changed body: preserve the existing task id for audit and use a new key only if the user still wants the modified request. Do not retry authorization or feature-disabled errors with altered identity or broader sources.
 
 ## Discover summaries
 

--- a/skills/octo-summary/SKILL.md
+++ b/skills/octo-summary/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-summary
 description: Read, create, find, and cite Octo summaries through octo-cli. Use when an agent needs to create an owner-only summary from explicit channels, discover summaries visible to its bot owner, inspect one summary, retrieve its current body, or ground an answer in returned citation metadata. Load after octo-shared.
-disabled: false
+disabled: true
 ---
 
 # Octo Summary

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -73,7 +73,7 @@ func TestOctoSummarySkillEmbedded(t *testing.T) {
 		t.Fatalf("octo-summary/SKILL.md not embedded: %v", err)
 	}
 	content := string(b)
-	for _, want := range []string{"name: octo-summary", "summary list", "summary get", "summary result", "context_before", "bf_*"} {
+	for _, want := range []string{"name: octo-summary", "summary create", "summary list", "summary get", "summary result", "context_before", "bf_*"} {
 		if !strings.Contains(content, want) {
 			t.Errorf("octo-summary skill missing %q", want)
 		}


### PR DESCRIPTION
## Summary

- add `octo-cli summary create` with required `--idempotency-key` and JSON request body validation
- define `summary create|list|get|result` for schema introspection while keeping the domain withheld until the backend is deployed
- embed the disabled `octo-summary` Skill with its eventual write-safety workflow
- keep owner, bot identity, and Space server-resolved; the CLI never sends a client Space header for Summary routes
- add registry and command tests for request path, headers, payload, risk, and skill discovery

## Dependencies

- includes the read-only Summary CLI foundation from #106
- requires the deployed backend from Mininglamp-OSS/octo-smart-summary#181

The Summary domain intentionally remains behind `x-octo-disabled` and the Skill behind `disabled: true` in this PR. A separate follow-up will enable both only after the backend is merged, deployed, and `BOT_SUMMARY_CREATE_ENABLED` is on.

## Safety

- creation requires explicit sources and time range
- retries must reuse the same stable idempotency key
- the Skill requires user confirmation before the write
- source authorization and effective identity remain enforced server-side

## Verification

```text
go test ./...
```

End-to-end tested locally with OpenClaw, `octo-cli --profile summary-test`, and the traditional Summary worker workflow.

Closes #114
