### PR TITLE
feat(docs): add full-text search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli docs search`** — permission-scoped full-text search across online
+  documents, sheets, and boards via `POST /v1/bot/docs/search`. Supports
+  repeatable `--doc-type` filters, manual cursor continuation, and `--page-all`.
+  The metadata-driven pagination engine now supports custom item/cursor paths,
+  explicit cursor-based has-more inference, POST body cursors, and opt-in
+  repeated-cursor detection with a `PAGINATION_LOOP` error.
 - **`octo-cli summary` domain** — `summary create|list|get|result` lets a
   personal Agent create owner-only summaries from explicit authorized sources,
   then discover and cite summaries visible to its human owner. The embedded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@
 - **Search subjects** (`message search` family): a `bf_` token searches as the bot, or as a real person with `--on-behalf-of <uid>` (OBO — requires an active grant); a `uk_` token searches as the real person it belongs to. An `app_` token cannot search — the CLI rejects it locally (`validation`, in `internal/client/search_route.go`) before any request, distinct from a server-side `FORBIDDEN`.
 - `OCTO_SPACE_ID` (or `--space`) supplies space context for platform-scoped bots. Space-scoped bots resolve their space server-side.
 
-## Command Structure (9 domains, 104 operations)
+## Command Structure (9 domains, 105 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -48,7 +48,7 @@ octo-cli thread    create | list | get | members
 octo-cli file      upload | download | credentials | presigned
 octo-cli bot       register | set-commands | user-info | space-members | typing | heartbeat
 octo-cli event     list | ack
-octo-cli docs      create | list | get | rename | delete | forward-grant
+octo-cli docs      create | list | search | get | rename | delete | forward-grant
                content  get|edit
                sheet    get|edit
                scene    get|edit|export

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ deterministic taxonomy. There is no interactive I/O.
 
 ## Architecture
 
-octo-cli is **metadata-driven**. The entire command tree — 104 operations
+octo-cli is **metadata-driven**. The entire command tree — 105 operations
 across 9 domains — is auto-registered at startup from OpenAPI 3.x specs
 embedded into the binary. Adding or changing an endpoint means editing a
 spec, not the code.
@@ -38,7 +38,7 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `docs`    | 31  | Documents, spreadsheets & whiteboards — lifecycle, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
+| `docs`    | 32  | Documents, spreadsheets & whiteboards — lifecycle, full-text search, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |
 | `summary` | 4   | Personal-bot summaries — create owner-only summaries from explicit sources, then discover/read/cite. **Temporarily withheld** while the create backend (Mininglamp-OSS/octo-smart-summary#181) is merged, deployed, and enabled |
@@ -126,9 +126,10 @@ octo-cli thread create group-abc --name "design review"
 octo-cli file upload --file ./report.pdf
 octo-cli file download abc123 --jq '.data.url'
 
-# Docs — create/list, then read and incrementally edit the live body.
+# Docs — create/list/search, then read and incrementally edit the live body.
 octo-cli docs create --title "Design notes"
 octo-cli docs list --sort updatedAt:desc
+octo-cli docs search --keyword "quarterly plan" --doc-type doc --page-all
 octo-cli docs get doc-123
 octo-cli docs content get doc-123          # returns the body + base version token
 octo-cli docs import doc-123 --file ./notes.md      # replaces a doc from .md/.markdown/.docx

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
 	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
 )
 
@@ -28,7 +30,7 @@ func TestDocs_TreeShape(t *testing.T) {
 	if docs == nil {
 		t.Fatal("missing docs service command")
 	}
-	for _, leaf := range []string{"create", "list", "get", "rename", "delete", "forward-grant"} {
+	for _, leaf := range []string{"create", "list", "search", "get", "rename", "delete", "forward-grant"} {
 		if !contains(childNames(docs), leaf) {
 			t.Errorf("docs: missing leaf %q; got %v", leaf, childNames(docs))
 		}
@@ -69,6 +71,7 @@ func TestDocs_RegistryShape(t *testing.T) {
 	cases := map[string]want{
 		"docs.create":              {"POST", "/v1/bot/docs"},
 		"docs.list":                {"GET", "/v1/bot/docs"},
+		"docs.search":              {"POST", "/v1/bot/docs/search"},
 		"docs.get":                 {"GET", "/v1/bot/docs/{docId}"},
 		"docs.rename":              {"PATCH", "/v1/bot/docs/{docId}"},
 		"docs.delete":              {"DELETE", "/v1/bot/docs/{docId}"},
@@ -205,6 +208,184 @@ func TestDocs_NoPagination(t *testing.T) {
 	}
 	if list.Flags().Lookup("page-all") != nil {
 		t.Error("docs list must not have --page-all")
+	}
+}
+
+func TestDocsSearch_FlagsAndRequestBody(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":1,"items":[{"docId":"d1","title":"Plan","docType":"doc","updatedAt":123,"spaceId":"s1","highlight":"roadmap"}]}`))
+	})
+
+	search := findCmd(findCmd(root, "docs"), "search")
+	if search == nil {
+		t.Fatal("docs search command missing")
+	}
+	for _, name := range []string{"keyword", "doc-type", "cursor", "page-size", "page-all", "page-limit"} {
+		if search.Flags().Lookup(name) == nil {
+			t.Errorf("docs search missing --%s", name)
+		}
+	}
+	if search.Flags().Lookup("q") != nil || search.Flags().Lookup("docType") != nil {
+		t.Error("docs search must expose caller-facing flag names, not wire names")
+	}
+
+	root.SetArgs([]string{"docs", "search", "--keyword", "roadmap", "--doc-type", "doc", "--doc-type", "board", "--cursor", "c1", "--page-size", "25"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/bot/docs/search" {
+		t.Errorf("request = %s %s", gotMethod, gotPath)
+	}
+	if gotBody["q"] != "roadmap" || gotBody["cursor"] != "c1" || gotBody["pageSize"] != float64(25) {
+		t.Errorf("body = %#v", gotBody)
+	}
+	types, ok := gotBody["docType"].([]any)
+	if !ok || len(types) != 2 || types[0] != "doc" || types[1] != "board" {
+		t.Errorf("docType = %#v", gotBody["docType"])
+	}
+
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Total int `json:"total"`
+			Items []struct {
+				DocID string `json:"docId"`
+			} `json:"items"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v -- out=%s", err, tf.Out.String())
+	}
+	if !env.OK || env.Data.Total != 1 || len(env.Data.Items) != 1 || env.Data.Items[0].DocID != "d1" {
+		t.Errorf("single-page response did not preserve backend object: %+v", env)
+	}
+}
+
+func TestDocsSearch_PageAllUsesBodyCursorAndStopsWithoutNextCursor(t *testing.T) {
+	pages := []string{
+		`{"total":3,"items":[{"docId":"d1"},{"docId":"d2"}],"nextCursor":"next-2"}`,
+		`{"total":3,"items":[{"docId":"d3"}]}`,
+	}
+	var cursors []string
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		cursor, _ := body["cursor"].(string)
+		cursors = append(cursors, cursor)
+		if queryCursor := r.URL.Query().Get("cursor"); queryCursor != "" {
+			t.Errorf("cursor leaked into query: %q", queryCursor)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(pages[len(cursors)-1]))
+	})
+	root.SetArgs([]string{"docs", "search", "--keyword", "plan", "--page-all"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if len(cursors) != 2 || cursors[0] != "" || cursors[1] != "next-2" {
+		t.Fatalf("body cursor progression = %v", cursors)
+	}
+	var env struct {
+		Data []struct {
+			DocID string `json:"docId"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if len(env.Data) != 3 {
+		t.Errorf("merged data = %+v", env.Data)
+	}
+}
+
+func TestDocsSearch_PageAllRejectsRepeatedCursor(t *testing.T) {
+	calls := 0
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":99,"items":[{"docId":"d"}],"nextCursor":"same"}`))
+	})
+	root.SetArgs([]string{"docs", "search", "--keyword", "plan", "--page-all", "--page-limit", "10"})
+	err := root.Execute()
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != "PAGINATION_LOOP" {
+		t.Fatalf("error = %#v, want PAGINATION_LOOP", err)
+	}
+	if calls != 2 {
+		t.Errorf("repeated cursor should fail after 2 requests, got %d", calls)
+	}
+}
+
+func TestDocsSearch_FinalPageStopsWithoutCursor(t *testing.T) {
+	calls := 0
+	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":1,"items":[{"docId":"d1"}],"nextCursor":""}`))
+	})
+	root.SetArgs([]string{"docs", "search", "--keyword", "plan", "--page-all"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("final page should stop after 1 request, got %d", calls)
+	}
+	var env struct {
+		Data []struct {
+			DocID string `json:"docId"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if len(env.Data) != 1 || env.Data[0].DocID != "d1" {
+		t.Errorf("merged data = %+v", env.Data)
+	}
+}
+
+func TestDocsSearch_PageLimitPreemptsLoopDetection(t *testing.T) {
+	calls := 0
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":99,"items":[{"docId":"d"}],"nextCursor":"same"}`))
+	})
+	root.SetArgs([]string{"docs", "search", "--keyword", "plan", "--page-all", "--page-limit", "1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("page-limit boundary must not report a loop: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("page-limit should stop after 1 request, got %d", calls)
+	}
+}
+
+func TestDocsSearch_PageAllSeedsManualCursor(t *testing.T) {
+	calls := 0
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body["cursor"] != "same" {
+			t.Errorf("cursor = %#v, want same", body["cursor"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":1,"items":[{"docId":"d1"}],"nextCursor":"same"}`))
+	})
+	root.SetArgs([]string{"docs", "search", "--keyword", "plan", "--cursor", "same", "--page-all"})
+	err := root.Execute()
+	var exitErr *output.ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != "PAGINATION_LOOP" {
+		t.Fatalf("error = %#v, want PAGINATION_LOOP", err)
+	}
+	if calls != 1 {
+		t.Fatalf("manual repeated cursor should fail after 1 request, got %d", calls)
 	}
 }
 

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -352,13 +352,7 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 	// leaving only the last page's bytes. No spec op declares both today, so this
 	// never fires in practice; it is a fail-loud guard against a future spec that
 	// wires the two together and would otherwise silently corrupt --output.
-	if firstReq.OutputPath != "" {
-		err := output.ErrWithHint(
-			"internal",
-			"PAGINATION_OUTPUT_CONFLICT",
-			"operation is paginated and also writes a binary body to --output; these are mutually exclusive",
-			"operation-spec bug: an op with x-octo-pagination must not also declare an inline 2xx binary body",
-		)
+	if err := validatePaginationRequest(firstReq); err != nil {
 		_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
 		return err
 	}
@@ -369,50 +363,34 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 		return err
 	}
 	pag := rt.detail.Pagination
-	cursorParam := pag.CursorParam
-	if cursorParam == "" {
-		cursorParam = "cursor"
-	}
-	limit := 10
-	if rt.pageLimit != nil && *rt.pageLimit > 0 {
-		limit = *rt.pageLimit
-	}
-
+	cursorParam, limit := paginationControls(rt, pag)
 	merged := make([]json.RawMessage, 0, 64)
 	req := *firstReq
+	seenCursors := paginationSeenCursors(&req, rt, pag, cursorParam)
 	for page := 0; page < limit; page++ {
 		body, err := cli.Do(ctx, &req)
 		if err != nil {
 			_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
 			return err
 		}
-		data, nextCursor, hasMore, perr := parsePage(body)
+		data, nextCursor, hasMore, perr := parsePage(body, pag)
 		if perr != nil {
 			_ = f.EmitError(perr) //nolint:errcheck // best-effort emit before returning err
 			return perr
 		}
 		merged = append(merged, data...)
-		if !hasMore || nextCursor == "" {
+		if !hasMore || nextCursor == "" || page+1 >= limit {
 			break
 		}
-		// Prepare next request. Copy the whole struct so no field is silently
-		// dropped (RawBody/ContentType/BinaryResponse/OutputPath). The cursor
-		// goes wherever the spec declares it: a query parameter (GET endpoints
-		// like matter.list) or a JSON body field (POST endpoints like the
-		// message.search family). Either way we clone the container before
-		// setting so the previous page's request is never mutated.
-		next := req
-		if cursorIsQueryParam(rt, cursorParam) {
-			nextQ := url.Values{}
-			for k, vs := range req.Query {
-				nextQ[k] = append([]string(nil), vs...)
-			}
-			nextQ.Set(cursorParam, nextCursor)
-			next.Query = nextQ
-		} else {
-			next.Body = withCursorBody(req.Body, cursorParam, nextCursor)
+		if cursorWasSeen(seenCursors, nextCursor) {
+			loopErr := paginationLoopError(nextCursor)
+			_ = f.EmitError(loopErr) //nolint:errcheck // best-effort emit before returning err
+			return loopErr
 		}
-		req = next
+		if seenCursors != nil {
+			seenCursors[nextCursor] = struct{}{}
+		}
+		req = requestWithCursor(&req, rt, cursorParam, nextCursor)
 	}
 
 	out, err := json.Marshal(merged)
@@ -420,6 +398,72 @@ func runPaginated(ctx context.Context, f *cmdutil.Factory, rt *operationRuntime,
 		return err
 	}
 	return f.EmitSuccess(out)
+}
+
+func paginationControls(rt *operationRuntime, pag *registry.PaginationInfo) (cursorParam string, limit int) {
+	cursorParam = pag.CursorParam
+	if cursorParam == "" {
+		cursorParam = "cursor"
+	}
+	limit = 10
+	if rt.pageLimit != nil && *rt.pageLimit > 0 {
+		limit = *rt.pageLimit
+	}
+	return cursorParam, limit
+}
+
+func paginationSeenCursors(req *client.Request, rt *operationRuntime, pag *registry.PaginationInfo, cursorParam string) map[string]struct{} {
+	if !pag.RejectCursorRepeats {
+		return nil
+	}
+	return initialSeenCursors(req, rt, cursorParam)
+}
+
+func validatePaginationRequest(req *client.Request) *output.ExitError {
+	if req.OutputPath == "" {
+		return nil
+	}
+	return output.ErrWithHint(
+		"internal",
+		"PAGINATION_OUTPUT_CONFLICT",
+		"operation is paginated and also writes a binary body to --output; these are mutually exclusive",
+		"operation-spec bug: an op with x-octo-pagination must not also declare an inline 2xx binary body",
+	)
+}
+
+func cursorWasSeen(seen map[string]struct{}, cursor string) bool {
+	if seen == nil || cursor == "" {
+		return false
+	}
+	_, ok := seen[cursor]
+	return ok
+}
+
+func paginationLoopError(cursor string) *output.ExitError {
+	return output.ErrWithHint(
+		"internal",
+		"PAGINATION_LOOP",
+		fmt.Sprintf("backend repeated pagination cursor %q", cursor),
+		"retry without --page-all or report the backend cursor loop",
+	)
+}
+
+// requestWithCursor copies the whole request so no field is silently dropped.
+// It clones the query/body container before setting the cursor, leaving the
+// previous page's request unchanged.
+func requestWithCursor(req *client.Request, rt *operationRuntime, cursorParam, cursor string) client.Request {
+	next := *req
+	if cursorIsQueryParam(rt, cursorParam) {
+		nextQ := url.Values{}
+		for key, values := range req.Query {
+			nextQ[key] = append([]string(nil), values...)
+		}
+		nextQ.Set(cursorParam, cursor)
+		next.Query = nextQ
+	} else {
+		next.Body = withCursorBody(req.Body, cursorParam, cursor)
+	}
+	return next
 }
 
 // cursorIsQueryParam reports whether this operation declares its pagination
@@ -434,6 +478,29 @@ func cursorIsQueryParam(rt *operationRuntime, cursorParam string) bool {
 		}
 	}
 	return false
+}
+
+// initialSeenCursors seeds the repeated-cursor guard with the cursor already
+// carried by the first request. This prevents --cursor C --page-all from
+// requesting C twice when a backend incorrectly returns C as its own next cursor.
+func initialSeenCursors(req *client.Request, rt *operationRuntime, cursorParam string) map[string]struct{} {
+	seen := map[string]struct{}{}
+	if cursor := requestCursor(req, rt, cursorParam); cursor != "" {
+		seen[cursor] = struct{}{}
+	}
+	return seen
+}
+
+func requestCursor(req *client.Request, rt *operationRuntime, cursorParam string) string {
+	if cursorIsQueryParam(rt, cursorParam) {
+		return req.Query.Get(cursorParam)
+	}
+	if body, ok := req.Body.(map[string]any); ok {
+		if cursor, ok := body[cursorParam].(string); ok {
+			return cursor
+		}
+	}
+	return ""
 }
 
 // withCursorBody returns a shallow clone of the JSON body map with the cursor
