### PR TITLE
feat(docs): support HTML document search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`octo-cli docs search`** — permission-scoped full-text search across online
-  documents, sheets, and boards via `POST /v1/bot/docs/search`. Supports
-  repeatable `--doc-type` filters, manual cursor continuation, and `--page-all`.
+  documents, sheets, boards, and mounted HTML documents registered in docs-backend
+  via `POST /v1/bot/docs/search`. Supports repeatable `--doc-type` filters, manual
+  cursor continuation, and `--page-all`. Resolve an HTML result's `octoDocSlug`
+  with `docs get` before continuing in the separate `html` domain.
   The metadata-driven pagination engine now supports custom item/cursor paths,
   explicit cursor-based has-more inference, POST body cursors, and opt-in
   repeated-cursor detection with a `PAGINATION_LOOP` error.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ octo-cli docs export doc-123 --export-format pdf -o ./notes.pdf
 octo-cli docs members set doc-123 --data '{"uid":"u-1","role":"writer"}'
 octo-cli docs comments add doc-123 --data '{"body":"looks good"}'
 
+# Mounted HTML documents registered in docs-backend use the same search endpoint.
+# Resolve a hit's slug with docs get, then continue in the separate html domain.
+octo-cli docs search --keyword "interactive roadmap" --doc-type html --page-all
+octo-cli docs get html-doc-id              # returns octoDocSlug for HTML documents
+octo-cli html get html-document-slug
+
 # Spreadsheets — read the live cells + base version, then batch-edit under If-Match.
 octo-cli docs sheet get sheet-9                      # whole sheet + base version token
 octo-cli docs import sheet-9 --file ./report.xlsx    # imports the first visible worksheet

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -236,7 +236,7 @@ func TestDocsSearch_FlagsAndRequestBody(t *testing.T) {
 		t.Error("docs search must expose caller-facing flag names, not wire names")
 	}
 
