### PR TITLE
feat(loop): expose complete Fleet business commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,6 @@ Key properties:
 - **Agent-first output.** A stable JSON envelope with identity, data,
   pagination, and rate-limit metadata; a small fixed error taxonomy.
 
-### Reusable Go client
-
-The public `github.com/Mininglamp-OSS/octo-cli/client` package is independent
-from Cobra and CLI profile storage. A single client instance can route both
-Octo and Fleet/Loop requests through service-specific endpoints and tokens.
-Loop DTOs and business compatibility aliases deliberately stay outside this
-transport package.
-
 ## Domains
 
 | Domain    | Ops | Purpose                                                        |

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 104 operations
-across 9 domains — is auto-registered at startup from OpenAPI 3.x specs
+octo-cli is **metadata-driven**. The command tree is auto-registered at startup
+from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.
 
@@ -34,6 +34,14 @@ Key properties:
 - **Agent-first output.** A stable JSON envelope with identity, data,
   pagination, and rate-limit metadata; a small fixed error taxonomy.
 
+### Reusable Go client
+
+The public `github.com/Mininglamp-OSS/octo-cli/client` package is independent
+from Cobra and CLI profile storage. A single client instance can route both
+Octo and Fleet/Loop requests through service-specific endpoints and tokens.
+Loop DTOs and business compatibility aliases deliberately stay outside this
+transport package.
+
 ## Domains
 
 | Domain    | Ops | Purpose                                                        |
@@ -47,6 +55,7 @@ Key properties:
 | `message` | 10  | Messaging — send, edit, sync, read-receipt; search (search/all/files/media/around/groups, in-channel or cross-channel) |
 | `file`    | 4   | Files — upload, download, credentials, presigned URLs          |
 | `event`   | 2   | Event polling — list, ack                                      |
+| `loop`    | 61  | Fleet control plane — tasks, executions, experts, expert templates, and expert teams |
 
 ## Installation
 
@@ -133,6 +142,10 @@ octo-cli docs content get doc-123          # returns the body + base version tok
 octo-cli docs import doc-123 --file ./notes.md      # replaces a doc from .md/.markdown/.docx
 octo-cli docs export doc-123 --export-format pdf -o ./notes.pdf
 octo-cli docs members set doc-123 --data '{"uid":"u-1","role":"writer"}'
+
+# Fleet/Loop can use the same gateway or an independent local endpoint.
+OCTO_LOOP_API_BASE_URL="http://127.0.0.1:8081" \
+  OCTO_BOT_TOKEN="octo_loop_your_credential" octo-cli loop task list
 octo-cli docs comments add doc-123 --data '{"body":"looks good"}'
 
 # Spreadsheets — read the live cells + base version, then batch-edit under If-Match.
@@ -198,7 +211,8 @@ All backend services are accessed through a single API base URL.
 
 | Var                 | Purpose                                                  |
 |---------------------|----------------------------------------------------------|
-| `OCTO_BOT_TOKEN`    | Bot token (`app_*`, `bf_*`, or `uk_*`). Required.       |
+| `OCTO_BOT_TOKEN`    | Active Octo or Loop bearer credential. Required.         |
+| `OCTO_LOOP_API_BASE_URL` | Optional Fleet/Loop endpoint; defaults to `OCTO_API_BASE_URL`. |
 | `OCTO_API_BASE_URL`  | Unified API base URL for all services. Required.          |
 | `OCTO_BOT_ID`       | Select/assert the bot credential by robot id (see `--bot-id`). |
 | `OCTO_CONFIG_DIR`   | Override the config/credential directory (default `~/.octo-cli`). |

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -26,7 +26,7 @@ import (
 func newAuthCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Manage stored bot credentials (profiles)",
+		Short: "Manage stored Octo credentials (profiles)",
 	}
 	cmd.AddCommand(
 		newAuthLoginCmd(f),
@@ -44,8 +44,8 @@ func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Store a bot token (read from a hidden prompt or stdin, never argv)",
-		Long: "Store a bot token under a profile. Identify the bot with --bot-id " +
+		Short: "Store a credential (read from a hidden prompt or stdin, never argv)",
+		Long: "Store an Octo or Loop bearer credential under a profile. Identify a bot with --bot-id " +
 			"(its robot id, recommended) and/or --profile (a friendly name). The " +
 			"token is read from a hidden prompt on a terminal, or from stdin with " +
 			"--with-token, or from --token-file — never from the command line.",
@@ -76,7 +76,7 @@ func newAuthLoginCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 			if token == "" {
 				return failErr(f, output.ErrValidation(
-					"empty token", "provide a non-empty app_*, bf_*, or uk_* bot token"))
+					"empty token", "provide a non-empty Octo or Loop bearer credential"))
 			}
 
 			store, err := f.AuthStore()

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -72,14 +72,15 @@ func newConfigShowCmd(f *cmdutil.Factory) *cobra.Command {
 			}
 
 			payload := map[string]any{
-				"api_base_url":     cfg.APIBaseURL,
-				"space_id":         nullableString(space),
-				"format":           cfg.Format,
-				"bot_token":        maskToken(token),
-				"bot_token_source": nullableString(source),
-				"bot_kind":         botKind(token),
-				"profile":          nullableString(profileName),
-				"robot_id":         nullableString(robotID),
+				"api_base_url":      cfg.APIBaseURL,
+				"loop_api_base_url": nullableString(cfg.LoopAPIBaseURL),
+				"space_id":          nullableString(space),
+				"format":            cfg.Format,
+				"bot_token":         maskToken(token),
+				"bot_token_source":  nullableString(source),
+				"bot_kind":          botKind(token),
+				"profile":           nullableString(profileName),
+				"robot_id":          nullableString(robotID),
 			}
 			raw, err := json.Marshal(payload)
 			if err != nil {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -12,7 +12,8 @@ func TestMaskToken(t *testing.T) {
 		{"app_abcdefgh12345678", "app_ab***5678"},
 		{"bf_something", "bf_so***hing"},
 		{"app_tiny", "app_***"}, // body too short to reveal
-		{"short", "***"},        // unknown prefix
+		{"octo_loop_abcdefghijk", "octo_loop_ab***hijk"},
+		{"short", "***"}, // unknown prefix
 		{"", nil},
 		{"unknown_format_token", "***"}, // unknown prefix: reveal nothing
 	}

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -210,10 +210,12 @@ func extractPathParams(path string) []string {
 	}
 }
 
-// serviceForBaseURL maps the spec's x-octo-base-url env-var name to the
-// config-level service key used by client.Request.Service. With the unified
-// gateway model all services route to the same URL, so this always returns
-// empty (default service). Retained for interface compatibility.
-func serviceForBaseURL(_ string) string {
+// serviceForBaseURL maps a spec endpoint to the config-level routing key. Loop
+// may use a standalone Fleet endpoint during local integration; all existing
+// Octo services continue to use the unified default URL.
+func serviceForBaseURL(baseURLEnv string) string {
+	if baseURLEnv == "OCTO_LOOP_API_BASE_URL" {
+		return "loop"
+	}
 	return ""
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -91,6 +91,13 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 		"message": {"edit", "read-receipt", "send", "sync"},
 		"event":   {"ack", "list"},
 	}
+
+	loop := findCmd(root, "loop")
+	for _, resource := range []string{"task", "execution", "expert", "expert-template", "expert-team"} {
+		if findCmd(loop, resource) == nil {
+			t.Errorf("loop: missing resource %q; got %v", resource, childNames(loop))
+		}
+	}
 	for svc, wantCmds := range want {
 		svcCmd := findCmd(root, svc)
 		if svcCmd == nil {
@@ -113,6 +120,46 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 	timeline := findCmd(matter, "timeline")
 	if timeline == nil || !contains(childNames(timeline), "add") || !contains(childNames(timeline), "list") || !contains(childNames(timeline), "delete") {
 		t.Errorf("matter timeline should nest add/list/delete; got %v", childNames(timeline))
+	}
+}
+
+func TestLoopCommandUsesFleetEndpointAndPublicPath(t *testing.T) {
+	var gotPath, gotAuth, gotSpace string
+	fleet := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotSpace = r.Header.Get("X-Space-Id")
+		_, _ = w.Write([]byte(`{"data":{"task_id":"task-1"}}`))
+	}))
+	defer fleet.Close()
+
+	tf := cmdutil.NewTestFactory()
+	cfg := &config.Config{
+		APIBaseURL:     "http://octo.invalid",
+		LoopAPIBaseURL: fleet.URL,
+		BotToken:       "octo_loop_test",
+		Format:         "json",
+	}
+	cred := &credential.BotCredential{Token: "octo_loop_test", SpaceID: "space-from-legacy-profile"}
+	tf.SetConfig(cfg)
+	tf.SetCredential(cred)
+	tf.SetClient(client.New(cfg, cred, client.Options{NoRetry: true}))
+	tf.RegistryFunc = registry.MustNew
+
+	root := &cobra.Command{Use: "octo-cli", SilenceUsage: true, SilenceErrors: true}
+	RegisterServiceCommands(root, tf.Factory)
+	root.SetArgs([]string{"loop", "task", "get", "task-1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("loop task get: %v", err)
+	}
+	if gotPath != "/api/v1/tasks/task-1" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer octo_loop_test" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotSpace != "" {
+		t.Fatalf("Loop public API must not receive X-Space-Id, got %q", gotSpace)
 	}
 }
 

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -93,7 +93,11 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 	}
 
 	loop := findCmd(root, "loop")