@@ -451,21 +518,115 @@ func withCursorBody(body any, cursorParam, nextCursor string) map[string]any {
 	return next
 }
 
-// parsePage extracts {data:[], pagination:{has_more, next_cursor}} from a
-// backend response. Tolerant: missing fields → empty data, no more pages.
-func parsePage(body []byte) (items []json.RawMessage, cursor string, hasMore bool, exitErr *output.ExitError) {
+// parsePage extracts pagination fields using x-octo-pagination paths. Defaults
+// preserve the historical {data, pagination:{has_more,next_cursor}} contract.
+// Specs without a has-more field must explicitly opt into cursor inference.
+func parsePage(body []byte, pag *registry.PaginationInfo) (items []json.RawMessage, cursor string, hasMore bool, exitErr *output.ExitError) {
 	if len(body) == 0 {
 		return nil, "", false, nil
 	}
-	var page struct {
-		Data       []json.RawMessage `json:"data"`
-		Pagination struct {
-			HasMore    bool   `json:"has_more"`
-			NextCursor string `json:"next_cursor"`
-		} `json:"pagination"`
+	fields := paginationFieldsFor(pag)
+	items, err := parsePageItems(body, fields.items)
+	if err != nil {
+		return nil, "", false, paginationParseError(err)
 	}
-	if err := json.Unmarshal(body, &page); err != nil {
-		return nil, "", false, output.ErrWithHint("internal", "PAGINATION_PARSE", err.Error(), "response did not match expected pagination shape")
+	cursor, err = parsePageCursor(body, fields.cursor)
+	if err != nil {
+		return nil, "", false, paginationParseError(err)
 	}
-	return page.Data, page.Pagination.NextCursor, page.Pagination.HasMore, nil
+	if fields.inferHasMore {
+		return items, cursor, cursor != "", nil
+	}
+	hasMore, err = parsePageHasMore(body, fields.hasMore)
+	if err != nil {
+		return nil, "", false, paginationParseError(err)
+	}
+	return items, cursor, hasMore, nil
+}
+
+type paginationFields struct {
+	items        string
+	cursor       string
+	hasMore      string
+	inferHasMore bool
+}
+
+func paginationFieldsFor(pag *registry.PaginationInfo) paginationFields {
+	fields := paginationFields{items: "data", cursor: "pagination.next_cursor", hasMore: "pagination.has_more"}
+	if pag == nil {
+		return fields
+	}
+	if pag.ItemsField != "" {
+		fields.items = pag.ItemsField
+	}
+	if pag.CursorField != "" {
+		fields.cursor = pag.CursorField
+	}
+	if pag.HasMoreField != "" {
+		fields.hasMore = pag.HasMoreField
+	}
+	fields.inferHasMore = pag.InferHasMore
+	return fields
+}
+
+func parsePageItems(body []byte, path string) ([]json.RawMessage, error) {
+	raw, found, err := rawValueAtPath(body, path)
+	if err != nil || !found {
+		return nil, err
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return nil, fmt.Errorf("field %q must be an array: %w", path, err)
+	}
+	return items, nil
+}
+
+func parsePageCursor(body []byte, path string) (string, error) {
+	raw, found, err := rawValueAtPath(body, path)
+	if err != nil || !found || string(raw) == "null" {
+		return "", err
+	}
+	var cursor string
+	if err := json.Unmarshal(raw, &cursor); err != nil {
+		return "", fmt.Errorf("field %q must be a string or null: %w", path, err)
+	}
+	return cursor, nil
+}
+
+func parsePageHasMore(body []byte, path string) (bool, error) {
+	raw, found, err := rawValueAtPath(body, path)
+	if err != nil || !found || string(raw) == "null" {
+		return false, err
+	}
+	var hasMore bool
+	if err := json.Unmarshal(raw, &hasMore); err != nil {
+		return false, fmt.Errorf("field %q must be a boolean or null: %w", path, err)
+	}
+	return hasMore, nil
+}
+
+func paginationParseError(err error) *output.ExitError {
+	return output.ErrWithHint("internal", "PAGINATION_PARSE", err.Error(), "response did not match expected pagination shape")
+}
+
+// rawValueAtPath resolves dot-separated object keys while retaining the exact
+// JSON bytes of the selected value. Literal dots in response keys are not
+// supported by x-octo-pagination paths.
+func rawValueAtPath(body []byte, path string) (json.RawMessage, bool, error) {
+	if path == "" {
+		return nil, false, nil
+	}
+	current := json.RawMessage(body)
+	for _, part := range strings.Split(path, ".") {
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(current, &object); err != nil {
+			return nil, false, fmt.Errorf("field path %q traverses a non-object: %w", path, err)
+		}
+		next, ok := object[part]
+		if !ok {
+			return nil, false, nil
+		}
+		current = next
+	}
+	return current, true, nil
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -399,18 +400,99 @@ func TestPagination_BodyCursorEndpoint(t *testing.T) {
 }
 
 func TestPagination_PageLimitStops(t *testing.T) {
-	page := `{"data":[{"id":"x"}],"pagination":{"has_more":true,"next_cursor":"c"}}`
 	calls := 0
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
 		calls++
+		page := fmt.Sprintf(`{"data":[{"id":"x"}],"pagination":{"has_more":true,"next_cursor":"c%d"}}`, calls)
 		_, _ = w.Write([]byte(page))
 	})
-	root.SetArgs([]string{"matter", "list", "--page-all", "--page-limit", "2"})
+	root.SetArgs([]string{"matter", "list", "--page-all", "--page-limit", "5"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if calls != 2 {
-		t.Errorf("expected 2 calls bounded by --page-limit, got %d", calls)
+	if calls != 5 {
+		t.Errorf("expected 5 calls bounded by --page-limit, got %d", calls)
+	}
+}
+
+func TestPagination_LegacyStableCursorStillUsesPageLimit(t *testing.T) {
+	calls := 0
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"data":[{"id":"x"}],"pagination":{"has_more":true,"next_cursor":"stable"}}`))
+	})
+	root.SetArgs([]string{"matter", "list", "--page-all", "--page-limit", "5"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if calls != 5 {
+		t.Errorf("stable cursor must remain valid for legacy operations: got %d calls, want 5", calls)
+	}
+}
+
+func TestParsePage_CustomFieldPaths(t *testing.T) {
+	items, cursor, hasMore, err := parsePage([]byte(`{
+		"result":{"hits":[{"z":1,"a":"<b>hi</b>"}]},
+		"paging":{"after":"c2","more":true}
+	}`), &registry.PaginationInfo{
+		ItemsField:   "result.hits",
+		CursorField:  "paging.after",
+		HasMoreField: "paging.more",
+	})
+	if err != nil {
+		t.Fatalf("parsePage: %v", err)
+	}
+	if len(items) != 1 || string(items[0]) != `{"z":1,"a":"<b>hi</b>"}` || cursor != "c2" || !hasMore {
+		t.Errorf("items=%s cursor=%q hasMore=%v", items, cursor, hasMore)
+	}
+}
+
+func TestParsePage_InferHasMoreRequiresOptIn(t *testing.T) {
+	body := []byte(`{"items":[],"nextCursor":"c2"}`)
+	base := registry.PaginationInfo{ItemsField: "items", CursorField: "nextCursor"}
+	_, _, hasMore, err := parsePage(body, &base)
+	if err != nil {
+		t.Fatalf("parsePage without inference: %v", err)
+	}
+	if hasMore {
+		t.Fatal("cursor alone must not imply has-more without explicit opt-in")
+	}
+	base.InferHasMore = true
+	_, _, hasMore, err = parsePage(body, &base)
+	if err != nil {
+		t.Fatalf("parsePage with inference: %v", err)
+	}
+	if !hasMore {
+		t.Fatal("non-empty cursor must imply has-more with explicit opt-in")
+	}
+}
+
+func TestParsePage_LegacyNullItemsAreEmpty(t *testing.T) {
+	items, cursor, hasMore, err := parsePage([]byte(`{"data":null,"pagination":{"has_more":false,"next_cursor":null}}`), nil)
+	if err != nil {
+		t.Fatalf("parsePage: %v", err)
+	}
+	if items != nil || cursor != "" || hasMore {
+		t.Errorf("items=%s cursor=%q hasMore=%v, want empty page", items, cursor, hasMore)
+	}
+}
+
+func TestParsePage_RejectsInvalidFieldTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "items object", body: `{"data":{},"pagination":{"has_more":false,"next_cursor":null}}`},
+		{name: "cursor object", body: `{"data":[],"pagination":{"has_more":true,"next_cursor":{}}}`},
+		{name: "has-more string", body: `{"data":[],"pagination":{"has_more":"yes","next_cursor":"c2"}}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := parsePage([]byte(tt.body), nil)
+			if err == nil || err.Code != "PAGINATION_PARSE" {
+				t.Fatalf("error = %#v, want PAGINATION_PARSE", err)
+			}
+		})
 	}
 }
 

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -193,14 +193,17 @@ type SchemaInfo struct {
 }
 
 // PaginationInfo captures the `x-octo-pagination` extension. It tells the
-// service engine which query parameters carry the cursor / limit and which
-// response fields carry the next cursor / has-more flag, so `--page-all`
-// can walk pages without operation-specific code.
+// service engine which query/body parameters carry the cursor / limit and
+// which response paths carry the items / next cursor / optional has-more flag,
+// so `--page-all` can walk pages without operation-specific code.
 type PaginationInfo struct {
-	CursorParam  string `json:"cursor_param,omitempty"`
-	LimitParam   string `json:"limit_param,omitempty"`
-	CursorField  string `json:"cursor_field,omitempty"`
-	HasMoreField string `json:"has_more_field,omitempty"`
+	CursorParam         string `json:"cursor_param,omitempty"`
+	LimitParam          string `json:"limit_param,omitempty"`
+	ItemsField          string `json:"items_field,omitempty"`
+	CursorField         string `json:"cursor_field,omitempty"`
+	HasMoreField        string `json:"has_more_field,omitempty"`
+	InferHasMore        bool   `json:"infer_has_more,omitempty"`
+	RejectCursorRepeats bool   `json:"reject_cursor_repeats,omitempty"`
 }
 
 // OperationDetail is the expanded view of a single operation returned by
@@ -402,10 +405,13 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 
 	if pag, ok := op["x-octo-pagination"].(map[string]any); ok {
 		d.Pagination = &PaginationInfo{
-			CursorParam:  stringOf(pag["cursorParam"]),
-			LimitParam:   stringOf(pag["limitParam"]),
-			CursorField:  stringOf(pag["cursorField"]),
-			HasMoreField: stringOf(pag["hasMoreField"]),
+			CursorParam:         stringOf(pag["cursorParam"]),
+			LimitParam:          stringOf(pag["limitParam"]),
+			ItemsField:          stringOf(pag["itemsField"]),
+			CursorField:         stringOf(pag["cursorField"]),
+			HasMoreField:        stringOf(pag["hasMoreField"]),
+			InferHasMore:        truthy(pag["inferHasMore"]),
+			RejectCursorRepeats: truthy(pag["rejectCursorRepeats"]),
 		}
 	}
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -42,7 +42,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":        4,
 		"bot":         6,
 		"event":       2,
-		"docs":        31,
+		"docs":        32,
 		"html":        20,
 		"marketplace": 25,
 		"summary":     4,
@@ -132,6 +132,20 @@ func TestGetOperationMatterList_Pagination(t *testing.T) {
 	}
 	if !foundStatus {
 		t.Error("missing status query parameter")
+	}
+}
+
+func TestGetOperationDocsSearch_Pagination(t *testing.T) {
+	r := MustNew()
+	op, ok := r.GetOperation("docs.search")
+	if !ok {
+		t.Fatal("docs.search not found")
+	}
+	if op.Pagination == nil {
+		t.Fatal("pagination: nil, want non-nil")
+	}
+	if op.Pagination.CursorParam != "cursor" || op.Pagination.ItemsField != "items" || op.Pagination.CursorField != "nextCursor" || op.Pagination.HasMoreField != "" || !op.Pagination.InferHasMore || !op.Pagination.RejectCursorRepeats {
+		t.Errorf("pagination: got %+v", op.Pagination)
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -95,6 +95,112 @@
         }
       }
     },