-	root.SetArgs([]string{"docs", "search", "--keyword", "roadmap", "--doc-type", "doc", "--doc-type", "board", "--cursor", "c1", "--page-size", "25"})
+	root.SetArgs([]string{"docs", "search", "--keyword", "roadmap", "--doc-type", "doc", "--doc-type", "board", "--doc-type", "html", "--cursor", "c1", "--page-size", "25"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
@@ -247,7 +247,7 @@ func TestDocsSearch_FlagsAndRequestBody(t *testing.T) {
 		t.Errorf("body = %#v", gotBody)
 	}
 	types, ok := gotBody["docType"].([]any)
-	if !ok || len(types) != 2 || types[0] != "doc" || types[1] != "board" {
+	if !ok || len(types) != 3 || types[0] != "doc" || types[1] != "board" || types[2] != "html" {
 		t.Errorf("docType = %#v", gotBody["docType"])
 	}
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -146,6 +147,14 @@ func TestGetOperationDocsSearch_Pagination(t *testing.T) {
 	}
 	if op.Pagination.CursorParam != "cursor" || op.Pagination.ItemsField != "items" || op.Pagination.CursorField != "nextCursor" || op.Pagination.HasMoreField != "" || !op.Pagination.InferHasMore || !op.Pagination.RejectCursorRepeats {
 		t.Errorf("pagination: got %+v", op.Pagination)
+	}
+	docType, ok := op.RequestBody.Properties["docType"]
+	if !ok || docType.Items == nil {
+		t.Fatal("docs.search docType item schema missing")
+	}
+	wantTypes := []any{"doc", "sheet", "board", "html"}
+	if !reflect.DeepEqual(docType.Items.Enum, wantTypes) {
+		t.Errorf("docs.search docType enum = %#v, want %#v", docType.Items.Enum, wantTypes)
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -99,7 +99,7 @@
       "post": {
         "operationId": "docs.search",
         "summary": "Search accessible documents by full-text content",
-        "description": "Full-text search across documents the bot can access. Use --keyword for the query and repeat --doc-type to restrict results to doc, sheet, or board. The HTML document type is intentionally not exposed. The default response preserves the backend {total, items, nextCursor} object; --page-all follows nextCursor and emits the merged items array.",
+        "description": "Full-text search across documents the bot can access. Use --keyword for the query and repeat --doc-type to restrict results to doc, sheet, board, or html. HTML results cover documents registered into docs-backend by a mounted octo-doc publish; docs-backend computes the caller's authoritative visible doc-id set before OpenSearch returns metadata or body highlights. The default response preserves the backend {total, items, nextCursor} object; --page-all follows nextCursor and emits the merged items array.",
         "x-octo-risk": "read",
         "x-octo-pagination": {
           "cursorParam": "cursor",
@@ -130,11 +130,12 @@
                       "enum": [
                         "doc",
                         "sheet",
-                        "board"
+                        "board",
+                        "html"
                       ]
                     },
                     "x-octo-flag": "doc-type",
-                    "description": "document type filter; repeat for multiple types (doc, sheet, board)"
+                    "description": "document type filter; repeat for multiple types (doc, sheet, board, html)"
                   },
                   "cursor": {
                     "type": "string",
@@ -224,6 +225,7 @@
                     "spaceId": { "type": "string" },
                     "folderId": { "type": "string" },
                     "docType": { "type": "string" },
+                    "octoDocSlug": { "type": "string", "description": "HTML document slug for use with octo-cli html commands" },
                     "role": { "type": "string" },
                     "createdAt": { "type": "string" },
                     "updatedAt": { "type": "string" }

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -24,16 +24,22 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 | Read/edit a **spreadsheet** (`doc_type: sheet`): cells, formulas, styles, column widths / row heights (dims), floating **images**, paged reads, xlsx export | **`sheet.md`** |
 | Read/edit a rich-text **document body** (`doc_type: doc`): incremental block ops | **`doc.md`** |
 | Read/edit a **whiteboard** (`doc_type: board`): scene elements/files, image export | **`board.md`** |
+| Continue from a searchable **HTML document** (`doc_type: html`): resolve its slug, then use immutable versions/drafts/assets/comments | **`../octo-html/SKILL.md`** |
 | Cross-cutting features — **comments** (doc range or sheet cell), **versions** (snapshot/restore), **members & sharing**, **attachments** (presign/upload) | **`common.md`** |
 
-> The first three split by `doc_type` (what kind of document you're editing);
-> `common.md` holds the features that apply to any kind. Read a reference with
+> The first four split by `doc_type` (what kind of document you're handling);
+> `common.md` holds the features that apply across kinds. Read a reference with
 > your file tool (it sits beside this SKILL.md, e.g. `sheet.md`), or reprint the
 > whole skill set anytime with `octo-cli skills octo-docs`.
 
 Pick by `doc_type`: a **doc** body → `doc.md`; a **sheet** → `sheet.md`; a
-**board** → `board.md`. Using the wrong surface returns `409 unsupported_doc_type`.
-`docs get <docId>` reports the `doc_type` and your role.
+**board** → `board.md`; an **html** result → the separate `octo-html` skill.
+Using the wrong surface returns `409 unsupported_doc_type`. HTML operations are
+addressed by `slug`, not `docId`: if a search hit does not include a slug, run
+`docs get <docId>` to resolve `octoDocSlug`, then use `html get <octoDocSlug>`
+(or another `html` command). Do not retry HTML through `docs content`,
+`docs sheet`, or `docs scene`.
+`docs get <docId>` reports the `doc_type`, your role, and `octoDocSlug` for HTML.
 
 ## Auth & space
 
@@ -58,7 +64,7 @@ octo-cli docs list [--folderId f_123] [--page 1] [--pageSize 20] [--sort updated
 
 # Full-text search every doc the bot may read. Repeat --doc-type to combine kinds.
 # Search is cursor-based; --page-all follows nextCursor automatically.
-octo-cli docs search --keyword "quarterly plan" [--doc-type doc|sheet|board] [--page-size 20] [--page-all]
+octo-cli docs search --keyword "quarterly plan" [--doc-type doc|sheet|board|html] [--page-size 20] [--page-all]
 
 octo-cli docs get    <docId>                 # metadata + doc_type + your role
 
@@ -93,8 +99,10 @@ Pagination depends on the endpoint's response contract:
 `docs attachments upload` (binary helper), invites, access-requests, and
 link-card are out of scope here. Body editing is limited to `doc_type: doc`
 incremental block ops (`doc.md`), `doc_type: sheet` cell/dims/drawings batches
-(`sheet.md`), and `doc_type: board` scene batches (`board.md`); the document
-outline is not editable through the CLI.
+(`sheet.md`), and `doc_type: board` scene batches (`board.md`). `doc_type: html`
+belongs to the separate `html` domain, is addressed by slug, and is published as
+immutable versions; it cannot be read or edited through these three body
+surfaces. The document outline is not editable through the CLI.
 
 ## Schema lookup
 


### PR DESCRIPTION
## Summary

- advertise mounted HTML documents in the existing unified `octo-cli docs search --doc-type` contract
- document that docs-backend computes the authoritative visible document set before OpenSearch returns metadata or body highlights
- route HTML results through `docs get <docId>` → `octoDocSlug` → the separate `html` domain
- preserve the executable rich-text quickstart and add a separate HTML search example
- pin the full enum and mixed `doc + board + html` request serialization

No separate HTML-search command or pagination behavior was added. The enum is descriptive metadata used by generated help/schema; this PR does not add local enum validation.

## Linked issue

Fixes #120

Backend capability: Mininglamp-OSS/octo-docs-backend#143 (`83ecfcc`).

## How verified

### Local gates

- `gofmt -l .` (empty)
- `go vet ./...`
- `go test -race -shuffle=on -count=1 ./...`
- `go build ./...`
- `python3 -m json.tool internal/registry/specs/docs.json`
- Skill/contract assertions for `octoDocSlug` and the HTML-domain route
- `git diff --check`

All Go gates ran in `golang:1.24`; the full test run mounted a fixed `/etc/machine-id` required by the existing auth-store tests.

### Real local E2E

Using the local test bot without a client-supplied space override:

1. published a complete self-contained HTML document with `mount_type=space` through the normal `octo-cli html publish` path;
2. HTML service stored metadata/body and registered the mounted document in docs-backend;
3. docs-backend emitted the Kafka index signal;
4. octo-doc-indexer read the latest HTML body from S3/MinIO, extracted text, and wrote it to OpenSearch;
5. `octo-cli docs search --keyword "学习 Agent 的路线" --doc-type html` returned the registered HTML document with a body highlight;
6. authenticated raw HTML and the canonical web document route both returned HTTP 200.

## COMPREHENSION

### What does this change actually do?

Before, the CLI wire already forwarded `html`, but generated help/schema and agent guidance described only three document kinds. After, the advertised contract matches backend #143 and agents have an explicit route from a search hit to slug-addressed HTML operations.

### What could break?

Misrouting an HTML hit into CRDT body operations would return `409 unsupported_doc_type`; the skill now forbids that route. Advertising HTML without authoritative visibility could expose body highlights; backend search computes the MySQL-visible `doc_id` set before querying OpenSearch, and the real E2E exercised the mounted registration/index/search path.

### How do you know it works?

The full Go gates pass, registry tests pin `doc/sheet/board/html`, request tests assert `doc + board + html` serialization, and the real publish → registration → Kafka → S3 extraction → OpenSearch → CLI search chain returned the expected HTML hit.