-	for _, resource := range []string{"task", "execution", "expert", "expert-template", "expert-team"} {
+	for _, resource := range []string{
+		"attachment", "autopilot", "comment", "execution", "expert",
+		"expert-template", "expert-team", "label", "project", "runtime",
+		"skill", "skill-file", "task", "workspace",
+	} {
 		if findCmd(loop, resource) == nil {
 			t.Errorf("loop: missing resource %q; got %v", resource, childNames(loop))
 		}
@@ -152,7 +156,7 @@ func TestLoopCommandUsesFleetEndpointAndPublicPath(t *testing.T) {
 	if err := root.Execute(); err != nil {
 		t.Fatalf("loop task get: %v", err)
 	}
-	if gotPath != "/api/v1/tasks/task-1" {
+	if gotPath != "/v1/tasks/task-1" {
 		t.Fatalf("path = %q", gotPath)
 	}
 	if gotAuth != "Bearer octo_loop_test" {
@@ -160,6 +164,39 @@ func TestLoopCommandUsesFleetEndpointAndPublicPath(t *testing.T) {
 	}
 	if gotSpace != "" {
 		t.Fatalf("Loop public API must not receive X-Space-Id, got %q", gotSpace)
+	}
+}
+
+func TestLoopWorkspaceHeaderFlag(t *testing.T) {
+	var gotPath, gotWorkspace string
+	fleet := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotWorkspace = r.Header.Get("X-Workspace-ID")
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+	}))
+	defer fleet.Close()
+
+	tf := cmdutil.NewTestFactory()
+	cfg := &config.Config{
+		APIBaseURL:     "http://octo.invalid",
+		LoopAPIBaseURL: fleet.URL,
+		BotToken:       "octo_pat_test",
+		Format:         "json",
+	}
+	cred := &credential.BotCredential{Token: "octo_pat_test"}
+	tf.SetConfig(cfg)
+	tf.SetCredential(cred)
+	tf.SetClient(client.New(cfg, cred, client.Options{NoRetry: true}))
+	tf.RegistryFunc = registry.MustNew
+
+	root := &cobra.Command{Use: "octo-cli", SilenceUsage: true, SilenceErrors: true}
+	RegisterServiceCommands(root, tf.Factory)
+	root.SetArgs([]string{"loop", "label", "list", "--workspace-id", "workspace-1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("loop label list: %v", err)
+	}
+	if gotPath != "/v1/labels" || gotWorkspace != "workspace-1" {
+		t.Fatalf("path=%q X-Workspace-ID=%q", gotPath, gotWorkspace)
 	}
 }
 

--- a/docs/loop-integration-test-plan.md
+++ b/docs/loop-integration-test-plan.md
@@ -2,6 +2,10 @@
 
 Status: test execution pending
 
+The executable, real-Fleet integration design is documented separately in
+`loop-live-integration-test-plan.md`. This file remains the broader release
+test matrix.
+
 Test branch: `feat/loop-integration-test`
 
 The branch contains only the Fleet public API command integration from

--- a/docs/loop-integration-test-plan.md
+++ b/docs/loop-integration-test-plan.md
@@ -53,7 +53,8 @@ This TODO does not add enrollment commands to `octo-cli`.
 - Loop command-tree discovery
 - isolated dry-run routing for task, execution, expert, expert-template, and
   expert-team
-- isolated task-create body validation and routing
+- isolated task-create routing; required-body validation defect recorded in
+  the test report
 
 Local checks use a temporary `OCTO_CONFIG_DIR` and placeholder credentials.
 They do not read or modify a developer's saved CLI profiles.

--- a/docs/loop-integration-test-plan.md
+++ b/docs/loop-integration-test-plan.md
@@ -1,0 +1,163 @@
+# Loop integration test plan
+
+Status: test execution pending
+
+Test branch: `feat/loop-integration-test`
+
+The branch contains only the Fleet public API command integration from
+`feature/loop-business-migration`. The previously proposed reusable public Go
+client extraction was cancelled and is not part of this branch.
+
+## Scope
+
+The CLI exposes the Fleet public control plane only:
+
+- tasks
+- executions
+- experts
+- expert templates
+- expert teams
+
+Repository operations, daemon device enrollment, task claim/heartbeat, and
+local runtime management are intentionally outside the generic CLI surface.
+
+## TODO: Space-scoped device enrollment
+
+The Web/Fleet/daemon enrollment flow must be changed as one coordinated
+feature:
+
+- Remove `workspace_id` from device bootstrap and enrollment requests and
+  responses.
+- Derive `octo_space_id` from the verified Human `LoopPrincipal`; never accept
+  it as an untrusted request field.
+- Bind enrollment, device identity, Device Credential, and Device
+  `LoopPrincipal` to Space and device, not Workspace.
+- Identify a daemon within a Space by `(octo_space_id, daemon_id)`.
+- Remove `--workspace-id` from the Web-generated daemon installation command.
+- Register machine-level runtimes with `workspace_id = NULL` and the Space from
+  the Device Credential.
+- Resolve and authorize Workspace only when accessing a Workspace-owned task,
+  runtime profile, or other resource.
+- Migrate the database, OpenAPI contract, Fleet policy, daemon enrollment, Web
+  flow, and tests together. Do not remove `workspace_id` from only one layer.
+
+This TODO does not add enrollment commands to `octo-cli`.
+
+## Completed local checks
+
+- `gofmt` verification
+- `go vet ./...`
+- `go test -race -count=1 ./...`
+- local binary build
+- embedded Loop schema discovery
+- Loop command-tree discovery
+- isolated dry-run routing for task, execution, expert, expert-template, and
+  expert-team
+- isolated task-create body validation and routing
+
+Local checks use a temporary `OCTO_CONFIG_DIR` and placeholder credentials.
+They do not read or modify a developer's saved CLI profiles.
+
+## Test environment setup
+
+Use a dedicated test identity and test Space. Do not put credentials in this
+document, shell history, command arguments, logs, or test fixtures.
+
+```bash
+export OCTO_CONFIG_DIR="$(mktemp -d)"
+export OCTO_API_BASE_URL="<test-octo-api>"
+export OCTO_LOOP_API_BASE_URL="<test-fleet-api>"
+export OCTO_BOT_TOKEN="<test-credential>"
+```
+
+When the credential already carries Space in its verified principal, do not
+send `X-Space-Id`. Loop public operations declare
+`x-octo-space-header: false`.
+
+## Test matrix
+
+### 1. Discovery and routing
+
+- `octo-cli schema --list loop` returns all 61 public operations.
+- `octo-cli loop --help` contains the five expected resource groups.
+- Loop requests use `OCTO_LOOP_API_BASE_URL`.
+- Non-Loop requests continue to use their existing service endpoint.
+- Authorization is sent as Bearer; tokens are masked in dry-run and verbose
+  output.
+
+### 2. Authentication and isolation
+
+Run the read-only matrix with each supported test credential:
+
+- Octo Session, if supported by the CLI execution environment
+- `bf_`
+- `uk_`
+- Human or bot `octo_loop_` appropriate for the selected operation
+
+Verify:
+
+- valid identity succeeds;
+- expired, revoked, or wrong-principal credentials fail deterministically;
+- no Loop request depends on `X-Space-Id`;
+- a principal cannot read a different Space;
+- multiple saved profiles require explicit `--profile` or `--bot-id`.
+
+### 3. Read-only smoke tests
+
+- task list, get, search, grouped view, timeline, comments, executions, usage
+- execution messages
+- expert list/get, skills, environment, executions
+- expert-template list/get
+- expert-team list/get, members, member statuses
+
+Check JSON envelope shape, pagination, empty lists, not-found behavior, and
+permission errors.
+
+### 4. Task lifecycle
+
+In an isolated test Space:
+
+1. Create a task.
+2. Read and update it.
+3. Add/list a comment and preview triggers.
+4. Add/list/remove a label.
+5. Set/list/delete metadata.
+6. Subscribe/list subscribers/unsubscribe.
+7. Add/remove a reaction.
+8. Create or discover an execution, then list/cancel/rerun as allowed.
+9. Delete the test task.
+
+Also cover quick-create, parent/child task queries, attachments, pull requests,
+and active executions when fixtures are available.
+
+### 5. Expert lifecycle
+
+1. Create an expert.
+2. Read and update it.
+3. Add/list/replace skills.
+4. Read/update environment.
+5. Archive and restore it.
+6. Create an expert from a template.
+7. List and cancel executions where permitted.
+
+### 6. Expert-team lifecycle
+
+1. Create and read an expert team.
+2. Update it.
+3. Add/list/update/remove a member.
+4. Read member statuses.
+5. Delete the team.
+
+## Exit criteria
+
+- All local checks remain green.
+- All 61 embedded operations match Fleet `openapi/public-v1.yaml`.
+- Read-only smoke tests pass for every supported identity.
+- The three write lifecycles pass and clean up their fixtures.
+- Cross-Space and wrong-principal tests are rejected.
+- CLI output never exposes a complete credential.
+- Existing non-Loop command tests remain green.
+
+Until the authenticated environment matrix is complete, report the Loop
+surface as “locally verified, environment integration pending”, not “fully
+available”.

--- a/docs/loop-integration-test-report.html
+++ b/docs/loop-integration-test-report.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>octo-cli Loop 接入测试报告</title>
+  <style>
+    :root{--bg:#f4f7fb;--surface:#fff;--ink:#172033;--muted:#667089;--line:#dfe5ef;--brand:#3159d8;--pass:#16845b;--warn:#a86000;--fail:#c13838}
+    *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:14px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main{max-width:1180px;margin:auto;padding:42px 24px 80px}
+    header{padding:36px 40px;border-radius:22px;color:#fff;background:linear-gradient(135deg,#152862,#3159d8 68%,#6685ef);box-shadow:0 12px 36px #28365c17}h1{margin:0 0 8px;font-size:34px}h2{margin:40px 0 14px;font-size:23px}h3{margin:24px 0 9px;font-size:17px}p{margin:7px 0}.subtitle{opacity:.86;font-size:16px}.meta{display:flex;flex-wrap:wrap;gap:8px;margin-top:20px}.meta span,.badge{border-radius:99px;padding:4px 10px}.meta span{border:1px solid #ffffff55;background:#ffffff12}
+    .grid{display:grid;grid-template-columns:repeat(2,1fr);gap:16px}.metrics{display:grid;grid-template-columns:repeat(5,1fr);gap:12px;margin:18px 0}.card{background:var(--surface);border:1px solid var(--line);border-radius:15px;padding:20px;box-shadow:0 5px 18px #28365c0a}.metric{text-align:center}.metric b{display:block;color:var(--brand);font-size:27px}.metric small,.muted{color:var(--muted)}
+    .verdict{margin-top:20px;border-left:5px solid var(--warn)}.verdict strong{display:block;color:var(--warn);font-size:22px}.badge{display:inline-block;font-weight:700;white-space:nowrap}.pass{color:var(--pass);background:#e6f7ef}.warn{color:var(--warn);background:#fff4dc}.fail{color:var(--fail);background:#ffebeb}.info{color:var(--brand);background:#eaf0ff}
+    .wrap{overflow-x:auto;border:1px solid var(--line);border-radius:14px;background:#fff}table{width:100%;border-collapse:collapse}th,td{padding:10px 12px;border-bottom:1px solid var(--line);vertical-align:top;text-align:left}th{font-size:12px;color:#47516a;background:#f7f9fc}tr:last-child td{border:0}code{padding:1px 4px;border-radius:4px;color:#2647a5;background:#eef2fb}pre{overflow:auto;padding:17px 19px;border-radius:12px;color:#e7edf9;background:#101827;font:12.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace}pre code{padding:0;color:inherit;background:none}
+    .callout{padding:13px 16px;border-left:4px solid var(--brand);border-radius:8px;background:#eaf0ff}.warnbox{border-color:var(--warn);background:#fff4dc}.failbox{border-color:var(--fail);background:#ffebeb}.bar{min-width:120px;height:9px;overflow:hidden;border-radius:99px;background:#edf0f6}.bar i{display:block;height:100%;background:linear-gradient(90deg,#3159d8,#6c8df5)}details{margin:10px 0;border:1px solid var(--line);border-radius:12px;background:#fff}summary{padding:13px 16px;cursor:pointer;font-weight:700}details div{padding:0 16px 16px}.ops{columns:2;padding-left:22px}.ops li{break-inside:avoid}footer{margin-top:44px;padding-top:20px;border-top:1px solid var(--line);color:var(--muted)}
+    @media(max-width:850px){.grid,.metrics{grid-template-columns:1fr 1fr}.ops{columns:1}header{padding:27px 23px}}@media(max-width:560px){.grid,.metrics{grid-template-columns:1fr}}
+  </style>
+</head>
+<body><main>
+  <header>
+    <h1>octo-cli Loop 接入测试报告</h1>
+    <p class="subtitle">Loop-only 临时测试分支 · 自动化、契约、CLI dry-run 与覆盖率</p>
+    <div class="meta"><span>2026-07-30 15:50 CST</span><span>feat/loop-integration-test</span><span>36c8e624</span><span>Go 1.26.3 · Darwin arm64</span></div>
+  </header>
+
+  <section class="card verdict">
+    <span class="badge warn">CONDITIONAL PASS</span>
+    <strong>本地验证通过，环境集成待执行</strong>
+    <p>构建、Race 测试、契约匹配和路由 smoke 均通过；发现 1 个请求体必填字段未在 CLI 本地校验的问题。尚未使用真实 Fleet 测试身份执行端到端读写，因此不能声明 61 个业务接口“全部可用”。</p>
+  </section>
+  <section class="metrics">
+    <div class="card metric"><b>346</b><small>Go Tests</small></div><div class="card metric"><b>82.6%</b><small>语句覆盖率</small></div><div class="card metric"><b>61/61</b><small>Operation 匹配</small></div><div class="card metric"><b>12</b><small>通过的 Package</small></div><div class="card metric"><b>1</b><small>确认异常</small></div>
+  </section>
+
+  <h2>1. 测试对象与制品</h2>
+  <div class="grid">
+    <div class="card"><h3>源码</h3><table><tr><td>仓库</td><td><code>Mininglamp-OSS/octo-cli</code></td></tr><tr><td>分支</td><td><code>feat/loop-integration-test</code></td></tr><tr><td>HEAD</td><td><code>36c8e62411d64e85bfe8e424b896c6d3d9207b08</code></td></tr><tr><td>Loop 实现</td><td><code>a18d5ba</code></td></tr><tr><td>公共 Client</td><td><span class="badge pass">已移除</span></td></tr></table></div>
+    <div class="card"><h3>测试二进制</h3><table><tr><td>路径</td><td><code>bin/octo-cli</code></td></tr><tr><td>版本</td><td><code>loop-integration-test-20260730</code></td></tr><tr><td>格式</td><td>Mach-O 64-bit arm64</td></tr><tr><td>SHA-256</td><td><code>361cb8e434540db527434a13111485da6db5b62dde9d58a18c21f6859af3e969</code></td></tr></table></div>
+  </div>
+
+  <h2>2. 测试命令</h2>
+  <h3>格式、静态检查、Race 与覆盖率</h3>
+  <pre><code>test_cache_dir=$(mktemp -d /tmp/octo-cli-html-report-cache.XXXXXX)
+GOCACHE="$test_cache_dir" make fmt
+GOCACHE="$test_cache_dir" make vet
+GOCACHE="$test_cache_dir" go test -race -count=1 \
+  -covermode=atomic -coverprofile=/tmp/octo-cli-loop-coverage.out ./...
+GOCACHE="$test_cache_dir" go tool cover -func=/tmp/octo-cli-loop-coverage.out</code></pre>
+  <h3>编译与制品校验</h3>
+  <pre><code>GOCACHE="$test_cache_dir" make build VERSION=loop-integration-test-20260730
+./bin/octo-cli version
+file bin/octo-cli
+shasum -a 256 bin/octo-cli</code></pre>
+  <h3>OpenAPI 契约对比</h3>
+  <pre><code>fleet_ops=$(rg '^\s+operationId:' ../octo-fleet/openapi/public-v1.yaml \
+  | sed 's/.*operationId:\s*//' | sort)
+cli_ops=$(jq -r '.paths[] | to_entries[]
+  | select(.key|IN("get","post","put","patch","delete"))
+  | .value.operationId' internal/registry/specs/loop.json | sort)
+test "$fleet_ops" = "$cli_ops"</code></pre>
+  <h3>隔离 dry-run</h3>
+  <pre><code>export OCTO_CONFIG_DIR="$(mktemp -d /tmp/octo-cli-smoke.XXXXXX)"
+export OCTO_BOT_TOKEN='octo_loop_test_placeholder'
+export OCTO_API_BASE_URL='https://octo.invalid'
+export OCTO_LOOP_API_BASE_URL='http://127.0.0.1:8081'
+export OCTO_SPACE_ID='space-test'
+
+./bin/octo-cli schema --list loop
+./bin/octo-cli --dry-run loop task list
+./bin/octo-cli --dry-run loop task get task-test
+./bin/octo-cli --dry-run loop task create --data '{"title":"CLI smoke test"}'
+./bin/octo-cli --dry-run loop execution message list execution-test
+./bin/octo-cli --dry-run loop expert list
+./bin/octo-cli --dry-run loop expert-template list
+./bin/octo-cli --dry-run loop expert-team list</code></pre>
+
+  <h2>3. Test Case 与实际结果</h2>
+  <div class="wrap"><table>
+    <thead><tr><th>ID</th><th>内容</th><th>期望</th><th>实际</th><th>状态</th></tr></thead><tbody>
+    <tr><td>BUILD-001</td><td>格式检查</td><td>无待格式化文件</td><td><code>make fmt</code> exit 0</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>BUILD-002</td><td>Go Vet</td><td>无静态错误</td><td><code>go vet ./...</code> exit 0</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>BUILD-003</td><td>Race 全量单测</td><td>无失败、无 race</td><td>346 tests / 12 packages 通过</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>BUILD-004</td><td>测试版编译</td><td>生成 arm64 binary</td><td><code>bin/octo-cli</code> 可执行</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>SCOPE-001</td><td>公共 Client 清理</td><td>无 <code>client/</code> 包</td><td>目录及 main diff 均不存在</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CONTRACT-001</td><td>Operation ID</td><td>CLI/Fleet 完全一致</td><td>61 / 61</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CONTRACT-002</td><td>共享 Schema 引用</td><td>参数与 Body 可解析</td><td>相关 Registry Test 通过</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-001</td><td>Schema discovery</td><td>返回 61 个 Operation</td><td>exit 0</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-002</td><td>Task list</td><td><code>GET /api/v1/tasks</code></td><td>Fleet URL 正确</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-003</td><td>Task get</td><td>替换 task ID</td><td><code>/tasks/task-test</code></td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-004</td><td>Task create 合法 Body</td><td>POST + title</td><td>方法、路径、Body 正确</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-005</td><td>Execution messages</td><td>子资源路径正确</td><td><code>/executions/execution-test/messages</code></td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-006</td><td>Expert list</td><td><code>/api/v1/experts</code></td><td>符合预期</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-007</td><td>Expert template</td><td><code>/api/v1/expert_templates</code></td><td>符合预期</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-008</td><td>Expert team</td><td><code>/api/v1/expert_teams</code></td><td>符合预期</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CLI-009</td><td>Task create 缺少 title</td><td>validation / exit 2</td><td>dry-run 成功 / exit 0</td><td><span class="badge fail">FAIL</span></td></tr>
+    <tr><td>AUTH-001</td><td>Token 缺失</td><td>认证错误 / exit 3</td><td><code>UNAUTHORIZED</code> / exit 3</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>AUTH-002</td><td>Token 脱敏</td><td>不输出完整值</td><td><code>octo_loop_te***lder</code></td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>AUTH-003</td><td>Space Header</td><td>Loop 不发送 <code>X-Space-Id</code></td><td>仅 Authorization</td><td><span class="badge pass">PASS</span></td></tr>
+    <tr><td>CONFIG-001</td><td>Fleet Endpoint override</td><td>使用 <code>OCTO_LOOP_API_BASE_URL</code></td><td>请求指向 127.0.0.1:8081</td><td><span class="badge pass">PASS</span></td></tr>
+  </tbody></table></div>
+
+  <h2>4. 覆盖率</h2>
+  <div class="callout"><strong>仓库总语句覆盖率：82.6%</strong><p>不是 61 个业务 API 的端到端覆盖率；Loop 特有覆盖集中在 Registry、Service command tree、Config、Credential 和 Client routing。</p></div>
+  <div class="wrap" style="margin-top:14px"><table><thead><tr><th>Package</th><th>覆盖率</th><th>可视化</th><th>覆盖内容</th></tr></thead><tbody>
+    <tr><td><code>cmd</code></td><td>75.9%</td><td><div class="bar"><i style="width:75.9%"></i></div></td><td>Root/Auth/Config</td></tr><tr><td><code>cmd/octo-cli</code></td><td>0.0%</td><td><div class="bar"></div></td><td>main wrapper；核心逻辑在 cmd</td></tr><tr><td><code>cmd/service</code></td><td>87.6%</td><td><div class="bar"><i style="width:87.6%"></i></div></td><td>命令树、参数、Body、路由</td></tr><tr><td><code>internal/authstore</code></td><td>72.9%</td><td><div class="bar"><i style="width:72.9%"></i></div></td><td>本地身份存储</td></tr><tr><td><code>internal/client</code></td><td>87.0%</td><td><div class="bar"><i style="width:87%"></i></div></td><td>HTTP、重试、Header、dry-run</td></tr><tr><td><code>internal/cmdutil</code></td><td>84.0%</td><td><div class="bar"><i style="width:84%"></i></div></td><td>Factory、输入</td></tr><tr><td><code>internal/config</code></td><td>100.0%</td><td><div class="bar"><i style="width:100%"></i></div></td><td>Loop endpoint override</td></tr><tr><td><code>internal/credential</code></td><td>88.1%</td><td><div class="bar"><i style="width:88.1%"></i></div></td><td>Token 分类、脱敏</td></tr><tr><td><code>internal/fracindex</code></td><td>100.0%</td><td><div class="bar"><i style="width:100%"></i></div></td><td>非 Loop 专属</td></tr><tr><td><code>internal/output</code></td><td>91.8%</td><td><div class="bar"><i style="width:91.8%"></i></div></td><td>Envelope、错误</td></tr><tr><td><code>internal/registry</code></td><td>90.6%</td><td><div class="bar"><i style="width:90.6%"></i></div></td><td>OpenAPI 装载、Ref 解析</td></tr><tr><td><code>skills</code></td><td>无语句</td><td>—</td><td>嵌入文档内容测试</td></tr>
+  </tbody></table></div>
+
+  <h2>5. Loop API 覆盖内容</h2>
+  <p>以下 61 个 Operation 均已进入 CLI 命令和嵌入契约；“覆盖”不表示已对真实数据库执行全部生命周期。</p>
+  <details open><summary>Task · 33</summary><div><ul class="ops"><li>task.list</li><li>task.create</li><li>task.search</li><li>task.group</li><li>task.child_progress</li><li>task.children_by_parent</li><li>task.quick_create</li><li>task.get</li><li>task.update</li><li>task.delete</li><li>task.comment.list</li><li>task.comment.create</li><li>task.comment.preview</li><li>task.timeline.list</li><li>task.subscriber.list</li><li>task.subscribe</li><li>task.unsubscribe</li><li>task.execution.list</li><li>task.active_execution.list</li><li>task.rerun</li><li>task.execution.cancel</li><li>task.usage</li><li>task.reaction.add</li><li>task.reaction.remove</li><li>task.attachment.list</li><li>task.child.list</li><li>task.label.list</li><li>task.label.add</li><li>task.label.remove</li><li>task.metadata.list</li><li>task.metadata.set</li><li>task.metadata.delete</li><li>task.pull_request.list</li></ul></div></details>
+  <details><summary>Execution · 2</summary><div><ul><li>execution.cancel</li><li>execution.message.list</li></ul></div></details>
+  <details><summary>Expert · 14</summary><div><ul class="ops"><li>expert.list</li><li>expert.create</li><li>expert.create_from_template</li><li>expert.get</li><li>expert.update</li><li>expert.archive</li><li>expert.restore</li><li>expert.execution.cancel</li><li>expert.execution.list</li><li>expert.skill.list</li><li>expert.skill.replace</li><li>expert.skill.add</li><li>expert.environment.get</li><li>expert.environment.update</li></ul></div></details>
+  <details><summary>Expert template · 2</summary><div><ul><li>expert_template.list</li><li>expert_template.get</li></ul></div></details>
+  <details><summary>Expert team · 10</summary><div><ul class="ops"><li>expert_team.list</li><li>expert_team.create</li><li>expert_team.get</li><li>expert_team.update</li><li>expert_team.delete</li><li>expert_team.member.list</li><li>expert_team.member.add</li><li>expert_team.member.remove</li><li>expert_team.member.update</li><li>expert_team.member_status.list</li></ul></div></details>
+
+  <h2>6. 异常与限制</h2>
+  <div class="wrap"><table><thead><tr><th>ID</th><th>类型</th><th>现象/影响</th><th>处理或建议</th></tr></thead><tbody>
+    <tr><td>ISSUE-001</td><td><span class="badge fail">代码异常</span></td><td><code>task.create --data '{}'</code> exit 0；CLI 未校验 Schema required Body 字段</td><td>在通用 Service engine 校验 <code>RequestBody.Required</code>，增加回归测试</td></tr>
+    <tr><td>ENV-001</td><td><span class="badge warn">环境</span></td><td>默认 Go build cache 无写权限，首次 vet 被沙箱阻止</td><td>已使用临时 <code>GOCACHE</code>，非代码异常</td></tr>
+    <tr><td>ENV-002</td><td><span class="badge warn">环境</span></td><td>module stat cache 有 permission warning；build exit 0</td><td>制品可执行且已记录哈希；CI 使用可写 cache</td></tr>
+    <tr><td>ENV-003</td><td><span class="badge warn">未执行</span></td><td><code>golangci-lint</code> 未安装</td><td>CI 或安装后补跑</td></tr>
+    <tr><td>SCOPE-001</td><td><span class="badge info">范围</span></td><td>无测试 Fleet 地址和专用身份，未验证真实权限、写入与跨 Space</td><td>执行下一节的端到端矩阵</td></tr>
+  </tbody></table></div>
+
+  <h2>7. 真实环境待测矩阵</h2>
+  <div class="callout warnbox"><strong>前置条件：</strong>测试 Fleet Base URL、隔离测试 Space、非生产测试凭证。凭证不得进入报告、Git、命令参数或共享日志。</div>
+  <ol><li>认证：允许的 Octo Session、bf_、uk_、octo_loop_；过期、撤销、错误 Principal。</li><li>Task：create → get → update → comment/label/metadata/reaction → execution/rerun → delete。</li><li>Expert：create → update → skills/env → archive/restore → template create。</li><li>Expert team：create → member add/update/remove → status → delete。</li><li>隔离：同 Space 成功、跨 Space 拒绝，且 Loop 不依赖 X-Space-Id。</li><li>稳定性：404/409/422/429/5xx、retry、timeout、分页、空结果和错误 envelope。</li></ol>
+
+  <h2>8. 最终判断</h2>
+  <div class="callout failbox"><strong>暂不标记为“全部功能可用”。</strong><p>准确状态：Loop CLI 本地自动化与契约接入通过；存在 1 个 Body required 本地校验缺口；真实 Fleet 端到端测试待执行。</p></div>
+  <footer>测试使用临时配置目录和占位 Token，未读取或修改开发者保存的 CLI 凭证。</footer>
+</main></body></html>

--- a/docs/loop-integration-test-report.md
+++ b/docs/loop-integration-test-report.md
@@ -1,0 +1,164 @@
+# Loop integration local test report
+
+Date: 2026-07-30
+
+Branch: `feat/loop-integration-test`
+
+Loop implementation commit: `a18d5ba`
+
+Result: **local verification passed; authenticated environment integration is
+pending**
+
+## Build artifact
+
+- Path: `bin/octo-cli`
+- Version: `loop-integration-test-20260730`
+- Platform: macOS arm64
+- SHA-256:
+  `505ced0b12b3069d834ec60652e74d74c09251491244b5bdd894e233071967bc`
+
+Build command:
+
+```bash
+make build VERSION=loop-integration-test-20260730
+```
+
+The Go build cache was redirected to a temporary writable directory because
+the execution sandbox cannot write to the default user cache directory. This
+does not change the source or resulting binary.
+
+## Executed checks
+
+### Formatting
+
+```bash
+make fmt
+```
+
+Result: passed.
+
+### Static analysis
+
+```bash
+make vet
+```
+
+Result: passed.
+
+`golangci-lint` was not installed in the execution environment, so the
+optional `make lint` check was not executed.
+
+### Unit and race tests
+
+```bash
+make test
+```
+
+This runs:
+
+```bash
+go test -race -count=1 ./...
+```
+
+Result: all packages passed:
+
+- `github.com/Mininglamp-OSS/octo-cli/cmd`
+- `github.com/Mininglamp-OSS/octo-cli/cmd/octo-cli`
+- `github.com/Mininglamp-OSS/octo-cli/cmd/service`
+- `github.com/Mininglamp-OSS/octo-cli/internal/authstore`
+- `github.com/Mininglamp-OSS/octo-cli/internal/client`
+- `github.com/Mininglamp-OSS/octo-cli/internal/cmdutil`
+- `github.com/Mininglamp-OSS/octo-cli/internal/config`
+- `github.com/Mininglamp-OSS/octo-cli/internal/credential`
+- `github.com/Mininglamp-OSS/octo-cli/internal/fracindex`
+- `github.com/Mininglamp-OSS/octo-cli/internal/output`
+- `github.com/Mininglamp-OSS/octo-cli/internal/registry`
+- `github.com/Mininglamp-OSS/octo-cli/skills`
+
+### Fleet OpenAPI contract comparison
+
+Compared the operation IDs embedded in:
+
+```text
+octo-cli/internal/registry/specs/loop.json
+```
+
+with:
+
+```text
+octo-fleet/openapi/public-v1.yaml
+```
+
+Result: `61/61` operations match.
+
+Operation distribution:
+
+- task: 33
+- execution: 2
+- expert: 14
+- expert-template: 2
+- expert-team: 10
+
+### Command discovery
+
+Executed:
+
+```bash
+./bin/octo-cli version
+./bin/octo-cli schema --list loop
+./bin/octo-cli loop --help
+```
+
+Result: passed. The Loop command tree contains:
+
+- `loop task`
+- `loop execution`
+- `loop expert`
+- `loop expert-template`
+- `loop expert-team`
+
+### Isolated dry-run routing
+
+Dry-run tests used a temporary empty `OCTO_CONFIG_DIR`, placeholder
+credentials, and a local placeholder Fleet endpoint. No developer credentials
+or saved profiles were read or modified.
+
+Verified:
+
+- task list
+- task get
+- task create with request-body validation
+- execution message list
+- expert list
+- expert-template list
+- expert-team list
+
+Result: passed.
+
+Observed behavior:
+
+- Loop requests route through `OCTO_LOOP_API_BASE_URL`.
+- Bearer credentials are attached.
+- Credentials are masked in dry-run output.
+- Loop public requests do not send `X-Space-Id`; Space is expected to come from
+  the verified principal.
+
+## Not yet executed
+
+The following require a dedicated test Fleet endpoint and non-production test
+identity:
+
+- authenticated read tests for all resource groups;
+- task create/update/comment/label/metadata/execution/delete lifecycle;
+- expert create/update/skills/environment/archive/restore lifecycle;
+- expert-team create/member/update/delete lifecycle;
+- expired and revoked credential handling;
+- Human, bot, and Loop credential permission matrix;
+- cross-Space isolation;
+- retry and rate-limit behavior against the deployed service;
+
+Therefore the current status must not be reported as “all Loop functions are
+fully available”. The supported statement is:
+
+> All local builds, tests, command routing, and embedded Fleet public API
+> contract checks pass. Authenticated environment integration remains pending.

--- a/docs/loop-integration-test-report.md
+++ b/docs/loop-integration-test-report.md
@@ -15,7 +15,7 @@ pending**
 - Version: `loop-integration-test-20260730`
 - Platform: macOS arm64
 - SHA-256:
-  `505ced0b12b3069d834ec60652e74d74c09251491244b5bdd894e233071967bc`
+  `361cb8e434540db527434a13111485da6db5b62dde9d58a18c21f6859af3e969`
 
 Build command:
 
@@ -127,13 +127,14 @@ Verified:
 
 - task list
 - task get
-- task create with request-body validation
+- task create with a valid request body
 - execution message list
 - expert list
 - expert-template list
 - expert-team list
 
-Result: passed.
+Result: routing passed. Required request-body validation has one confirmed
+defect documented below.
 
 Observed behavior:
 
@@ -162,3 +163,20 @@ fully available”. The supported statement is:
 
 > All local builds, tests, command routing, and embedded Fleet public API
 > contract checks pass. Authenticated environment integration remains pending.
+
+## Confirmed issue
+
+`task.create` declares `title` as a required request-body property, but this
+currently succeeds with exit code 0:
+
+```bash
+octo-cli --dry-run loop task create --data '{}'
+```
+
+The generic service engine resolves the request-body schema but does not
+validate `RequestBody.Required` against the merged body. Fleet should reject
+the real request, but the CLI does not fail early. This is a CLI validation
+defect, not a passed Loop test.
+
+The detailed commands, case matrix, package coverage, all 61 operations, and
+execution limitations are in `loop-integration-test-report.html`.

--- a/docs/loop-live-integration-test-plan.md
+++ b/docs/loop-live-integration-test-plan.md
@@ -1,0 +1,479 @@
+# octo-cli Loop live integration test plan
+
+Status: designed, environment execution pending
+
+Target branch: `feat/loop-integration-test`
+
+This plan tests the real `octo-cli loop ...` command surface against a deployed
+Fleet service. It is intentionally separate from unit tests and `--dry-run`
+tests.
+
+## 1. Objective
+
+Prove that the compiled CLI can use a real credential to:
+
+1. route all Loop commands to the deployed Fleet endpoint;
+2. authenticate and receive the expected public API envelope;
+3. create, read, update and clean up Loop resources;
+4. preserve the public task/expert/expert-team vocabulary;
+5. enforce principal type, Space isolation and permission boundaries;
+6. handle pagination, validation, not-found, conflict, rate-limit and retry
+   responses consistently.
+
+Passing local Go tests or matching 61 OpenAPI operation IDs is necessary but
+does not satisfy this plan.
+
+## 2. Safety and environment requirements
+
+Run only in a dedicated test Space. Never run the write suite in production.
+
+Required environment variables:
+
+```bash
+export OCTO_CLI_BIN="$(pwd)/bin/octo-cli"
+export OCTO_LOOP_API_BASE_URL="<test-fleet-base-url>"
+export OCTO_API_BASE_URL="<test-octo-base-url>"
+export OCTO_BOT_TOKEN="<non-production-test-credential>"
+export OCTO_CONFIG_DIR="$(mktemp -d)"
+
+# Pre-provisioned fixture IDs. See the dependency table below.
+export LOOP_TEST_RUNTIME_ID="<runtime-uuid>"
+export LOOP_TEST_TEMPLATE_ID="<template-id>"       # optional
+export LOOP_TEST_SKILL_ID="<skill-uuid>"           # optional
+export LOOP_TEST_LABEL_ID="<label-uuid>"           # optional
+```
+
+For isolation tests, provide a second identity from another Space through a
+separate protected environment, not a command argument:
+
+```bash
+export LOOP_TEST_OTHER_SPACE_TOKEN="<non-production-other-space-credential>"
+```
+
+Rules:
+
+- Do not pass credentials on argv.
+- Do not write credentials to Git, reports, fixtures or command logs.
+- Do not use `set -x`.
+- Use a fresh `OCTO_CONFIG_DIR` for every run.
+- Prefix every resource name with a unique run ID.
+- Record only masked headers and sanitized response bodies.
+
+## 3. Fixture dependency graph
+
+```text
+test Space + identity
+        |
+        +---- Task basic lifecycle (no runtime required)
+        |
+        +---- pre-existing runtime_id
+                  |
+                  +---- Expert A
+                  |       |
+                  |       +---- Expert Team
+                  |       |       |
+                  |       |       +---- Team-assigned Task
+                  |       |
+                  |       +---- Expert-assigned Task
+                  |               |
+                  |               +---- Execution (requires online daemon)
+                  |
+                  +---- Expert from template (optional template fixture)
+```
+
+| Fixture | Source | Required for | Cleanup |
+|---|---|---|---|
+| Test identity and Space | Test environment | All tests | Revoke after campaign if temporary |
+| Runtime | Web/daemon provisioning or test seed | Expert create | Environment-owned |
+| Expert template | `expert-template list` | Template create | Read-only |
+| Skill | Test seed/catalog | Expert skill mutation | Removed by expert cleanup/archive policy |
+| Label | Test seed | Task label mutation | Task deletion cascades association |
+| Online daemon | Test deployment | Execution state and messages | Stop after campaign |
+| Second-Space identity | Test environment | Cross-Space denial | Revoke after campaign if temporary |
+
+The public Loop API does not create runtimes, skills or labels. Their IDs must
+be provisioned before the dependent test level starts.
+
+## 4. Runner design
+
+Implement the runner as `scripts/integration/loop-live.sh` using Bash and
+`jq`. The runner must:
+
+- use `set -euo pipefail`, but capture expected non-zero cases explicitly;
+- generate `RUN_ID="cli-it-$(date +%Y%m%d%H%M%S)-$RANDOM"`;
+- capture every JSON response before extracting identifiers;
+- assert `.ok == true` for success cases;
+- assert exit code and `.error.code` for failure cases;
+- register cleanup actions immediately after each successful create;
+- run cleanup in reverse dependency order through `trap cleanup EXIT`;
+- classify each case as `PASS`, `FAIL`, `BLOCKED` or `SKIP`;
+- continue independent levels when one optional fixture is unavailable;
+- never print the unmasked environment.
+- avoid shell variables named `PATH` or `path`; zsh treats lowercase `path` as
+  a special array tied to command lookup.
+
+Suggested result layout:
+
+```text
+test-results/loop-live/<run-id>/
+  summary.json
+  junit.xml
+  report.html
+  commands.log                 # sanitized; no token or raw auth header
+  responses/<case-id>.json     # sanitized API envelopes
+```
+
+Basic assertion helpers:
+
+```bash
+run_cli() {
+  case_id="$1"
+  shift
+  output_file="$RESULT_DIR/responses/$case_id.json"
+  set +e
+  "$OCTO_CLI_BIN" "$@" >"$output_file" 2>&1
+  rc=$?
+  set -e
+  return "$rc"
+}
+
+assert_ok() {
+  jq -e '.ok == true' "$1" >/dev/null
+}
+
+assert_error() {
+  file="$1" expected_code="$2"
+  jq -e --arg code "$expected_code" \
+    '.ok == false and .error.code == $code' "$file" >/dev/null
+}
+```
+
+## 5. Execution levels
+
+### Level 0: preflight and read-only discovery
+
+These cases must run before any mutation.
+
+| ID | Command | Assertion |
+|---|---|---|
+| LIVE-000 | `octo-cli version` | Expected test version |
+| LIVE-001 | `octo-cli schema --list loop` | 61 operations |
+| LIVE-002 | `octo-cli loop task list --page 1 --page-size 2` | Success envelope and pagination |
+| LIVE-003 | `octo-cli loop expert list --page 1 --page-size 2` | Success envelope |
+| LIVE-004 | `octo-cli loop expert-template list --page 1 --page-size 2` | Success envelope |
+| LIVE-005 | `octo-cli loop expert-team list --page 1 --page-size 2` | Success envelope |
+| LIVE-006 | Repeat one list with `--no-retry` | Same business response |
+
+Gate: stop all write levels if authentication, Space scope or base URL is
+incorrect.
+
+### Level 1: Task core lifecycle
+
+This level does not require a runtime or daemon.
+
+```bash
+create_response=$(
+  "$OCTO_CLI_BIN" loop task create --data "$(jq -nc \
+    --arg title "$RUN_ID task" \
+    --arg description "octo-cli live integration fixture" \
+    '{title:$title,description:$description,priority:"normal"}')"
+)
+TASK_ID=$(jq -er '.data.task_id' <<<"$create_response")
+```
+
+Cases:
+
+| ID | Action | Required assertion |
+|---|---|---|
+| LIVE-100 | Create task | HTTP success; `.data.task_id` non-empty |
+| LIVE-101 | Get task | Returned ID/title match fixture |
+| LIVE-102 | Update title and description | Follow-up get returns new values |
+| LIVE-103 | Call search endpoint | Valid collection; targeted query is blocked by the current contract |
+| LIVE-104 | List timeline | Valid collection envelope |
+| LIVE-105 | Create comment | Comment returned or visible in list |
+| LIVE-106 | List comments | Fixture comment present |
+| LIVE-107 | Subscribe | Success; subscriber list contains actor |
+| LIVE-108 | Unsubscribe | Actor no longer present, or API confirms removal |
+| LIVE-109 | Add reaction | Success |
+| LIVE-110 | Remove reaction | Success and idempotency semantics recorded |
+| LIVE-111 | Set metadata | List returns exact JSON value |
+| LIVE-112 | Delete metadata | Entry absent afterwards |
+| LIVE-113 | Add/list/remove label | Run only when `LOOP_TEST_LABEL_ID` exists |
+| LIVE-114 | Get usage/attachments/pull requests | Valid empty or populated envelopes |
+| LIVE-115 | Delete task | Success |
+| LIVE-116 | Get deleted task | exit non-zero and `NOT_FOUND` |
+
+Task deletion is the primary cleanup action and should remove task-owned test
+comments, metadata, reactions and label associations.
+
+### Level 2: Expert lifecycle
+
+Requires `LOOP_TEST_RUNTIME_ID`.
+
+```bash
+expert_response=$(
+  "$OCTO_CLI_BIN" loop expert create --data "$(jq -nc \
+    --arg name "$RUN_ID expert" \
+    --arg runtime "$LOOP_TEST_RUNTIME_ID" \
+    '{name:$name,runtime_id:$runtime,description:"CLI integration fixture"}')"
+)
+EXPERT_ID=$(jq -er '.data.expert.expert_id // .data.expert_id' \
+  <<<"$expert_response")
+```
+
+| ID | Action | Required assertion |
+|---|---|---|
+| LIVE-200 | Create expert | Expert ID returned; runtime matches fixture |
+| LIVE-201 | Get expert | Public vocabulary uses `expert_id` |
+| LIVE-202 | Update expert | Name/description persisted |
+| LIVE-203 | Get/update environment | `custom_env` round trip; use non-secret values only |
+| LIVE-204 | List/add/replace skills | Run only with `LOOP_TEST_SKILL_ID` |
+| LIVE-205 | List expert executions | Valid collection |
+| LIVE-206 | Archive expert | Archived state visible |
+| LIVE-207 | Restore expert | Active state visible |
+| LIVE-208 | Create from template | Run only with template and runtime fixtures |
+
+There is no public expert delete endpoint. Final cleanup archives created
+experts. Therefore this suite must use a dedicated test Space or a backend
+fixture cleanup job.
+
+### Level 3: Expert team lifecycle
+
+Requires Expert A. Create Expert B when member mutation is tested.
+
+```bash
+team_response=$(
+  "$OCTO_CLI_BIN" loop expert-team create --data "$(jq -nc \
+    --arg name "$RUN_ID team" --arg leader "$EXPERT_ID" \
+    '{name:$name,leader_expert_id:$leader,description:"CLI integration fixture"}')"
+)
+TEAM_ID=$(jq -er '.data.expert_team_id' <<<"$team_response")
+```
+
+| ID | Action | Required assertion |
+|---|---|---|
+| LIVE-300 | Create team | Team ID and leader Expert ID returned |
+| LIVE-301 | Get/update team | Public fields persisted |
+| LIVE-302 | List members | Leader visible as `member_type=expert` |
+| LIVE-303 | Add Expert B | Member appears with requested role |
+| LIVE-304 | Update Expert B role | New role visible |
+| LIVE-305 | Read member statuses | Valid public task/expert vocabulary |
+| LIVE-306 | Remove Expert B | Member absent afterwards |
+| LIVE-307 | Delete team | Success; subsequent get is `NOT_FOUND` |
+
+For member add/update, send an explicit body even though the current CLI schema
+display is incomplete:
+
+```json
+{"member_type":"expert","member_id":"<expert-b-id>","role":"member"}
+```
+
+### Level 4: Assignment and execution
+
+Requires an online daemon/runtime capable of consuming assigned work.
+
+| ID | Action | Required assertion |
+|---|---|---|
+| LIVE-400 | Create task assigned to Expert | Task stores expert assignment |
+| LIVE-401 | Create task assigned to Expert Team | Task stores team assignment |
+| LIVE-402 | Poll active executions | Execution appears before timeout |
+| LIVE-403 | List task executions | Public execution fields returned |
+| LIVE-404 | Read execution messages | Valid ordered collection |
+| LIVE-405 | Cancel execution | Terminal/cancelled state observed |
+| LIVE-406 | Rerun execution | New execution ID differs from original |
+| LIVE-407 | Expert execution list | Execution references correct expert/task |
+
+Use bounded polling, for example 60 seconds with a 2-second interval. A timeout
+is `BLOCKED` when daemon health is unavailable, not automatically a CLI defect.
+
+### Level 5: negative authentication and isolation
+
+| ID | Scenario | Expected result |
+|---|---|---|
+| LIVE-500 | No token | CLI exit 3, `UNAUTHORIZED` |
+| LIVE-501 | Invalid token | Auth failure; no retry storm |
+| LIVE-502 | Revoked/expired token | Auth failure with stable error envelope |
+| LIVE-503 | Read first-Space task using second-Space token | `NOT_FOUND` or `FORBIDDEN`, never data |
+| LIVE-504 | Mutate first-Space task using second-Space token | Rejected; original data unchanged |
+| LIVE-505 | Device/execution principal invokes Human-only operation | `FORBIDDEN` |
+| LIVE-506 | Loop request with local `OCTO_SPACE_ID` set | Server scope still comes from principal; no scope escape |
+
+Do not infer cross-Space correctness from list returning an empty page; create a
+known first-Space fixture and address it directly from the second identity.
+
+### Level 6: transport and error behavior
+
+| ID | Scenario | Expected result |
+|---|---|---|
+| LIVE-600 | Missing required body field | CLI validation after known defect is fixed; otherwise Fleet 4xx recorded |
+| LIVE-601 | Unknown resource | Stable `NOT_FOUND` envelope and non-zero exit |
+| LIVE-602 | Invalid UUID/path ID | Validation or 4xx; no panic |
+| LIVE-603 | Page size boundary | Valid boundary accepted, invalid rejected |
+| LIVE-604 | Fleet 429 | Retry-After honored unless `--no-retry` |
+| LIVE-605 | Transient 503 | Bounded retry then success/final error |
+| LIVE-606 | Timeout | Deterministic timeout envelope and non-zero exit |
+| LIVE-607 | Token masking | Complete credential absent from all artifacts |
+
+429/503 injection should use a controlled test proxy or Fleet fault-injection
+mode, not production traffic.
+
+## 6. Canonical real CLI command set
+
+The runner should invoke the public command surface directly. These are real
+calls: do not add `--dry-run`.
+
+### Task commands
+
+```bash
+"$OCTO_CLI_BIN" loop task create --data "$TASK_CREATE_BODY"
+"$OCTO_CLI_BIN" loop task get "$TASK_ID"
+"$OCTO_CLI_BIN" loop task update "$TASK_ID" --data "$TASK_UPDATE_BODY"
+"$OCTO_CLI_BIN" loop task search --page 1 --page-size 20
+"$OCTO_CLI_BIN" loop task timeline list "$TASK_ID"
+
+"$OCTO_CLI_BIN" loop task comment create "$TASK_ID" \
+  --content "$RUN_ID comment"
+"$OCTO_CLI_BIN" loop task comment list "$TASK_ID"
+
+"$OCTO_CLI_BIN" loop task subscribe "$TASK_ID"
+"$OCTO_CLI_BIN" loop task subscriber list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task unsubscribe "$TASK_ID"
+
+"$OCTO_CLI_BIN" loop task reaction add "$TASK_ID" --emoji "thumbsup"
+"$OCTO_CLI_BIN" loop task reaction remove "$TASK_ID" --emoji "thumbsup"
+
+METADATA_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+"$OCTO_CLI_BIN" loop task metadata set "$TASK_ID" "$METADATA_ID" \
+  --data "$(jq -nc --arg run "$RUN_ID" '{value:{integration_run:$run}}')"
+"$OCTO_CLI_BIN" loop task metadata list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task metadata delete "$TASK_ID" "$METADATA_ID"
+
+"$OCTO_CLI_BIN" loop task label add "$TASK_ID" \
+  --label-id "$LOOP_TEST_LABEL_ID"
+"$OCTO_CLI_BIN" loop task label list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task label remove "$TASK_ID" "$LOOP_TEST_LABEL_ID"
+
+"$OCTO_CLI_BIN" loop task usage "$TASK_ID"
+"$OCTO_CLI_BIN" loop task attachment list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task pull-request list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task delete "$TASK_ID"
+```
+
+### Expert commands
+
+```bash
+"$OCTO_CLI_BIN" loop expert create --data "$EXPERT_CREATE_BODY"
+"$OCTO_CLI_BIN" loop expert get "$EXPERT_ID"
+"$OCTO_CLI_BIN" loop expert update "$EXPERT_ID" --data "$EXPERT_UPDATE_BODY"
+
+"$OCTO_CLI_BIN" loop expert environment get "$EXPERT_ID"
+"$OCTO_CLI_BIN" loop expert environment update "$EXPERT_ID" \
+  --data '{"custom_env":{"OCTO_CLI_INTEGRATION":"true"}}'
+
+"$OCTO_CLI_BIN" loop expert skill add "$EXPERT_ID" \
+  --data "$(jq -nc --arg id "$LOOP_TEST_SKILL_ID" '{skill_ids:[$id]}')"
+"$OCTO_CLI_BIN" loop expert skill list "$EXPERT_ID"
+"$OCTO_CLI_BIN" loop expert skill replace "$EXPERT_ID" \
+  --data '{"skill_ids":[]}'
+
+"$OCTO_CLI_BIN" loop expert execution list "$EXPERT_ID"
+"$OCTO_CLI_BIN" loop expert archive "$EXPERT_ID"
+"$OCTO_CLI_BIN" loop expert restore "$EXPERT_ID"
+
+"$OCTO_CLI_BIN" loop expert create-from-template \
+  --data "$EXPERT_FROM_TEMPLATE_BODY"
+```
+
+### Expert-team commands
+
+```bash
+"$OCTO_CLI_BIN" loop expert-team create --data "$TEAM_CREATE_BODY"
+"$OCTO_CLI_BIN" loop expert-team get "$TEAM_ID"
+"$OCTO_CLI_BIN" loop expert-team update "$TEAM_ID" --data "$TEAM_UPDATE_BODY"
+"$OCTO_CLI_BIN" loop expert-team member list "$TEAM_ID"
+
+TEAM_MEMBER_BODY=$(jq -nc --arg id "$EXPERT_B_ID" \
+  '{member_type:"expert",member_id:$id,role:"member"}')
+"$OCTO_CLI_BIN" loop expert-team member add "$TEAM_ID" \
+  --data "$TEAM_MEMBER_BODY"
+"$OCTO_CLI_BIN" loop expert-team member update "$TEAM_ID" \
+  --data "$TEAM_MEMBER_BODY"
+"$OCTO_CLI_BIN" loop expert-team member-status list "$TEAM_ID"
+"$OCTO_CLI_BIN" loop expert-team member remove "$TEAM_ID" \
+  --data "$(jq -nc --arg id "$EXPERT_B_ID" \
+    '{member_type:"expert",member_id:$id}')"
+"$OCTO_CLI_BIN" loop expert-team delete "$TEAM_ID"
+```
+
+### Execution commands
+
+```bash
+"$OCTO_CLI_BIN" loop task active-execution list "$TASK_ID"
+"$OCTO_CLI_BIN" loop task execution list "$TASK_ID"
+"$OCTO_CLI_BIN" loop execution message list "$EXECUTION_ID"
+"$OCTO_CLI_BIN" loop task execution cancel "$TASK_ID" "$EXECUTION_ID"
+"$OCTO_CLI_BIN" loop execution cancel "$EXECUTION_ID"
+"$OCTO_CLI_BIN" loop task rerun "$TASK_ID" \
+  --data "$(jq -nc --arg id "$EXECUTION_ID" '{execution_id:$id}')"
+```
+
+Before implementing the runner, execute `--help` for every leaf command and pin
+the command syntax in a shell test. This prevents an OpenAPI operation rename
+from silently changing the generated Cobra tree.
+
+## 7. Cleanup order
+
+Cleanup runs even when assertions fail:
+
+1. cancel any active test executions;
+2. delete test tasks;
+3. remove non-leader team members;
+4. delete expert teams;
+5. archive created experts;
+6. stop or release dedicated runtime/daemon fixtures;
+7. remove temporary config and unredacted temporary response files.
+
+Every cleanup result appears in the report. Cleanup failure changes the run
+status to `FAIL-CLEANUP` and prints the resource IDs for an operator, but never
+prints credentials.
+
+## 8. Known blockers before claiming full coverage
+
+1. **CLI required-body validation:** `task.create --data '{}'` currently passes
+   local dry-run despite `title` being required. The live suite must record the
+   Fleet response until CLI validation is fixed.
+2. **Expert-team member schema:** the OpenAPI schema uses `allOf`; the CLI schema
+   loader currently shows an empty request body for member add/update. Explicit
+   `--data` still transports the body, but schema discovery/validation coverage
+   is incomplete.
+3. **Runtime fixture:** expert creation cannot run without a valid runtime.
+4. **Execution fixture:** execution behavior cannot run without an online
+   daemon consuming tasks.
+5. **Expert cleanup:** public API can archive but cannot delete experts.
+6. **Task search parameters:** `task.search` currently exposes only `page` and
+   `page_size`; no keyword or filter parameter is defined, so the live suite
+   cannot perform a deterministic run-ID search.
+
+## 9. Pass criteria
+
+The release gate is satisfied only when:
+
+- all mandatory Level 0 and Level 1 cases pass;
+- Levels 2 and 3 pass with provisioned runtime fixtures;
+- Level 4 passes with a healthy online daemon;
+- cross-Space read and write attempts are rejected;
+- all created tasks and teams are deleted and experts archived;
+- no full credential appears in output or reports;
+- no unexpected 5xx, panic, malformed envelope or vocabulary leak occurs;
+- the two known CLI schema/validation gaps are fixed or explicitly accepted as
+  release exceptions;
+- the generated report contains commands, exit codes, sanitized responses,
+  timings, cleanup results and fixture IDs.
+
+Final statuses:
+
+- `PASS`: all mandatory and provisioned optional levels pass.
+- `CONDITIONAL PASS`: core levels pass; optional fixture-dependent levels are
+  `SKIP` with approved reasons.
+- `FAIL`: assertion, security, cleanup or unexpected server error.
+- `BLOCKED`: Fleet, identity, runtime or daemon prerequisite is unavailable.

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -352,7 +352,7 @@ func WrapCLIError(err error) error {
 	case strings.Contains(lower, "octo_bot_token"),
 		strings.Contains(lower, "bot token"),
 		strings.Contains(lower, "token is required"):
-		return output.ErrAuth(msg, "set OCTO_BOT_TOKEN to an app_* or bf_* token")
+		return output.ErrAuth(msg, "set OCTO_BOT_TOKEN to an Octo or Loop bearer credential")
 	case strings.Contains(lower, "unknown flag"),
 		strings.Contains(lower, "unknown command"),
 		strings.Contains(lower, "unknown subcommand"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,11 @@ import (
 
 // Environment variable names. Centralised for testability and discoverability.
 const (
-	EnvAPIBaseURL = "OCTO_API_BASE_URL"
-	EnvBotToken   = "OCTO_BOT_TOKEN"
-	EnvSpaceID    = "OCTO_SPACE_ID"
-	EnvFormat     = "OCTO_FORMAT"
+	EnvAPIBaseURL     = "OCTO_API_BASE_URL"
+	EnvLoopAPIBaseURL = "OCTO_LOOP_API_BASE_URL"
+	EnvBotToken       = "OCTO_BOT_TOKEN"
+	EnvSpaceID        = "OCTO_SPACE_ID"
+	EnvFormat         = "OCTO_FORMAT"
 	// EnvBotID is the env form of --bot-id: a robot id that selects a stored
 	// credential profile. It is a selector, not a secret (cf. EnvBotToken).
 	EnvBotID = "OCTO_BOT_ID"
@@ -27,7 +28,10 @@ type Config struct {
 	// APIBaseURL is the unified base URL for all backend services.
 	// Set via OCTO_API_BASE_URL.
 	APIBaseURL string
-	// BotToken is the App Bot token (OCTO_BOT_TOKEN).
+	// LoopAPIBaseURL is the optional Fleet/Loop endpoint. Empty means the
+	// unified API base URL is used.
+	LoopAPIBaseURL string
+	// BotToken is the active Octo or Loop bearer credential.
 	BotToken string
 	// SpaceID is the platform-bot space context (OCTO_SPACE_ID). Optional for space-scoped bots.
 	SpaceID string
@@ -38,10 +42,11 @@ type Config struct {
 // Load reads configuration from the environment.
 func Load() *Config {
 	return &Config{
-		APIBaseURL: envOrDefault(EnvAPIBaseURL, "http://127.0.0.1:8080"),
-		BotToken:   os.Getenv(EnvBotToken),
-		SpaceID:    os.Getenv(EnvSpaceID),
-		Format:     envOrDefault(EnvFormat, "json"),
+		APIBaseURL:     envOrDefault(EnvAPIBaseURL, "http://127.0.0.1:8080"),
+		LoopAPIBaseURL: os.Getenv(EnvLoopAPIBaseURL),
+		BotToken:       os.Getenv(EnvBotToken),
+		SpaceID:        os.Getenv(EnvSpaceID),
+		Format:         envOrDefault(EnvFormat, "json"),
 	}
 }
 
@@ -50,7 +55,7 @@ func Load() *Config {
 // is space- or platform-scoped from the spec).
 func (c *Config) Validate() error {
 	if c.BotToken == "" {
-		return fmt.Errorf("%s is required (App Bot token, app_*)", EnvBotToken)
+		return fmt.Errorf("%s is required (Octo or Loop bearer credential)", EnvBotToken)
 	}
 	return nil
 }
@@ -60,6 +65,9 @@ func (c *Config) Validate() error {
 // for interface compatibility so the client and service engine don't need
 // to change their routing logic.
 func (c *Config) ServiceURL(service string) string {
+	if service == "loop" && c.LoopAPIBaseURL != "" {
+		return c.LoopAPIBaseURL
+	}
 	return c.APIBaseURL
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,3 +63,16 @@ func TestServiceURL_Unified(t *testing.T) {
 		}
 	}
 }
+
+func TestServiceURL_LoopOverride(t *testing.T) {
+	cfg := &Config{
+		APIBaseURL:     "http://api.example",
+		LoopAPIBaseURL: "http://fleet.example",
+	}
+	if got := cfg.ServiceURL("loop"); got != "http://fleet.example" {
+		t.Fatalf("ServiceURL(loop) = %q", got)
+	}
+	if got := cfg.ServiceURL("message"); got != "http://api.example" {
+		t.Fatalf("ServiceURL(message) = %q", got)
+	}
+}

--- a/internal/credential/env_provider.go
+++ b/internal/credential/env_provider.go
@@ -6,7 +6,7 @@ import (
 )
 
 // EnvProvider reads the bot credential from environment variables.
-// OCTO_BOT_TOKEN holds one of the three token kinds (app_*, bf_*, or uk_*).
+// OCTO_BOT_TOKEN holds an Octo or Loop bearer credential.
 // OCTO_SPACE_ID is optional and only required for platform-scoped bots.
 type EnvProvider struct {
 	// TokenVar is the env var holding the token. Defaults to OCTO_BOT_TOKEN.

--- a/internal/credential/token.go
+++ b/internal/credential/token.go
@@ -1,17 +1,16 @@
 package credential
 
-// Token prefixes route a bot token to its kind. app_* is an App Bot; bf_* is a
-// User Bot; uk_* is a user API key (real-person identity, used for message
-// search). The prefix is the only thing the CLI inspects — routing is otherwise
-// server-side.
+// Token prefixes describe the credential format. They never determine a Loop
+// principal class; Fleet derives human/device/execution identity only after
+// server-side verification.
 const (
 	prefixApp     = "app_"
 	prefixUser    = "bf_"
 	prefixUserKey = "uk_"
+	prefixLoop    = "octo_loop_"
 )
 
-// TokenKind classifies a token by its prefix: "app_bot", "user_bot",
-// "user_key", or "unknown". An empty token returns "".
+// TokenKind classifies only the token format. An empty token returns "".
 func TokenKind(tok string) string {
 	switch {
 	case tok == "":
@@ -22,6 +21,8 @@ func TokenKind(tok string) string {
 		return "user_bot"
 	case hasPrefix(tok, prefixUserKey):
 		return "user_key"
+	case hasPrefix(tok, prefixLoop):
+		return "loop_credential"
 	}
 	return "unknown"
 }
@@ -53,6 +54,8 @@ func MaskToken(tok string) string {
 		prefix = prefixUser
 	case hasPrefix(tok, prefixUserKey):
 		prefix = prefixUserKey
+	case hasPrefix(tok, prefixLoop):
+		prefix = prefixLoop
 	default:
 		// Unknown kind: reveal nothing. Without a recognized prefix there is no
 		// way to say what the revealed head/tail belong to, so don't leak it.

--- a/internal/credential/token_test.go
+++ b/internal/credential/token_test.go
@@ -27,8 +27,9 @@ func TestMaskToken(t *testing.T) {
 		{"", ""},
 		{"app_abcdefgh12345678", "app_ab***5678"},
 		{"bf_something", "bf_so***hing"},
-		{"app_tiny", "app_***"},         // body "tiny" too short
-		{"bf_xx", "bf_***"},             // body too short
+		{"app_tiny", "app_***"}, // body "tiny" too short
+		{"bf_xx", "bf_***"},     // body too short
+		{"octo_loop_abcdefghijk", "octo_loop_ab***hijk"},
 		{"short", "***"},                // unknown prefix
 		{"unknown_format_token", "***"}, // unknown prefix: reveal nothing
 	}
@@ -41,6 +42,12 @@ func TestMaskToken(t *testing.T) {
 		if c.in != "" && got != "" && strings.Contains(got, "****") {
 			t.Errorf("MaskToken(%q) = %q leaks length via variable asterisks", c.in, got)
 		}
+	}
+}
+
+func TestTokenKindLoopDoesNotInferPrincipal(t *testing.T) {
+	if got := TokenKind("octo_loop_abcdefghijk"); got != "loop_credential" {
+		t.Fatalf("TokenKind = %q", got)
 	}
 }
 

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -346,49 +346,8 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 		}
 	}
 
-	if params, ok := op["parameters"].([]any); ok {
-		for _, p := range params {
-			pm, ok := p.(map[string]any)
-			if !ok {
-				continue
-			}
-			if ref := stringOf(pm["$ref"]); ref != "" {
-				pm = followComponentRef(doc, ref, "parameters")
-				if pm == nil {
-					continue
-				}
-			}
-			pi := ParamInfo{
-				Name:        stringOf(pm["name"]),
-				In:          stringOf(pm["in"]),
-				Required:    boolOf(pm["required"]),
-				Description: stringOf(pm["description"]),
-				FlagName:    stringOf(pm["x-octo-flag"]),
-			}
-			if sch, ok := pm["schema"].(map[string]any); ok {
-				pi.Type = stringOf(sch["type"])
-				pi.Default = sch["default"]
-				if items, ok := sch["items"].(map[string]any); ok {
-					resolved := resolveSchema(doc, items)
-					pi.Items = &resolved
-				}
-				if enum, ok := sch["enum"].([]any); ok {
-					pi.Enum = enum
-				}
-			}
-			d.Parameters = append(d.Parameters, pi)
-		}
-	}
-
-	if body, ok := op["requestBody"].(map[string]any); ok {
-		if ref := stringOf(body["$ref"]); ref != "" {
-			body = followComponentRef(doc, ref, "requestBodies")
-		}
-		if s := extractJSONSchema(body); s != nil {
-			resolved := resolveSchema(doc, s)
-			d.RequestBody = &resolved
-		}
-	}
+	d.Parameters = operationParameters(doc, op)
+	d.RequestBody = operationRequestBody(doc, op)
 
 	if resps, ok := op["responses"].(map[string]any); ok {
 		d.ResponseSchema = firstSuccessSchema(doc, resps)
@@ -404,6 +363,58 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 	}
 
 	return d
+}
+
+func operationParameters(doc, op map[string]any) []ParamInfo {
+	params, _ := op["parameters"].([]any)
+	result := make([]ParamInfo, 0, len(params))
+	for _, raw := range params {
+		pm, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ref := stringOf(pm["$ref"]); ref != "" {
+			pm = followComponentRef(doc, ref, "parameters")
+			if pm == nil {
+				continue
+			}
+		}
+		parameter := ParamInfo{
+			Name:        stringOf(pm["name"]),
+			In:          stringOf(pm["in"]),
+			Required:    boolOf(pm["required"]),
+			Description: stringOf(pm["description"]),
+			FlagName:    stringOf(pm["x-octo-flag"]),
+		}
+		if schema, ok := pm["schema"].(map[string]any); ok {
+			parameter.Type = stringOf(schema["type"])
+			parameter.Default = schema["default"]
+			if items, ok := schema["items"].(map[string]any); ok {
+				resolved := resolveSchema(doc, items)
+				parameter.Items = &resolved
+			}
+			if enum, ok := schema["enum"].([]any); ok {
+				parameter.Enum = enum
+			}
+		}
+		result = append(result, parameter)
+	}
+	return result
+}
+
+func operationRequestBody(doc, op map[string]any) *SchemaInfo {
+	body, ok := op["requestBody"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if ref := stringOf(body["$ref"]); ref != "" {
+		body = followComponentRef(doc, ref, "requestBodies")
+	}
+	if schema := extractJSONSchema(body); schema != nil {
+		resolved := resolveSchema(doc, schema)
+		return &resolved
+	}
+	return nil
 }
 
 func extractJSONSchema(body map[string]any) map[string]any {

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -352,6 +352,12 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 			if !ok {
 				continue
 			}
+			if ref := stringOf(pm["$ref"]); ref != "" {
+				pm = followComponentRef(doc, ref, "parameters")
+				if pm == nil {
+					continue
+				}
+			}
 			pi := ParamInfo{
 				Name:        stringOf(pm["name"]),
 				In:          stringOf(pm["in"]),
@@ -375,6 +381,9 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 	}
 
 	if body, ok := op["requestBody"].(map[string]any); ok {
+		if ref := stringOf(body["$ref"]); ref != "" {
+			body = followComponentRef(doc, ref, "requestBodies")
+		}
 		if s := extractJSONSchema(body); s != nil {
 			resolved := resolveSchema(doc, s)
 			d.RequestBody = &resolved
@@ -457,7 +466,11 @@ func hasSuccessBody(doc, resps map[string]any) bool {
 // followResponseRef resolves a `#/components/responses/<name>` pointer to its
 // response object. It returns nil for any other ref shape or an unknown name.
 func followResponseRef(doc map[string]any, ref string) map[string]any {
-	const prefix = "#/components/responses/"
+	return followComponentRef(doc, ref, "responses")
+}
+
+func followComponentRef(doc map[string]any, ref, section string) map[string]any {
+	prefix := "#/components/" + section + "/"
 	if !strings.HasPrefix(ref, prefix) {
 		return nil
 	}
@@ -466,11 +479,11 @@ func followResponseRef(doc map[string]any, ref string) map[string]any {
 	if !ok {
 		return nil
 	}
-	responses, ok := comps["responses"].(map[string]any)
+	entries, ok := comps[section].(map[string]any)
 	if !ok {
 		return nil
 	}
-	s, _ := responses[name].(map[string]any)
+	s, _ := entries[name].(map[string]any)
 	return s
 }
 
@@ -479,6 +492,9 @@ func firstSuccessSchema(doc, resps map[string]any) *SchemaInfo {
 	order := []string{"200", "201", "204"}
 	for _, code := range order {
 		if r, ok := resps[code].(map[string]any); ok {
+			if ref := stringOf(r["$ref"]); ref != "" {
+				r = followResponseRef(doc, ref)
+			}
 			if s := extractJSONSchema(r); s != nil {
 				resolved := resolveSchema(doc, s)
 				return &resolved

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -46,7 +46,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"html":        20,
 		"marketplace": 25,
 		"summary":     3,
-		"loop":        61,
+		"loop":        136,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -68,7 +68,7 @@ func TestLoopPublicContractResolvesSharedComponents(t *testing.T) {
 	if !ok {
 		t.Fatal("task.create: not found")
 	}
-	if create.Path != "/api/v1/tasks" || create.BaseURLEnv != "OCTO_LOOP_API_BASE_URL" {
+	if create.Path != "/v1/tasks" || create.BaseURLEnv != "OCTO_LOOP_API_BASE_URL" {
 		t.Fatalf("task.create route = %s (%s)", create.Path, create.BaseURLEnv)
 	}
 	if create.RequestBody == nil {
@@ -84,6 +84,44 @@ func TestLoopPublicContractResolvesSharedComponents(t *testing.T) {
 	}
 	if len(list.Parameters) < 2 || list.Parameters[0].Name == "" {
 		t.Fatalf("task.list parameter refs were not resolved: %+v", list.Parameters)
+	}
+}
+
+func TestLoopExtendedBusinessContract(t *testing.T) {
+	r := MustNew()
+	for _, id := range []string{
+		"workspace.list",
+		"label.create",
+		"project.resource.create",
+		"comment.reaction.add",
+		"attachment.upload",
+		"loop.skill.list",
+		"runtime.update_request.create",
+		"autopilot.delivery.replay",
+		"task.team_evaluation.record",
+	} {
+		op, ok := r.GetOperation(id)
+		if !ok {
+			t.Errorf("%s: not found", id)
+			continue
+		}
+		if op.Service != "loop" || !strings.HasPrefix(op.Path, "/v1/") {
+			t.Errorf("%s: got service=%q path=%q", id, op.Service, op.Path)
+		}
+	}
+
+	op, ok := r.GetOperation("label.list")
+	if !ok {
+		t.Fatal("label.list: not found")
+	}
+	foundWorkspaceHeader := false
+	for _, parameter := range op.Parameters {
+		if parameter.Name == "X-Workspace-ID" && parameter.In == "header" && parameter.FlagName == "workspace-id" {
+			foundWorkspaceHeader = true
+		}
+	}
+	if !foundWorkspaceHeader {
+		t.Errorf("label.list parameters = %+v, want X-Workspace-ID workspace-id flag", op.Parameters)
 	}
 }
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -11,7 +11,7 @@ func TestNewLoadsAllServices(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 	got := r.ListServices()
-	want := []string{"bot", "docs", "event", "file", "group", "html", "marketplace", "matter", "message", "summary", "thread"}
+	want := []string{"bot", "docs", "event", "file", "group", "html", "loop", "marketplace", "matter", "message", "summary", "thread"}
 	if len(got) != len(want) {
 		t.Fatalf("ListServices: got %d services, want %d (%v)", len(got), len(want), got)
 	}
@@ -46,6 +46,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"html":        20,
 		"marketplace": 25,
 		"summary":     3,
+		"loop":        61,
 	}
 	totalWant := 0
 	for svc, want := range expected {
@@ -58,6 +59,31 @@ func TestAllDomainOperationCounts(t *testing.T) {
 	all := r.ListAllOperations()
 	if len(all) != totalWant {
 		t.Errorf("ListAllOperations: got %d, want %d", len(all), totalWant)
+	}
+}
+
+func TestLoopPublicContractResolvesSharedComponents(t *testing.T) {
+	r := MustNew()
+	create, ok := r.GetOperation("task.create")
+	if !ok {
+		t.Fatal("task.create: not found")
+	}
+	if create.Path != "/api/v1/tasks" || create.BaseURLEnv != "OCTO_LOOP_API_BASE_URL" {
+		t.Fatalf("task.create route = %s (%s)", create.Path, create.BaseURLEnv)
+	}
+	if create.RequestBody == nil {
+		t.Fatal("task.create request body ref was not resolved")
+	}
+	if _, ok := create.RequestBody.Properties["title"]; !ok {
+		t.Fatalf("task.create body properties = %v", create.RequestBody.Properties)
+	}
+
+	list, ok := r.GetOperation("task.list")
+	if !ok {
+		t.Fatal("task.list: not found")
+	}
+	if len(list.Parameters) < 2 || list.Parameters[0].Name == "" {
+		t.Fatalf("task.list parameter refs were not resolved: %+v", list.Parameters)
 	}
 }
 

--- a/internal/registry/specs/loop.json
+++ b/internal/registry/specs/loop.json
@@ -28,11 +28,43 @@
     {
       "name": "expert_teams",
       "description": "Expert team and membership operations."
+    },
+    {
+      "name": "skills",
+      "description": "Skills operations."
+    },
+    {
+      "name": "workspaces",
+      "description": "Workspaces operations."
+    },
+    {
+      "name": "labels",
+      "description": "Labels operations."
+    },
+    {
+      "name": "projects",
+      "description": "Projects operations."
+    },
+    {
+      "name": "comments",
+      "description": "Comments operations."
+    },
+    {
+      "name": "attachments",
+      "description": "Attachments operations."
+    },
+    {
+      "name": "runtimes",
+      "description": "Runtimes operations."
+    },
+    {
+      "name": "autopilots",
+      "description": "Autopilots operations."
     }
   ],
   "servers": [
     {
-      "url": "/api/v1"
+      "url": "/v1"
     }
   ],
   "security": [
@@ -68,7 +100,7 @@
     }
   },
   "paths": {
-    "/api/v1/tasks": {
+    "/v1/tasks": {
       "get": {
         "summary": "List tasks",
         "description": "Returns one workspace-scoped page of tasks.",
@@ -143,7 +175,7 @@
         }
       }
     },
-    "/api/v1/tasks/_search": {
+    "/v1/tasks/_search": {
       "get": {
         "summary": "Search tasks",
         "description": "Searches tasks using public task and assignee vocabulary.",
@@ -184,7 +216,7 @@
         }
       }
     },
-    "/api/v1/tasks/_grouped": {
+    "/v1/tasks/_grouped": {
       "get": {
         "summary": "Group tasks",
         "description": "Returns task groups using the requested grouping filters.",
@@ -217,7 +249,7 @@
         }
       }
     },
-    "/api/v1/tasks/_child_progress": {
+    "/v1/tasks/_child_progress": {
       "get": {
         "summary": "Get child progress",
         "description": "Aggregates child-task progress for the requested parents.",
@@ -250,7 +282,7 @@
         }
       }
     },
-    "/api/v1/tasks/_children_by_parent": {
+    "/v1/tasks/_children_by_parent": {
       "get": {
         "summary": "List children by parent",
         "description": "Returns one page of child tasks grouped by parent selection.",
@@ -291,7 +323,7 @@
         }
       }
     },
-    "/api/v1/tasks/_quick_create": {
+    "/v1/tasks/_quick_create": {
       "post": {
         "summary": "Queue task creation",
         "description": "Creates and dispatches a task to exactly one expert or expert team.",
@@ -327,7 +359,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}": {
+    "/v1/tasks/{task_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -430,7 +462,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/comments": {
+    "/v1/tasks/{task_id}/comments": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -510,7 +542,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/comments/_trigger_preview": {
+    "/v1/tasks/{task_id}/comments/_trigger_preview": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -551,7 +583,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/timeline": {
+    "/v1/tasks/{task_id}/timeline": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -597,7 +629,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/subscribers": {
+    "/v1/tasks/{task_id}/subscribers": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -643,7 +675,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/subscribe": {
+    "/v1/tasks/{task_id}/subscribe": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -684,7 +716,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/unsubscribe": {
+    "/v1/tasks/{task_id}/unsubscribe": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -725,7 +757,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/executions": {
+    "/v1/tasks/{task_id}/executions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -771,7 +803,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/active_executions": {
+    "/v1/tasks/{task_id}/active_executions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -817,7 +849,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/rerun": {
+    "/v1/tasks/{task_id}/rerun": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -858,7 +890,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/executions/{execution_id}/cancel": {
+    "/v1/tasks/{task_id}/executions/{execution_id}/cancel": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -899,7 +931,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/usage": {
+    "/v1/tasks/{task_id}/usage": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -937,7 +969,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/reactions": {
+    "/v1/tasks/{task_id}/reactions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1012,7 +1044,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/attachments": {
+    "/v1/tasks/{task_id}/attachments": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1058,7 +1090,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/children": {
+    "/v1/tasks/{task_id}/children": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1104,7 +1136,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/labels": {
+    "/v1/tasks/{task_id}/labels": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1184,7 +1216,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/labels/{label_id}": {
+    "/v1/tasks/{task_id}/labels/{label_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1225,7 +1257,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/metadata": {
+    "/v1/tasks/{task_id}/metadata": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1263,7 +1295,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/metadata/{metadata_id}": {
+    "/v1/tasks/{task_id}/metadata/{metadata_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1338,7 +1370,7 @@
         }
       }
     },
-    "/api/v1/tasks/{task_id}/pull_requests": {
+    "/v1/tasks/{task_id}/pull_requests": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TaskID"
@@ -1384,7 +1416,7 @@
         }
       }
     },
-    "/api/v1/executions/{execution_id}/messages": {
+    "/v1/executions/{execution_id}/messages": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExecutionID"
@@ -1430,7 +1462,7 @@
         }
       }
     },
-    "/api/v1/executions/{execution_id}/cancel": {
+    "/v1/executions/{execution_id}/cancel": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExecutionID"
@@ -1468,7 +1500,7 @@
         }
       }
     },
-    "/api/v1/experts": {
+    "/v1/experts": {
       "get": {
         "summary": "List experts",
         "description": "Returns one page of experts in the current workspace.",
@@ -1543,7 +1575,7 @@
         }
       }
     },
-    "/api/v1/experts/_from_template": {
+    "/v1/experts/_from_template": {
       "post": {
         "summary": "Create expert from template",
         "description": "Instantiates an expert from the selected template.",
@@ -1579,7 +1611,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}": {
+    "/v1/experts/{expert_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1651,7 +1683,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/archive": {
+    "/v1/experts/{expert_id}/archive": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1689,7 +1721,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/restore": {
+    "/v1/experts/{expert_id}/restore": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1727,7 +1759,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/executions/cancel": {
+    "/v1/experts/{expert_id}/executions/cancel": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1765,7 +1797,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/executions": {
+    "/v1/experts/{expert_id}/executions": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1811,7 +1843,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/skills": {
+    "/v1/experts/{expert_id}/skills": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1925,7 +1957,7 @@
         }
       }
     },
-    "/api/v1/experts/{expert_id}/env": {
+    "/v1/experts/{expert_id}/env": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertID"
@@ -1997,7 +2029,7 @@
         }
       }
     },
-    "/api/v1/expert_templates": {
+    "/v1/expert_templates": {
       "get": {
         "summary": "List expert templates",
         "description": "Returns one page of templates available to the workspace.",
@@ -2038,7 +2070,7 @@
         }
       }
     },
-    "/api/v1/expert_templates/{template_id}": {
+    "/v1/expert_templates/{template_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/TemplateID"
@@ -2076,7 +2108,7 @@
         }
       }
     },
-    "/api/v1/expert_teams": {
+    "/v1/expert_teams": {
       "get": {
         "summary": "List expert teams",
         "description": "Returns one page of expert teams in the workspace.",
@@ -2151,7 +2183,7 @@
         }
       }
     },
-    "/api/v1/expert_teams/{expert_team_id}": {
+    "/v1/expert_teams/{expert_team_id}": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertTeamID"
@@ -2254,7 +2286,7 @@
         }
       }
     },
-    "/api/v1/expert_teams/{expert_team_id}/members": {
+    "/v1/expert_teams/{expert_team_id}/members": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertTeamID"
@@ -2368,7 +2400,7 @@
         }
       }
     },
-    "/api/v1/expert_teams/{expert_team_id}/members/role": {
+    "/v1/expert_teams/{expert_team_id}/members/role": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertTeamID"
@@ -2409,7 +2441,7 @@
         }
       }
     },
-    "/api/v1/expert_teams/{expert_team_id}/member_statuses": {
+    "/v1/expert_teams/{expert_team_id}/member_statuses": {
       "parameters": [
         {
           "$ref": "#/components/parameters/ExpertTeamID"
@@ -2442,6 +2474,4001 @@
             "$ref": "#/components/responses/InternalError"
           },
           "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/workspaces": {
+      "get": {
+        "summary": "List workspaces",
+        "description": "List workspaces in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create workspace",
+        "description": "Create workspace in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/workspaces/{workspace_id}": {
+      "get": {
+        "summary": "Get workspace",
+        "description": "Get workspace in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update workspace",
+        "description": "Update workspace in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.update",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete workspace",
+        "description": "Delete workspace in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/workspaces/{workspace_id}/members": {
+      "get": {
+        "summary": "List workspace members",
+        "description": "List workspace members in the authenticated workspace.",
+        "tags": [
+          "workspaces"
+        ],
+        "operationId": "workspace.member.list",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/labels": {
+      "get": {
+        "summary": "List labels",
+        "description": "List labels in the authenticated workspace.",
+        "tags": [
+          "labels"
+        ],
+        "operationId": "label.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create label",
+        "description": "Create label in the authenticated workspace.",
+        "tags": [
+          "labels"
+        ],
+        "operationId": "label.create",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/labels/{label_id}": {
+      "get": {
+        "summary": "Get label",
+        "description": "Get label in the authenticated workspace.",
+        "tags": [
+          "labels"
+        ],
+        "operationId": "label.get",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update label",
+        "description": "Update label in the authenticated workspace.",
+        "tags": [
+          "labels"
+        ],
+        "operationId": "label.update",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete label",
+        "description": "Delete label in the authenticated workspace.",
+        "tags": [
+          "labels"
+        ],
+        "operationId": "label.delete",
+        "parameters": [
+          {
+            "name": "label_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/projects/_search": {
+      "get": {
+        "summary": "Search projects",
+        "description": "Search projects in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include_closed",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/projects": {
+      "get": {
+        "summary": "List projects",
+        "description": "List projects in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create project",
+        "description": "Create project in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.create",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "priority",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}": {
+      "get": {
+        "summary": "Get project",
+        "description": "Get project in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update project",
+        "description": "Update project in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.update",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete project",
+        "description": "Delete project in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/resources": {
+      "get": {
+        "summary": "List project resources",
+        "description": "List project resources in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.resource.list",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create project resource",
+        "description": "Create project resource in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.resource.create",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/projects/{project_id}/resources/{project_resource_id}": {
+      "patch": {
+        "summary": "Update project resource",
+        "description": "Update project resource in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.resource.update",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "project_resource_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete project resource",
+        "description": "Delete project resource in the authenticated workspace.",
+        "tags": [
+          "projects"
+        ],
+        "operationId": "project.resource.delete",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "project_resource_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/comments/{comment_id}": {
+      "patch": {
+        "summary": "Update comment",
+        "description": "Update comment in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.update",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete comment",
+        "description": "Delete comment in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.delete",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/comments/{comment_id}/resolve": {
+      "post": {
+        "summary": "Resolve comment",
+        "description": "Resolve comment in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.resolve",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/comments/{comment_id}/reopen": {
+      "post": {
+        "summary": "Reopen comment",
+        "description": "Reopen comment in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.reopen",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/comments/{comment_id}/reactions": {
+      "post": {
+        "summary": "Add comment reaction",
+        "description": "Add comment reaction in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.reaction.add",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove comment reaction",
+        "description": "Remove comment reaction in the authenticated workspace.",
+        "tags": [
+          "comments"
+        ],
+        "operationId": "comment.reaction.remove",
+        "parameters": [
+          {
+            "name": "comment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/attachments": {
+      "post": {
+        "summary": "Upload attachment",
+        "description": "Upload attachment in the authenticated workspace.",
+        "tags": [
+          "attachments"
+        ],
+        "operationId": "attachment.upload",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/AttachmentUpload"
+              }
+            }
+          }
+        },
+        "x-octo-multipart": true,
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/attachments/{attachment_id}": {
+      "get": {
+        "summary": "Get attachment",
+        "description": "Get attachment in the authenticated workspace.",
+        "tags": [
+          "attachments"
+        ],
+        "operationId": "attachment.get",
+        "parameters": [
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete attachment",
+        "description": "Delete attachment in the authenticated workspace.",
+        "tags": [
+          "attachments"
+        ],
+        "operationId": "attachment.delete",
+        "parameters": [
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/attachments/{attachment_id}/content": {
+      "get": {
+        "summary": "Get attachment content",
+        "description": "Get attachment content in the authenticated workspace.",
+        "tags": [
+          "attachments"
+        ],
+        "operationId": "attachment.content.get",
+        "parameters": [
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "x-octo-binary-response": true,
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "description": "Binary content.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/attachments/{attachment_id}/download": {
+      "get": {
+        "summary": "Download attachment",
+        "description": "Download attachment in the authenticated workspace.",
+        "tags": [
+          "attachments"
+        ],
+        "operationId": "attachment.download",
+        "parameters": [
+          {
+            "name": "attachment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "x-octo-binary-response": true,
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "description": "Binary content.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/skills/_search": {
+      "get": {
+        "summary": "Search skills",
+        "description": "Search skills in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/skills/_import": {
+      "post": {
+        "summary": "Import skill",
+        "description": "Import skill in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.import",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/skills": {
+      "get": {
+        "summary": "List skills",
+        "description": "List skills in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create skill",
+        "description": "Create skill in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.create",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/skills/{skill_id}": {
+      "get": {
+        "summary": "Get skill",
+        "description": "Get skill in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.get",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update skill",
+        "description": "Update skill in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.update",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete skill",
+        "description": "Delete skill in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill.delete",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/skills/{skill_id}/files": {
+      "get": {
+        "summary": "List skill files",
+        "description": "List skill files in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill_file.list",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "put": {
+        "summary": "Create or update skill file",
+        "description": "Create or update skill file in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill_file.upsert",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/skills/{skill_id}/files/{skill_file_id}": {
+      "delete": {
+        "summary": "Delete skill file",
+        "description": "Delete skill file in the authenticated workspace.",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "loop.skill_file.delete",
+        "parameters": [
+          {
+            "name": "skill_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "skill_file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes": {
+      "get": {
+        "summary": "List runtimes",
+        "description": "List runtimes in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "owner",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}": {
+      "patch": {
+        "summary": "Update runtime",
+        "description": "Update runtime in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.update",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete runtime",
+        "description": "Delete runtime in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.delete",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/archive_agents_and_delete": {
+      "post": {
+        "summary": "Archive experts and delete runtime",
+        "description": "Archive experts and delete runtime in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.archive_and_delete",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/usage": {
+      "get": {
+        "summary": "Get runtime usage",
+        "description": "Get runtime usage in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.usage.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tz",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/usage_by_expert": {
+      "get": {
+        "summary": "Get runtime usage by expert",
+        "description": "Get runtime usage by expert in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.usage_by_expert.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tz",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/usage_by_hour": {
+      "get": {
+        "summary": "Get runtime usage by hour",
+        "description": "Get runtime usage by hour in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.usage_by_hour.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tz",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/activity": {
+      "get": {
+        "summary": "List runtime activity",
+        "description": "List runtime activity in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.activity.list",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "tz",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/updates": {
+      "post": {
+        "summary": "Request runtime update",
+        "description": "Request runtime update in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.update_request.create",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/updates/{runtime_update_id}": {
+      "get": {
+        "summary": "Get runtime update request",
+        "description": "Get runtime update request in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.update_request.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "runtime_update_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/model_requests": {
+      "post": {
+        "summary": "Request runtime models",
+        "description": "Request runtime models in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.model_request.create",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/model_requests/{model_request_id}": {
+      "get": {
+        "summary": "Get runtime model request",
+        "description": "Get runtime model request in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.model_request.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "model_request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/local_skill_requests": {
+      "post": {
+        "summary": "Request local skills",
+        "description": "Request local skills in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.local_skill_request.create",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/local_skill_requests/{local_skill_request_id}": {
+      "get": {
+        "summary": "Get local skill request",
+        "description": "Get local skill request in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.local_skill_request.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "local_skill_request_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/local_skill_imports": {
+      "post": {
+        "summary": "Request local skill import",
+        "description": "Request local skill import in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.local_skill_import.create",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/runtimes/{runtime_id}/local_skill_imports/{local_skill_import_id}": {
+      "get": {
+        "summary": "Get local skill import",
+        "description": "Get local skill import in the authenticated workspace.",
+        "tags": [
+          "runtimes"
+        ],
+        "operationId": "runtime.local_skill_import.get",
+        "parameters": [
+          {
+            "name": "runtime_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "local_skill_import_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots": {
+      "get": {
+        "summary": "List autopilots",
+        "description": "List autopilots in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create autopilot",
+        "description": "Create autopilot in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.create",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}": {
+      "get": {
+        "summary": "Get autopilot",
+        "description": "Get autopilot in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.get",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update autopilot",
+        "description": "Update autopilot in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.update",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete autopilot",
+        "description": "Delete autopilot in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.delete",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/trigger": {
+      "post": {
+        "summary": "Trigger autopilot",
+        "description": "Trigger autopilot in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.trigger",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/runs": {
+      "get": {
+        "summary": "List autopilot runs",
+        "description": "List autopilot runs in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.run.list",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/runs/{autopilot_run_id}": {
+      "get": {
+        "summary": "Get autopilot run",
+        "description": "Get autopilot run in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.run.get",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/deliveries": {
+      "get": {
+        "summary": "List autopilot deliveries",
+        "description": "List autopilot deliveries in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.delivery.list",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/deliveries/{autopilot_delivery_id}": {
+      "get": {
+        "summary": "Get autopilot delivery",
+        "description": "Get autopilot delivery in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.delivery.get",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_delivery_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/deliveries/{autopilot_delivery_id}/replay": {
+      "post": {
+        "summary": "Replay autopilot delivery",
+        "description": "Replay autopilot delivery in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.delivery.replay",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_delivery_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/triggers": {
+      "post": {
+        "summary": "Create autopilot trigger",
+        "description": "Create autopilot trigger in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.trigger_config.create",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/triggers/{autopilot_trigger_id}": {
+      "patch": {
+        "summary": "Update autopilot trigger",
+        "description": "Update autopilot trigger in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.trigger_config.update",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_trigger_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete autopilot trigger",
+        "description": "Delete autopilot trigger in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.trigger_config.delete",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_trigger_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/triggers/{autopilot_trigger_id}/rotate_webhook_token": {
+      "post": {
+        "summary": "Rotate autopilot webhook token",
+        "description": "Rotate autopilot webhook token in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.webhook_token.rotate",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_trigger_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/autopilots/{autopilot_id}/triggers/{autopilot_trigger_id}/signing_secret": {
+      "put": {
+        "summary": "Set autopilot signing secret",
+        "description": "Set autopilot signing secret in the authenticated workspace.",
+        "tags": [
+          "autopilots"
+        ],
+        "operationId": "autopilot.signing_secret.set",
+        "parameters": [
+          {
+            "name": "autopilot_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "autopilot_trigger_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/v1/tasks/{task_id}/expert_team_evaluation": {
+      "post": {
+        "summary": "Record expert team evaluation",
+        "description": "Record expert team evaluation in the authenticated workspace.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.team_evaluation.record",
+        "parameters": [
+          {
+            "name": "task_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/WorkspaceIDHeader"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FlexibleRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
             "$ref": "#/components/responses/Resource"
           }
         }
@@ -2550,6 +6577,17 @@
         "description": "Stable expert-template slug or identifier.",
         "schema": {
           "type": "string"
+        }
+      },
+      "WorkspaceIDHeader": {
+        "name": "X-Workspace-ID",
+        "in": "header",
+        "required": false,
+        "description": "Explicit workspace selector for human credentials; workspace-bound Loop credentials may omit it.",
+        "x-octo-flag": "workspace-id",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
         }
       }
     },
@@ -3138,6 +7176,17 @@
             "type": "string",
             "minLength": 1
           },
+          "parent_comment_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "suppress_expert_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
           "attachment_ids": {
             "type": "array",
             "items": {
@@ -3275,6 +7324,31 @@
             }
           }
         ]
+      },
+      "FlexibleRequest": {
+        "type": "object",
+        "description": "Operation-specific request fields. Use CLI --data for fields not exposed as dedicated flags.",
+        "additionalProperties": true
+      },
+      "AttachmentUpload": {
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "task_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "comment_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
       }
     }
   },

--- a/internal/registry/specs/loop.json
+++ b/internal/registry/specs/loop.json
@@ -1,0 +1,3285 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Octo Fleet Public API",
+    "version": "1.0.0",
+    "description": "Stable Fleet API using product vocabulary: task, expert, expert team, and\nexecution. Legacy internal issue, agent, and squad routes remain separate.\n",
+    "contact": {
+      "name": "Octo API Team"
+    }
+  },
+  "tags": [
+    {
+      "name": "tasks",
+      "description": "Task lifecycle, collaboration, and execution operations."
+    },
+    {
+      "name": "executions",
+      "description": "Execution messages and lifecycle operations."
+    },
+    {
+      "name": "experts",
+      "description": "Expert configuration and runtime operations."
+    },
+    {
+      "name": "expert_templates",
+      "description": "Reusable expert templates."
+    },
+    {
+      "name": "expert_teams",
+      "description": "Expert team and membership operations."
+    }
+  ],
+  "servers": [
+    {
+      "url": "/api/v1"
+    }
+  ],
+  "security": [
+    {
+      "bearer_auth": [
+
+      ]
+    },
+    {
+      "octo_session": [
+
+      ]
+    }
+  ],
+  "x-common-errors": {
+    "400": {
+      "$ref": "#/components/responses/ValidationError"
+    },
+    "401": {
+      "$ref": "#/components/responses/Unauthorized"
+    },
+    "403": {
+      "$ref": "#/components/responses/Forbidden"
+    },
+    "404": {
+      "$ref": "#/components/responses/NotFound"
+    },
+    "429": {
+      "$ref": "#/components/responses/RateLimited"
+    },
+    "500": {
+      "$ref": "#/components/responses/InternalError"
+    }
+  },
+  "paths": {
+    "/api/v1/tasks": {
+      "get": {
+        "summary": "List tasks",
+        "description": "Returns one workspace-scoped page of tasks.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create task",
+        "description": "Creates a task in the authenticated workspace.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.create",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TaskCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/_search": {
+      "get": {
+        "summary": "Search tasks",
+        "description": "Searches tasks using public task and assignee vocabulary.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.search",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/_grouped": {
+      "get": {
+        "summary": "Group tasks",
+        "description": "Returns task groups using the requested grouping filters.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.group",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/_child_progress": {
+      "get": {
+        "summary": "Get child progress",
+        "description": "Aggregates child-task progress for the requested parents.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.child_progress",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/_children_by_parent": {
+      "get": {
+        "summary": "List children by parent",
+        "description": "Returns one page of child tasks grouped by parent selection.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.children_by_parent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/_quick_create": {
+      "post": {
+        "summary": "Queue task creation",
+        "description": "Creates and dispatches a task to exactly one expert or expert team.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.quick_create",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TaskQuickCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "202": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "Get task",
+        "description": "Returns the task identified within the current workspace.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.get",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update task",
+        "description": "Applies the supplied mutable task fields.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.update",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TaskUpdate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete task",
+        "description": "Deletes the task and returns an empty data object.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.delete",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/comments": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task comments",
+        "description": "Returns one page of comments for the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.comment.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create task comment",
+        "description": "Adds a comment to the task as the authenticated principal.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.comment.create",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CommentCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/comments/_trigger_preview": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "post": {
+        "summary": "Preview comment triggers",
+        "description": "Resolves mentions and automation triggers without creating a comment.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.comment.preview",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/CommentCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/timeline": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task timeline",
+        "description": "Returns one chronological page of task activity.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.timeline.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/subscribers": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task subscribers",
+        "description": "Returns one page of principals subscribed to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.subscriber.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/subscribe": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "post": {
+        "summary": "Subscribe to task",
+        "description": "Subscribes the authenticated principal or supplied actor target.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.subscribe",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ActorTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/unsubscribe": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "post": {
+        "summary": "Unsubscribe from task",
+        "description": "Removes the authenticated principal or supplied actor target.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.unsubscribe",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ActorTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/executions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task executions",
+        "description": "Returns one page of executions created for the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.execution.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/active_executions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List active executions",
+        "description": "Returns one page of non-terminal executions for the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.active_execution.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/rerun": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "post": {
+        "summary": "Rerun task execution",
+        "description": "Queues a replacement execution from the selected prior execution.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.rerun",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExecutionTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "202": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/executions/{execution_id}/cancel": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        },
+        {
+          "$ref": "#/components/parameters/ExecutionID"
+        }
+      ],
+      "post": {
+        "summary": "Cancel task execution",
+        "description": "Requests cancellation of one execution belonging to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.execution.cancel",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/usage": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "Get task usage",
+        "description": "Returns aggregated execution resource usage for the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.usage",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/reactions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "post": {
+        "summary": "Add task reaction",
+        "description": "Adds the authenticated principal reaction to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.reaction.add",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Reaction"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove task reaction",
+        "description": "Removes the authenticated principal reaction from the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.reaction.remove",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Reaction"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/attachments": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task attachments",
+        "description": "Returns one page of files attached to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.attachment.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/children": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List child tasks",
+        "description": "Returns one page of immediate child tasks.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.child.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/labels": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task labels",
+        "description": "Returns one page of labels attached to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.label.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Attach task label",
+        "description": "Attaches one existing workspace label to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.label.add",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/LabelTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/labels/{label_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        },
+        {
+          "$ref": "#/components/parameters/LabelID"
+        }
+      ],
+      "delete": {
+        "summary": "Detach task label",
+        "description": "Removes one label association and returns the remaining labels.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.label.remove",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/metadata": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task metadata",
+        "description": "Returns the task metadata map without rewriting opaque values.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.metadata.list",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/metadata/{metadata_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        },
+        {
+          "$ref": "#/components/parameters/MetadataID"
+        }
+      ],
+      "put": {
+        "summary": "Set task metadata",
+        "description": "Creates or replaces one opaque task metadata value.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.metadata.set",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/MetadataValue"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete task metadata",
+        "description": "Deletes one metadata key and returns the remaining metadata.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.metadata.delete",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/tasks/{task_id}/pull_requests": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TaskID"
+        }
+      ],
+      "get": {
+        "summary": "List task pull requests",
+        "description": "Returns one page of pull requests linked to the task.",
+        "tags": [
+          "tasks"
+        ],
+        "operationId": "task.pull_request.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/executions/{execution_id}/messages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExecutionID"
+        }
+      ],
+      "get": {
+        "summary": "List execution messages",
+        "description": "Returns one page of messages produced by the execution.",
+        "tags": [
+          "executions"
+        ],
+        "operationId": "execution.message.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/executions/{execution_id}/cancel": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExecutionID"
+        }
+      ],
+      "post": {
+        "summary": "Cancel execution",
+        "description": "Requests cancellation of the selected execution.",
+        "tags": [
+          "executions"
+        ],
+        "operationId": "execution.cancel",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts": {
+      "get": {
+        "summary": "List experts",
+        "description": "Returns one page of experts in the current workspace.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create expert",
+        "description": "Creates an expert using public expert vocabulary.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.create",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/_from_template": {
+      "post": {
+        "summary": "Create expert from template",
+        "description": "Instantiates an expert from the selected template.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.create_from_template",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/TemplateTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "get": {
+        "summary": "Get expert",
+        "description": "Returns one expert from the current workspace.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.get",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update expert",
+        "description": "Applies supplied mutable expert configuration fields.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.update",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertUpdate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/archive": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "post": {
+        "summary": "Archive expert",
+        "description": "Marks the expert unavailable for new task assignment.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.archive",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/restore": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "post": {
+        "summary": "Restore expert",
+        "description": "Restores an archived expert for future assignments.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.restore",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/executions/cancel": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "post": {
+        "summary": "Cancel expert executions",
+        "description": "Requests cancellation of active executions owned by the expert.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.execution.cancel",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/executions": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "get": {
+        "summary": "List expert executions",
+        "description": "Returns one page of executions assigned to the expert.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.execution.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/skills": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "get": {
+        "summary": "List expert skills",
+        "description": "Returns one page of skills assigned to the expert.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.skill.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "put": {
+        "summary": "Replace expert skills",
+        "description": "Replaces the complete expert skill assignment set.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.skill.replace",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SkillTargets"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add expert skills",
+        "description": "Adds skills without removing existing expert assignments.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.skill.add",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/SkillTargets"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/experts/{expert_id}/env": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertID"
+        }
+      ],
+      "get": {
+        "summary": "Get expert environment",
+        "description": "Returns the expert custom runtime environment variables.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.environment.get",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update expert environment",
+        "description": "Replaces the expert custom runtime environment variables.",
+        "tags": [
+          "experts"
+        ],
+        "operationId": "expert.environment.update",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Environment"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_templates": {
+      "get": {
+        "summary": "List expert templates",
+        "description": "Returns one page of templates available to the workspace.",
+        "tags": [
+          "expert_templates"
+        ],
+        "operationId": "expert_template.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_templates/{template_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/TemplateID"
+        }
+      ],
+      "get": {
+        "summary": "Get expert template",
+        "description": "Returns one expert template by stable template identifier.",
+        "tags": [
+          "expert_templates"
+        ],
+        "operationId": "expert_template.get",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_teams": {
+      "get": {
+        "summary": "List expert teams",
+        "description": "Returns one page of expert teams in the workspace.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Create expert team",
+        "description": "Creates an expert team and assigns its leader.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.create",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertTeamCreate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_teams/{expert_team_id}": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertTeamID"
+        }
+      ],
+      "get": {
+        "summary": "Get expert team",
+        "description": "Returns one expert team from the current workspace.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.get",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update expert team",
+        "description": "Applies supplied mutable expert-team fields.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.update",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertTeamUpdate"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete expert team",
+        "description": "Deletes the expert team and returns an empty data object.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.delete",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_teams/{expert_team_id}/members": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertTeamID"
+        }
+      ],
+      "get": {
+        "summary": "List expert team members",
+        "description": "Returns one page of expert-team members.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.member.list",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/Page"
+          },
+          {
+            "$ref": "#/components/parameters/PageSize"
+          }
+        ],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Collection"
+          }
+        }
+      },
+      "post": {
+        "summary": "Add expert team member",
+        "description": "Adds one expert or nested expert team as a member.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.member.add",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertTeamMember"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "201": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove expert team member",
+        "description": "Removes one supplied member from the expert team.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.member.remove",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertTeamMemberTarget"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Empty"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_teams/{expert_team_id}/members/role": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertTeamID"
+        }
+      ],
+      "patch": {
+        "summary": "Update expert team member role",
+        "description": "Changes one member role without replacing membership.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.member.update",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ExpertTeamMember"
+        },
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    },
+    "/api/v1/expert_teams/{expert_team_id}/member_statuses": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ExpertTeamID"
+        }
+      ],
+      "get": {
+        "summary": "List expert team member statuses",
+        "description": "Returns current workload status for all team members.",
+        "tags": [
+          "expert_teams"
+        ],
+        "operationId": "expert_team.member_status.list",
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalError"
+          },
+          "200": {
+            "$ref": "#/components/responses/Resource"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Loop credential or supported long-lived Octo server credential."
+      },
+      "octo_session": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Token",
+        "description": "Octo session token accepted directly by Fleet."
+      }
+    },
+    "parameters": {
+      "Page": {
+        "name": "page",
+        "in": "query",
+        "description": "One-based page number.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1
+        }
+      },
+      "PageSize": {
+        "name": "page_size",
+        "in": "query",
+        "description": "Number of resources per page.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100,
+          "default": 20
+        }
+      },
+      "TaskID": {
+        "name": "task_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable task identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "ExecutionID": {
+        "name": "execution_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable execution identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "ExpertID": {
+        "name": "expert_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable expert identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "ExpertTeamID": {
+        "name": "expert_team_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable expert-team identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "LabelID": {
+        "name": "label_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable label identifier.",
+        "schema": {
+          "type": "string",
+          "format": "uuid"
+        }
+      },
+      "MetadataID": {
+        "name": "metadata_id",
+        "in": "path",
+        "required": true,
+        "description": "Metadata key encoded as a path identifier.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "TemplateID": {
+        "name": "template_id",
+        "in": "path",
+        "required": true,
+        "description": "Stable expert-template slug or identifier.",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "requestBodies": {
+      "TaskCreate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TaskCreate"
+            }
+          }
+        }
+      },
+      "TaskUpdate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TaskUpdate"
+            }
+          }
+        }
+      },
+      "TaskQuickCreate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/TaskQuickCreate"
+            }
+          }
+        }
+      },
+      "CommentCreate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CommentCreate"
+            }
+          }
+        }
+      },
+      "ActorTarget": {
+        "required": false,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ActorTarget"
+            }
+          }
+        }
+      },
+      "ExecutionTarget": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "execution_id"
+              ],
+              "properties": {
+                "execution_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Reaction": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "emoji"
+              ],
+              "properties": {
+                "emoji": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LabelTarget": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "label_id"
+              ],
+              "properties": {
+                "label_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      },
+      "MetadataValue": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "value"
+              ],
+              "properties": {
+                "value": {
+                }
+              }
+            }
+          }
+        }
+      },
+      "ExpertCreate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertCreate"
+            }
+          }
+        }
+      },
+      "ExpertUpdate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertUpdate"
+            }
+          }
+        }
+      },
+      "TemplateTarget": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "template_id",
+                "name",
+                "runtime_id"
+              ],
+              "properties": {
+                "template_id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "runtime_id": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
+      },
+      "SkillTargets": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "skill_ids"
+              ],
+              "properties": {
+                "skill_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uuid"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Environment": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "required": [
+                "custom_env"
+              ],
+              "properties": {
+                "custom_env": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ExpertTeamCreate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertTeamCreate"
+            }
+          }
+        }
+      },
+      "ExpertTeamUpdate": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertTeamUpdate"
+            }
+          }
+        }
+      },
+      "ExpertTeamMember": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertTeamMember"
+            }
+          }
+        }
+      },
+      "ExpertTeamMemberTarget": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ExpertTeamMemberTarget"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Resource": {
+        "description": "Resource returned successfully.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ResourceEnvelope"
+            }
+          }
+        }
+      },
+      "Collection": {
+        "description": "Paginated collection returned successfully.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/CollectionEnvelope"
+            }
+          }
+        }
+      },
+      "Empty": {
+        "description": "Operation completed with no resource payload.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/EmptyEnvelope"
+            }
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "VALIDATION_ERROR — request fields or pagination are invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "AUTH_REQUIRED — credentials are absent or invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "FORBIDDEN — principal lacks the required action.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "NOT_FOUND — requested workspace resource does not exist.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "RATE_LIMITED — request rate exceeded the configured limit.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "INTERNAL_ERROR — Fleet could not complete the operation.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorEnvelope"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "ResourceEnvelope": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "CollectionEnvelope": {
+        "type": "object",
+        "required": [
+          "data",
+          "pagination"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/OffsetPagination"
+          }
+        }
+      },
+      "EmptyEnvelope": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "object",
+            "maxProperties": 0
+          }
+        }
+      },
+      "ErrorEnvelope": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "type": "object",
+            "required": [
+              "code",
+              "message"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "AUTH_REQUIRED",
+                  "FORBIDDEN",
+                  "NOT_FOUND",
+                  "CONFLICT",
+                  "DUPLICATE",
+                  "VALIDATION_ERROR",
+                  "PAYLOAD_TOO_LARGE",
+                  "UNSUPPORTED_MEDIA_TYPE",
+                  "CLIENT_VERSION_TOO_OLD",
+                  "RATE_LIMITED",
+                  "INTERNAL_ERROR",
+                  "UPSTREAM_UNAVAILABLE"
+                ]
+              },
+              "message": {
+                "type": "string"
+              },
+              "details": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "hint": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "OffsetPagination": {
+        "type": "object",
+        "required": [
+          "total",
+          "page",
+          "page_size"
+        ],
+        "properties": {
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "page_size": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100
+          }
+        }
+      },
+      "TaskCreate": {
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "parent_task_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignee_type": {
+            "type": "string",
+            "enum": [
+              "expert",
+              "expert_team",
+              "member"
+            ]
+          },
+          "assignee_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "priority": {
+            "type": "string"
+          }
+        }
+      },
+      "TaskUpdate": {
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "parent_task_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignee_type": {
+            "type": "string",
+            "enum": [
+              "expert",
+              "expert_team",
+              "member"
+            ]
+          },
+          "assignee_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          }
+        }
+      },
+      "TaskQuickCreate": {
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "expert_id"
+            ]
+          },
+          {
+            "required": [
+              "expert_team_id"
+            ]
+          }
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expert_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "expert_team_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "project_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parent_task_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "attachment_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "CommentCreate": {
+        "type": "object",
+        "required": [
+          "content"
+        ],
+        "properties": {
+          "content": {
+            "type": "string",
+            "minLength": 1
+          },
+          "attachment_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "ActorTarget": {
+        "type": "object",
+        "properties": {
+          "user_type": {
+            "type": "string",
+            "enum": [
+              "expert",
+              "expert_team",
+              "member"
+            ]
+          },
+          "user_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertCreate": {
+        "type": "object",
+        "required": [
+          "name",
+          "runtime_id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "runtime_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertUpdate": {
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "runtime_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertTeamCreate": {
+        "type": "object",
+        "required": [
+          "name",
+          "leader_expert_id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "leader_expert_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertTeamUpdate": {
+        "type": "object",
+        "minProperties": 1,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string"
+          },
+          "leader_expert_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertTeamMemberTarget": {
+        "type": "object",
+        "required": [
+          "member_type",
+          "member_id"
+        ],
+        "properties": {
+          "member_type": {
+            "type": "string",
+            "enum": [
+              "expert",
+              "member"
+            ]
+          },
+          "member_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ExpertTeamMember": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ExpertTeamMemberTarget"
+          },
+          {
+            "type": "object",
+            "required": [
+              "role"
+            ],
+            "properties": {
+              "role": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "x-octo-source": "octo-fleet/openapi/public-v1.yaml",
+  "x-octo-service": "loop",
+  "x-octo-base-url": "OCTO_LOOP_API_BASE_URL",
+  "x-octo-space-header": false
+}

--- a/skills/octo-loop/SKILL.md
+++ b/skills/octo-loop/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: octo-loop
+description: Manage Fleet tasks, executions, experts, expert templates, and expert teams through the stable Loop API exposed by octo-cli.
+---
+
+# Octo Loop
+
+Use the `loop` namespace for Fleet control-plane operations. Product names are
+`task`, `expert`, `expert-team`, and `execution`; do not use the legacy
+issue/agent/squad names.
+
+## Authentication
+
+Set `OCTO_BOT_TOKEN` to a credential Fleet accepts directly, such as an Octo
+Session credential, `bf_`, `uk_`, or `octo_loop_`. The CLI does not infer a
+human, device, or execution principal from a token prefix. Fleet verifies the
+credential and constructs the principal.
+
+Set `OCTO_LOOP_API_BASE_URL` only when Fleet is served separately from
+`OCTO_API_BASE_URL`, for example during local integration testing.
+
+## Discover and execute operations
+
+```bash
+octo-cli loop task list
+octo-cli loop task get <task-id>
+octo-cli loop expert list
+octo-cli loop expert-team list
+octo-cli loop execution message list <execution-id>
+```
+
+Inspect the current contract before constructing a write:
+
+```bash
+octo-cli schema task.create
+octo-cli schema expert.create
+octo-cli schema expert_team.create
+```
+
+Use `--data` for complex request bodies. Repository operations, daemon device
+enrollment, task claim/heartbeat, and local runtime paths are intentionally not
+part of this CLI surface.

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -80,6 +80,26 @@ func TestOctoSummarySkillEmbedded(t *testing.T) {
 	}
 }
 
+func TestOctoLoopSkillEmbedded(t *testing.T) {
+	b, err := FS.ReadFile("octo-loop/SKILL.md")
+	if err != nil {
+		t.Fatalf("octo-loop/SKILL.md not embedded: %v", err)
+	}
+	content := string(b)
+	for _, want := range []string{
+		"name: octo-loop",
+		"loop task list",
+		"loop expert list",
+		"loop expert-team list",
+		"OCTO_LOOP_API_BASE_URL",
+		"not infer",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("octo-loop skill missing %q", want)
+		}
+	}
+}
+
 func TestOctoMarketplaceReferencesEmbedded(t *testing.T) {
 	b, err := FS.ReadFile("octo-marketplace/SKILL.md")
 	if err != nil {


### PR DESCRIPTION
## What

Expose the complete Fleet public Loop API through octo-cli, expanding the existing task and expert integration to the remaining business resources.

## How

- Extend the embedded Loop OpenAPI registry from 61 to 136 operations.
- Add workspace, label, project, comment, attachment, skill, runtime, and autopilot command groups.
- Add explicit `--workspace-id` selection for human credentials while preserving workspace-bound Loop credentials.
- Keep Fleet routing on `/v1/*` and avoid operation ID collisions with Marketplace skill commands.

## Tests

- `go test ./...`
- Command-tree coverage for every new resource group.
- Fleet endpoint, workspace header, multipart, and registry contract coverage.

## Checklist

- [x] Tests added or updated
- [x] Documentation and embedded API contract updated
- [x] Conventional Commits used

Closes #116