+    "/v1/bot/docs/search": {
+      "post": {
+        "operationId": "docs.search",
+        "summary": "Search accessible documents by full-text content",
+        "description": "Full-text search across documents the bot can access. Use --keyword for the query and repeat --doc-type to restrict results to doc, sheet, or board. The HTML document type is intentionally not exposed. The default response preserves the backend {total, items, nextCursor} object; --page-all follows nextCursor and emits the merged items array.",
+        "x-octo-risk": "read",
+        "x-octo-pagination": {
+          "cursorParam": "cursor",
+          "itemsField": "items",
+          "cursorField": "nextCursor",
+          "inferHasMore": true,
+          "rejectCursorRepeats": true
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "q"
+                ],
+                "properties": {
+                  "q": {
+                    "type": "string",
+                    "x-octo-flag": "keyword",
+                    "description": "full-text search keyword"
+                  },
+                  "docType": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "doc",
+                        "sheet",
+                        "board"
+                      ]
+                    },
+                    "x-octo-flag": "doc-type",
+                    "description": "document type filter; repeat for multiple types (doc, sheet, board)"
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "opaque cursor from the previous page"
+                  },
+                  "pageSize": {
+                    "type": "integer",
+                    "x-octo-flag": "page-size",
+                    "description": "items per page"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "total": {
+                      "type": "integer"
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "docId": {
+                            "type": "string"
+                          },
+                          "title": {
+                            "type": "string"
+                          },
+                          "docType": {
+                            "type": "string"
+                          },
+                          "updatedAt": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "spaceId": {
+                            "type": "string"
+                          },
+                          "highlight": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "nextCursor": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}": {
       "get": {
         "operationId": "docs.get",

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -56,6 +56,10 @@ octo-cli docs create [--title "Runbook"] [--folderId f_123] [--docType doc|sheet
 # List docs you own or are a member of. Page-based (see the pagination note below).
 octo-cli docs list [--folderId f_123] [--page 1] [--pageSize 20] [--sort updatedAt:desc]
 
+# Full-text search every doc the bot may read. Repeat --doc-type to combine kinds.
+# Search is cursor-based; --page-all follows nextCursor automatically.
+octo-cli docs search --keyword "quarterly plan" [--doc-type doc|sheet|board] [--page-size 20] [--page-all]
+
 octo-cli docs get    <docId>                 # metadata + doc_type + your role
 
 # Import a local file into an existing target. .md/.markdown/.docx require a doc;
@@ -73,11 +77,13 @@ octo-cli docs delete <docId>                 # soft delete (admin)
 
 ## Pagination note
 
-The docs list endpoints do **not** use the shared `{data, pagination}` envelope,
-so `--page-all` is intentionally not offered on them:
+Pagination depends on the endpoint's response contract:
 
 - `docs list` is **page-based** — response is `{total, items}`. Walk it with
-  `--page` / `--pageSize`.
+  `--page` / `--pageSize`; `--page-all` is not offered.
+- `docs search` is **cursor-based** — response is `{total, items, nextCursor}`.
+  Pass `nextCursor` back via `--cursor`, or use `--page-all` to follow it
+  automatically; `--page-limit` caps automatic requests (default 10).
 - `docs comments list` and `docs versions list` are **cursor-based** — response is
   `{items, nextCursor}`. Pass the returned `nextCursor` back via `--cursor` to get
   the next page; stop when `nextCursor` is null.
@@ -96,5 +102,6 @@ Any operation's parameters + response schema come from the embedded registry:
 
 ```bash
 octo-cli schema docs.create
+octo-cli schema docs.search
 octo-cli schema docs.content.edit     # + docs.sheet.edit / docs.scene.edit / docs.comments.add / …
 ```


### PR DESCRIPTION
## Summary

Expose the existing permission-scoped online-document full-text search API as `octo-cli docs search`.

## Changes

- add `docs search` with keyword, repeatable document-type, cursor, and page-size flags
- extend metadata-driven pagination with configurable item/cursor response paths and POST body cursor progression
- seed repeated-cursor detection from an explicitly supplied first-page cursor
- document the command in README, project instructions, and the embedded docs skill
- add registry, request-shape, cursor progression, and loop-prevention tests

## Linked Spec

- Fixes #117
- Backend contract: `POST /v1/bot/docs/search`

## How verified

- `go test -race -shuffle=on -count=1 ./...`
- `go vet ./...`
- `go build ./cmd/octo-cli`
- `golangci-lint run` (v2.12.2): 0 issues
- `go mod tidy` with no module-file drift
- `gofmt -l .` and `git diff --check`: clean
- local Kafka + OpenSearch + backend + indexer E2E
- deployed test-environment E2E for keyword, type filters, cursor, and `--page-all`
- local final commit `bb419cf` reviewed and APPROVED before PR creation

## Comprehension

### What does this change actually do?

Before this change, agents had to use the generic API command and manually manage search cursors. After it, `docs search` preserves the backend `{total, items, nextCursor}` object for a single page, while `--page-all` follows body cursors and emits one merged item array.

### What could break?

The shared pagination parser is the main blast radius. Existing contracts retain historical defaults; custom paths are opt-in. Repeated-cursor detection is seeded from the initial request and covers both self-repeating cursors and later loops before duplicate requests are sent.

### How do you know it works?

Tests cover registration, request body flags, body cursor placement, custom response paths, manual continuation cursors, normal progression, and loop stop conditions. Real E2E tests verified Bot authentication, permission filtering, OpenSearch results, cursor progression, and all-page aggregation.

## Checklist

- [x] Code, comments, and commit message are in English
- [x] README command reference and examples updated
- [x] CLAUDE.md command list updated
- [x] New feature includes tests
- [x] No unrelated changes included
