### PR TITLE
feat(docs): add the docs invite command family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli docs invite` family** (4 commands) — link invites for an online
+  document, generated from `docs.json`: `invite create` mints a token granting
+  `reader` | `commenter` | `writer` | `admin` (default `writer`) for 1–7 days
+  (`--expiresInDays`, default 3) with an optional accept cap (`--maxUses`,
+  `0` = unlimited),
+  `invite list` shows a doc's live invites with their usage counters,
+  `invite revoke` kills one, and `invite accept` claims one for the credential in
+  use. Three details differ from the `drive invite` family and are pinned by
+  tests: the role vocabulary is the full docs member ladder
+  `reader|commenter|writer|admin` (docs-backend's invite `parseRole` accepts all
+  four — only an *omitted* role takes the `writer` default, and an unrecognised
+  one is a `400`, never a downgrade), the lifetime is `expiresInDays` and not
+  `expires_in_seconds`, and **revoke is addressed by the invite token**
+  (`--invite-token`) because the docs backend stores no separate invite id.
+  Accept is idempotent — repeating it, or accepting into a document you already
+  belong to, is still `200` with the resulting role and never downgrades a higher
+  role already held; an unknown, revoked, expired or exhausted token is
+  `410 invite_invalid`.
+  - **`invite accept` also takes the whole invite link.** The web app serves
+    invites at `{octo web origin}/docs/invite/<token>`, so pasting that link
+    works. It is parsed locally under the same strict same-origin rules as
+    `drive share access` and is **never fetched**: the host is only compared
+    against `OCTO_API_BASE_URL`, and a link on another host, with embedded
+    credentials, a downgraded scheme, a percent-encoded path or extra segments is
+    refused with `INVALID_INVITE_URL` (exit 2) before any request.
+  - **Invite tokens are credential-equivalent** and declared `x-octo-secret`, so
+    they are masked in `--dry-run` and `--verbose` traces and never echoed in a
+    rejection message. `invite create`'s success envelope necessarily carries the
+    token in full — it is the deliverable — so that output is not safe to paste
+    into a ticket.
 - **`octo-cli marketplace expert` / `squad` families** — CRUD, `mine` lists,
   taxonomy (`expert-category` / `expert-tag`), viewable `skillmd get`, presigned
   `expert-skill-upload create` / `skill-download` for the Expert Marketplace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ octo-cli docs      create | list | search | get | rename | delete | forward-gran
                scene    get|edit|export
                members  list|set|remove
                share    get|set
+               invite   create|list|revoke|accept
                comments list|add|edit|delete
                versions list|create|state|rename|delete|restore
                attachments presign|get|resolve

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `docs`    | 32  | Documents, spreadsheets & whiteboards — lifecycle, full-text search, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
+| `docs`    | 36  | Documents, spreadsheets & whiteboards — lifecycle, full-text search, body content, sheet cells (paged read), board scenes, members, invite links, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `drive`   | 42  | Network drive — spaces & members, folder/file tree, two-phase blob upload & signed download, online-document mounts, share links, invites, IM-attachment transfer. Plus 3 composite commands (`upload file`, `download file`, `share create`) for 45 leaves total |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |

--- a/cmd/docs_inviteurl.go
+++ b/cmd/docs_inviteurl.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/cmd/service"
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/internal/output"
+)
+
+// docsInvitePathPrefix is where the Octo web app serves a document invite link:
+// {octo web origin}/docs/invite/<inviteToken>.
+const docsInvitePathPrefix = "/docs/invite/"
+
+// inviteLinkPolicy is the invite-link spelling of the shared link rules: the
+// same enforcement as a share link, reported as INVALID_INVITE_URL with a hint
+// naming the two accepted forms.
+var inviteLinkPolicy = linkPolicy{noun: "invite link", fail: invalidInviteURL}
+
+// docsInviteAcceptOp is the operation this file wraps. It is named once, here,
+// because the wrapper's correctness depends on it matching the spec: see
+// registerDocsInviteAcceptURL for what happens when it stops matching.
+const docsInviteAcceptOp = "docs.invite.accept"
+
+// registerDocsInviteAcceptURL lets `docs invite accept` take the whole invite
+// link in place of the bare token.
+//
+// The leaf itself stays the generated one — flags, risk gate, secret masking and
+// `octo-cli schema docs.invite.accept` all keep coming from the spec. Only the
+// *value* of the inviteToken slot is normalised first, because that is the whole
+// difference: the backend endpoint is unchanged, and what a person actually has
+// in hand is the link the web app gave them, not the token buried in it.
+//
+// Wrapping rather than detaching is deliberate. A hand-written composite (the
+// shape `drive share access` needs, because it takes an argument the engine
+// cannot express at all) would have to re-derive the path, the mount, the risk
+// annotation and the secret list, and would drift from the spec the first time
+// one of them changed. Here the engine still builds and runs the request.
+//
+// # Why the shape is asserted rather than tolerated
+//
+// This function used to return quietly whenever it could not find what it was
+// looking for. That made the whole feature silently optional: rename the
+// operationId, regroup the leaf, or change the flag, and link support would
+// vanish with nothing failing — and the first symptom would be a user pasting a
+// link and getting a backend 410 for a "token" that is really a whole URL.
+//
+// So the expectation is derived from the registry instead of assumed. If the
+// embedded spec does not declare the operation at all, there is genuinely
+// nothing to wrap and returning is correct. If it *does* declare it, the command
+// tree must carry the matching leaf with a runnable RunE and a string
+// invite-token flag, and anything else is a wiring bug in embedded data — the
+// same class registry.MustNew panics on (internal/registry/loader.go:96, used by
+// cmdutil's default RegistryFunc on the stated grounds that "specs are embedded;
+// parse failure is a build-time bug"). It panics for the same reason: it cannot
+// be provoked by user input or by the network, only by a change in this repo,
+// and every test that builds a root command runs straight into it.
+func registerDocsInviteAcceptURL(root *cobra.Command, f *cmdutil.Factory) {
+	reg := f.Registry()
+	if reg == nil {
+		return
+	}
+	if _, declared := reg.GetOperation(docsInviteAcceptOp); !declared {
+		// The spec does not offer this operation (a fixture registry, or the
+		// operation withdrawn on purpose). Nothing to wrap, and nothing lost.
+		return
+	}
+
+	accept := docsInviteAcceptLeaf(root)
+	if accept == nil {
+		panic(docsInviteAcceptOp + " is declared in the embedded spec but `docs invite accept` is not in the " +
+			"command tree: the invite-link wrapper in cmd/docs_inviteurl.go has nothing to attach to, so pasting " +
+			"an invite link would send the whole URL to the backend as a token. Re-point the wrapper at the leaf " +
+			"the spec now produces.")
+	}
+	if accept.RunE == nil {
+		panic(docsInviteAcceptOp + " leaf has no RunE, so the invite-link wrapper would replace nothing " +
+			"(cmd/docs_inviteurl.go).")
+	}
+	if flag := accept.Flags().Lookup(docsInviteTokenFlag); flag == nil || flag.Value.Type() != "string" {
+		panic(docsInviteAcceptOp + " leaf has no string --" + docsInviteTokenFlag + " flag, which is the slot the " +
+			"invite-link wrapper rewrites (cmd/docs_inviteurl.go). Check x-octo-flag on the inviteToken path " +
+			"parameter in internal/registry/specs/docs.json.")
+	}
+
+	generated := accept.RunE
+	accept.RunE = func(cmd *cobra.Command, args []string) error {
+		if err := normalizeInviteTokenArg(cmd, f, args); err != nil {
+			return failErr(f, err)
+		}
+		return generated(cmd, args)
+	}
+	accept.Long += docsInviteLinkHelp
+}
+
+// docsInviteAcceptLeaf walks root to the generated `docs invite accept` leaf, or
+// returns nil if any step of the path is missing. Split out so a test can assert
+// the wrapper landed on the same command a user reaches.
+func docsInviteAcceptLeaf(root *cobra.Command) *cobra.Command {
+	cur := root
+	for _, name := range []string{"docs", "invite", "accept"} {
+		if cur == nil {
+			return nil
+		}
+		cur = service.FindChild(cur, name)
+	}
+	return cur
+}
+
+// docsInviteTokenFlag is the flag form of the inviteToken path parameter
+// (x-octo-flag in docs.json). The wrapper rewrites this slot, so the name is a
+// contract between this file and the spec.
+const docsInviteTokenFlag = "invite-token"
+
+// docsInviteLinkHelp is the help text the wrapper appends. It is a package-level
+// constant so a test can assert it is present on the assembled leaf and absent
+// from a bare generated one — i.e. that the wrapper is what put it there.
+const docsInviteLinkHelp = "\n\n<invite-token> may also be given as the whole invite link " +
+	"(" + docsInvitePathPrefix + "<token> on the configured Octo origin). The link is " +
+	"parsed locally and never fetched: only the token is extracted, and the request goes " +
+	"to the configured Octo API."
+
+// normalizeInviteTokenArg rewrites the inviteToken value in place when the
+// caller supplied a link instead of a token. A bare token is left untouched, so
+// the ordinary path is byte-identical to the generated leaf's.
+func normalizeInviteTokenArg(cmd *cobra.Command, f *cmdutil.Factory, args []string) *output.ExitError {
+	if cmd.Flags().Changed(docsInviteTokenFlag) {
+		raw, err := cmd.Flags().GetString(docsInviteTokenFlag)
+		if err != nil {
+			// Fail closed. The caller set the flag, so a value exists and this
+			// code cannot read it; forwarding regardless would hand an
+			// unvalidated value — possibly a whole URL — straight to the
+			// backend, which is exactly the check this wrapper exists to make.
+			// registerDocsInviteAcceptURL already refuses to attach unless the
+			// flag is a string, so reaching here means the leaf changed shape
+			// under us at runtime.
+			return invalidInviteURL("the --" + docsInviteTokenFlag + " value could not be read for checking")
+		}
+		token, verr := inviteTokenFromValue(f, raw)
+		if verr != nil {
+			return verr
+		}
+		if token != raw {
+			if err := cmd.Flags().Set(docsInviteTokenFlag, token); err != nil {
+				return invalidInviteURL("the invite link could not be reduced to its token")
+			}
+		}
+		return nil
+	}
+	if len(args) == 0 {
+		return nil // the engine reports the missing-value error, naming both forms
+	}
+	token, verr := inviteTokenFromValue(f, args[0])
+	if verr != nil {
+		return verr
+	}
+	args[0] = token
+	return nil
+}
+
+// inviteTokenFromValue returns the invite token a caller supplied, accepting
+// either the token itself or the link that contains it.
+//
+// A value with no "/" cannot be a link — an absolute URL needs one for its
+// authority and a site-relative path starts with one, and the token charset
+// (isShareIDChar) excludes it — so a bare token is returned as given without
+// even resolving the configured origin. Everything else is parsed as a link,
+// which means a mistyped link fails as a link rather than being forwarded to the
+// backend as a nonsense token.
+func inviteTokenFromValue(f *cmdutil.Factory, raw string) (string, *output.ExitError) {
+	trimmed := strings.TrimSpace(raw)
+	if !strings.Contains(trimmed, "/") {
+		return raw, nil
+	}
+	cfg, err := f.Config()
+	if err != nil {
+		return "", output.ErrWithHint("config", "MISSING_API_BASE_URL",
+			"the invite link cannot be checked because the configuration is unreadable",
+			"set "+config.EnvAPIBaseURL+", or pass the bare invite token instead of the link")
+	}
+	return parseInviteURL(cfg, trimmed)
+}
+
+// parseInviteURL resolves a document invite link to its token, refusing
+// anything that is not an invite link on the configured Octo origin.
+//
+// This is the same boundary parseShareURL draws, for the same reason and with
+// the same rules — an invite link arrives from another person, so the CLI must
+// never fetch it. The link's host is only ever *compared* against the configured
+// Octo origin; the request that follows goes to the configured API with the
+// token that was parsed out. Rejected, exactly as on the share path: any other
+// host, userinfo in the authority, a non-http(s) scheme, a scheme that differs
+// from the configured origin's, percent-encoding in the path (%2F would decode
+// to a slash and smuggle extra segments past the shape check), extra path
+// segments, and an empty or malformed token.
+//
+// The two share the enforcement helpers (assertSameOrigin, assertShareIDSegment)
+// rather than restating them, so a future hardening of the share boundary
+// applies here too instead of leaving a second, older copy behind.
+func parseInviteURL(cfg *config.Config, raw string) (string, *output.ExitError) {
+	if raw == "" {
+		return "", invalidInviteURL("the invite link is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		// urlParseCause, not err: *url.Error.Error() quotes its whole input, and
+		// the whole input here is the link, whose last path segment is the invite
+		// token. The inner cause names what was wrong without repeating it.
+		return "", invalidInviteURL(fmt.Sprintf("not a valid URL: %v", urlParseCause(err)))
+	}
+	origin, oerr := webOrigin(cfg)
+	if oerr != nil {
+		return "", oerr
+	}
+	if verr := assertSameOrigin(u, origin, inviteLinkPolicy); verr != nil {
+		return "", verr
+	}
+	if !strings.HasPrefix(u.Path, docsInvitePathPrefix) {
+		// The path is not echoed: it contains the token on every link that is
+		// nearly right, and this runs before the token is known to be a secret.
+		return "", invalidInviteURL(fmt.Sprintf(
+			"the link path is not a document invite link; expected %s<inviteToken>", docsInvitePathPrefix))
+	}
+	token := strings.TrimPrefix(u.Path, docsInvitePathPrefix)
+	if verr := assertShareIDSegment("invite token", token, inviteLinkPolicy); verr != nil {
+		return "", verr
+	}
+	return token, nil
+}
+
+// invalidInviteURL is the shared failure for an unusable invite link. The
+// message never carries the link or the token.
+func invalidInviteURL(msg string) *output.ExitError {
+	return output.ErrWithHint("validation", "INVALID_INVITE_URL", msg,
+		"pass the invite link exactly as `octo-cli docs invite create` / the web app produced it, "+
+			"or pass the bare inviteToken")
+}

--- a/cmd/drive_share.go
+++ b/cmd/drive_share.go
@@ -280,7 +280,7 @@ func runDriveShareCreate(cmd *cobra.Command, f *cmdutil.Factory, fileID string, 
 		// same situation as the document branch's ref_id: hold it to the charset
 		// the consuming side enforces so this command cannot emit a share_url that
 		// `share access` would then refuse.
-		if verr := assertShareIDSegment("share token", share.ID); verr != nil {
+		if verr := assertShareIDSegment("share token", share.ID, shareLinkPolicy); verr != nil {
 			return failErr(f, verr)
 		}
 		return emitJSON(f, shareTarget{
@@ -379,7 +379,7 @@ func emitDocShareTarget(f *cmdutil.Factory, origin *url.URL, entry *driveEntryRe
 	// (assertShareIDSegment, used by `share access`) so this command cannot hand
 	// out a link its own parser would refuse — a `?`, `#`, space or slash in a
 	// ref_id would otherwise produce a structurally different URL.
-	if verr := assertShareIDSegment("document id", docID); verr != nil {
+	if verr := assertShareIDSegment("document id", docID, shareLinkPolicy); verr != nil {
 		return failErr(f, verr)
 	}
 	return emitJSON(f, shareTarget{

--- a/cmd/drive_shareurl.go
+++ b/cmd/drive_shareurl.go
@@ -77,14 +77,14 @@ func parseShareURL(cfg *config.Config, raw string) (*parsedShareURL, *output.Exi
 	if oerr != nil {
 		return nil, oerr
 	}
-	if verr := assertSameOrigin(u, origin); verr != nil {
+	if verr := assertSameOrigin(u, origin, shareLinkPolicy); verr != nil {
 		return nil, verr
 	}
 
 	switch {
 	case strings.HasPrefix(u.Path, blobSharePathPrefix):
 		token := strings.TrimPrefix(u.Path, blobSharePathPrefix)
-		if verr := assertShareIDSegment("share token", token); verr != nil {
+		if verr := assertShareIDSegment("share token", token, shareLinkPolicy); verr != nil {
 			return nil, verr
 		}
 		return &parsedShareURL{
@@ -96,7 +96,7 @@ func parseShareURL(cfg *config.Config, raw string) (*parsedShareURL, *output.Exi
 
 	case strings.HasPrefix(u.Path, docSharePathPrefix):
 		docID := strings.TrimPrefix(u.Path, docSharePathPrefix)
-		if verr := assertShareIDSegment("document id", docID); verr != nil {
+		if verr := assertShareIDSegment("document id", docID, shareLinkPolicy); verr != nil {
 			return nil, verr
 		}
 		docSpaceID := strings.TrimSpace(u.Query().Get(docSpaceQueryParam))
@@ -122,8 +122,29 @@ func parseShareURL(cfg *config.Config, raw string) (*parsedShareURL, *output.Exi
 		blobSharePathPrefix, docSharePathPrefix))
 }
 
+// linkPolicy names the kind of link being parsed and how to fail it, so the two
+// enforcement helpers below can be shared by every command that accepts a link
+// someone else handed over.
+//
+// It exists because the rules — not the wording — are the load-bearing part. A
+// second link surface (`docs invite accept`, cmd/docs_inviteurl.go) needs the
+// identical same-origin and segment checks, and the alternative to a parameter
+// here was a second copy that a future hardening of this one would not reach.
+// The drive spellings are the zero value of this indirection: shareLinkPolicy
+// reproduces the previous strings and code exactly.
+type linkPolicy struct {
+	// noun is how the link is named in a diagnostic ("share link").
+	noun string
+	// fail builds the rejection, and owns the error code and hint.
+	fail func(msg string) *output.ExitError
+}
+
+// shareLinkPolicy is the drive share-link spelling: INVALID_SHARE_URL, worded
+// as before.
+var shareLinkPolicy = linkPolicy{noun: "share link", fail: invalidShareURL}
+
 // assertSameOrigin enforces the "compare, never contact" rule for an incoming
-// share link. A site-relative link has no authority to check. An absolute one
+// link. A site-relative link has no authority to check. An absolute one
 // must match the configured origin exactly — same scheme, and host equal
 // (comparison is case-insensitive but includes the port, so a link on another
 // port is a different origin) — and must carry no userinfo, which would
@@ -138,25 +159,25 @@ func parseShareURL(cfg *config.Config, raw string) (*parsedShareURL, *output.Exi
 // Percent-encoding in the path is refused rather than decoded: %2F would decode
 // to a slash and let a crafted link pass the later shape check while actually
 // addressing a different path.
-func assertSameOrigin(u, origin *url.URL) *output.ExitError {
+func assertSameOrigin(u, origin *url.URL, p linkPolicy) *output.ExitError {
 	if u.IsAbs() || u.Host != "" {
 		if u.User != nil {
-			return invalidShareURL("the share link must not embed credentials")
+			return p.fail("the " + p.noun + " must not embed credentials")
 		}
 		if u.Scheme != "http" && u.Scheme != "https" {
-			return invalidShareURL(fmt.Sprintf("unsupported scheme %q", u.Scheme))
+			return p.fail(fmt.Sprintf("unsupported scheme %q", u.Scheme))
 		}
 		if !strings.EqualFold(u.Scheme, origin.Scheme) {
-			return invalidShareURL(fmt.Sprintf(
-				"the share link scheme %q is not the configured Octo origin's scheme %q", u.Scheme, origin.Scheme))
+			return p.fail(fmt.Sprintf(
+				"the %s scheme %q is not the configured Octo origin's scheme %q", p.noun, u.Scheme, origin.Scheme))
 		}
 		if !strings.EqualFold(u.Host, origin.Host) {
-			return invalidShareURL(fmt.Sprintf(
-				"the share link host %q is not the configured Octo origin %q", u.Host, origin.Host))
+			return p.fail(fmt.Sprintf(
+				"the %s host %q is not the configured Octo origin %q", p.noun, u.Host, origin.Host))
 		}
 	}
 	if u.EscapedPath() != u.Path {
-		return invalidShareURL("the share link path must not be percent-encoded")
+		return p.fail("the " + p.noun + " path must not be percent-encoded")
 	}
 	return nil
 }
@@ -170,19 +191,19 @@ func assertSameOrigin(u, origin *url.URL) *output.ExitError {
 // url.PathEscape does not escape it, so a segment that is exactly "." or ".."
 // would reach the URL as a real dot segment — see rejectDotSegments in
 // cmd/service for why that matters on a DELETE.
-func assertShareIDSegment(what, seg string) *output.ExitError {
+func assertShareIDSegment(what, seg string, p linkPolicy) *output.ExitError {
 	if seg == "" {
-		return invalidShareURL("the " + what + " is missing from the link")
+		return p.fail("the " + what + " is missing from the link")
 	}
 	if strings.Contains(seg, "/") {
-		return invalidShareURL("the link has extra path segments after the " + what)
+		return p.fail("the link has extra path segments after the " + what)
 	}
 	if seg == "." || seg == ".." {
-		return invalidShareURL(fmt.Sprintf("the %s must be an id, not the path segment %q", what, seg))
+		return p.fail(fmt.Sprintf("the %s must be an id, not the path segment %q", what, seg))
 	}
 	for i := 0; i < len(seg); i++ {
 		if !isShareIDChar(seg[i]) {
-			return invalidShareURL(fmt.Sprintf("the %s contains an unexpected character %q", what, string(seg[i])))
+			return p.fail(fmt.Sprintf("the %s contains an unexpected character %q", what, string(seg[i])))
 		}
 	}
 	return nil

--- a/cmd/drive_shareurl_test.go
+++ b/cmd/drive_shareurl_test.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
 	"github.com/Mininglamp-OSS/octo-cli/internal/config"
 )
 
@@ -205,5 +209,310 @@ func TestShareRealRun_AlsoMasksTheToken(t *testing.T) {
 	}
 	if !strings.Contains(out, "share_url") {
 		t.Errorf("share_url was dropped rather than masked:\n%s", out)
+	}
+}
+
+// --- document invite links ---
+//
+// These live beside the share-link tests rather than in a file of their own
+// because they exercise the SAME boundary: `docs invite accept` reuses
+// assertSameOrigin and assertShareIDSegment (cmd/docs_inviteurl.go), so a
+// hardening applied to one surface must be observably true of both. Splitting
+// them would have left two half-lists that drift.
+
+// TestParseInviteURL_Accepts covers the shapes a person can actually paste: the
+// whole link the web app shows, absolute or site-relative.
+func TestParseInviteURL_Accepts(t *testing.T) {
+	cfg := &config.Config{APIBaseURL: "https://octo.example.com"}
+	const token = "Ab3cDeFgHiJkLmN0pQrS"
+	for _, tc := range []struct{ name, in string }{
+		{"absolute link", "https://octo.example.com" + docsInvitePathPrefix + token},
+		{"relative link", docsInvitePathPrefix + token},
+		{"link with surrounding whitespace", "  https://octo.example.com" + docsInvitePathPrefix + token + "  "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseInviteURL(cfg, strings.TrimSpace(tc.in))
+			if err != nil {
+				t.Fatalf("parseInviteURL(%q): %v", tc.in, err)
+			}
+			if got != token {
+				t.Errorf("token: got %q, want %q", got, token)
+			}
+		})
+	}
+}
+
+// TestParseInviteURL_Rejects is the SSRF test for the invite surface. An invite
+// link arrives from another person, so it is untrusted: the CLI must refuse
+// anything that is not an invite path on the configured origin, and must never
+// be in a position to fetch an attacker-chosen host. The case list mirrors
+// TestParseShareURL_Rejects deliberately — the same rules, asserted on the same
+// inputs, so neither surface can quietly enforce less than the other.
+func TestParseInviteURL_Rejects(t *testing.T) {
+	cfg := &config.Config{APIBaseURL: "https://octo.example.com"}
+	for _, tc := range []struct{ name, in string }{
+		{"foreign host", "https://evil.example.com/docs/invite/tok-1"},
+		{"host that merely shares a suffix", "https://notocto.example.com/docs/invite/tok-1"},
+		{"host with an added port", "https://octo.example.com:8443/docs/invite/tok-1"},
+		{"embedded credentials", "https://user:pw@octo.example.com/docs/invite/tok-1"},
+		{"downgraded scheme", "http://octo.example.com/docs/invite/tok-1"},
+		{"file scheme", "file:///etc/passwd"},
+		{"gopher scheme", "gopher://octo.example.com/docs/invite/tok-1"},
+		{"encoded slash smuggling a segment", "https://octo.example.com/docs/invite/tok%2F..%2Fadmin"},
+		{"extra path segment", "https://octo.example.com/docs/invite/tok-1/extra"},
+		{"empty token", "https://octo.example.com/docs/invite/"},
+		{"dot segment as the token", "https://octo.example.com/docs/invite/.."},
+		{"the share path, not an invite path", "https://octo.example.com/drive/s/tok-1"},
+		{"unrelated path", "https://octo.example.com/v1/bot/docs/invites"},
+		{"empty input", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseInviteURL(cfg, tc.in)
+			if err == nil {
+				t.Fatalf("parseInviteURL(%q) should have failed, got %q", tc.in, got)
+			}
+			if err.Code != "INVALID_INVITE_URL" {
+				t.Errorf("code: got %q, want INVALID_INVITE_URL (%s)", err.Code, err.Message)
+			}
+			if err.ExitCode() != 2 {
+				t.Errorf("exit code: got %d, want 2", err.ExitCode())
+			}
+		})
+	}
+}
+
+// TestParseInviteURL_NeverEchoesTheToken is the invite-side counterpart of
+// TestParseShareURL_ParseFailureDoesNotEchoTheLink. The whole argument is the
+// link and its last segment is the invite token, so every rejection path — not
+// just the url.Parse wrapper — has to name the mistake without quoting the value.
+func TestParseInviteURL_NeverEchoesTheToken(t *testing.T) {
+	const token = "Ab3cDeFgHiJkLmN0pQrS"
+	cfg := &config.Config{APIBaseURL: "https://octo.example.com"}
+
+	for _, tc := range []struct{ name, raw string }{
+		{"control character in the link", "https://octo.example.com/docs/invite/" + token + "\x7f"},
+		{"invalid percent escape", "https://octo.example.com/docs/invite/" + token + "%zz"},
+		{"malformed IPv6 authority", "https://[::1/docs/invite/" + token},
+		{"foreign host", "https://evil.example.com/docs/invite/" + token},
+		{"embedded credentials", "https://user:pw@octo.example.com/docs/invite/" + token},
+		{"wrong path shape", "https://octo.example.com/nope/" + token},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseInviteURL(cfg, tc.raw)
+			if err == nil {
+				t.Fatal("a malformed or foreign invite link must be refused")
+			}
+			visible := err.Message + " " + err.Hint + " " + string(err.Detail)
+			if strings.Contains(visible, token) {
+				t.Errorf("the invite token reached the error envelope: %s", visible)
+			}
+			if err.Message == "" {
+				t.Error("stripping the input must not strip the reason")
+			}
+		})
+	}
+}
+
+// TestInviteTokenFromValue_BareTokenPassesThrough pins the other half of the
+// contract: a bare token is NOT a link and must be forwarded untouched, without
+// even consulting the configured origin. base64url tokens contain "-", "_" and
+// "." and must all survive; the one character that forces link parsing is "/",
+// which the token charset excludes.
+func TestInviteTokenFromValue_BareTokenPassesThrough(t *testing.T) {
+	// No config is set on this factory: reaching webOrigin would fail, which is
+	// what proves the bare-token path never gets there.
+	f := cmdutil.NewTestFactory()
+	for _, token := range []string{
+		"Ab3cDeFgHiJkLmN0pQrS",
+		"-leading-dash-token",
+		"tok_with.dots-and_underscores",
+	} {
+		t.Run(token, func(t *testing.T) {
+			got, err := inviteTokenFromValue(f.Factory, token)
+			if err != nil {
+				t.Fatalf("a bare token must pass through: %v", err)
+			}
+			if got != token {
+				t.Errorf("token: got %q, want %q unchanged", got, token)
+			}
+		})
+	}
+}
+
+// TestDocsInviteAccept_TakesALinkOrAToken drives the real command tree end to
+// end: both spellings must produce the same request, and neither must send the
+// token anywhere except the configured Octo API. A link on another host must
+// fail locally with no request at all — that is the property the whole parser
+// exists for.
+func TestDocsInviteAccept_TakesALinkOrAToken(t *testing.T) {
+	const token = "Ab3cDeFgHiJkLmN0pQrS"
+
+	t.Run("whole invite link", func(t *testing.T) {
+		var gotPath string
+		tf, srv := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_, _ = w.Write([]byte(`{"docId":"d1","documentName":"Plan","role":"writer"}`))
+		})
+		link := srv.URL + docsInvitePathPrefix + token
+		if _, _, err := execRoot(t, tf, "docs", "invite", "accept", link); err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		if want := "/v1/bot/docs/invites/" + token + "/accept"; gotPath != want {
+			t.Errorf("path: got %q, want %q", gotPath, want)
+		}
+	})
+
+	t.Run("bare token", func(t *testing.T) {
+		var gotPath string
+		tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_, _ = w.Write([]byte(`{"docId":"d1","documentName":"Plan","role":"writer"}`))
+		})
+		if _, _, err := execRoot(t, tf, "docs", "invite", "accept", token); err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		if want := "/v1/bot/docs/invites/" + token + "/accept"; gotPath != want {
+			t.Errorf("path: got %q, want %q", gotPath, want)
+		}
+	})
+
+	t.Run("link via the --invite-token flag", func(t *testing.T) {
+		var gotPath string
+		tf, srv := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_, _ = w.Write([]byte(`{"docId":"d1","documentName":"Plan","role":"writer"}`))
+		})
+		link := srv.URL + docsInvitePathPrefix + token
+		if _, _, err := execRoot(t, tf, "docs", "invite", "accept", "--invite-token", link); err != nil {
+			t.Fatalf("accept: %v", err)
+		}
+		if want := "/v1/bot/docs/invites/" + token + "/accept"; gotPath != want {
+			t.Errorf("path: got %q, want %q", gotPath, want)
+		}
+	})
+
+	t.Run("link on another host is refused without a request", func(t *testing.T) {
+		var called bool
+		tf, _ := importTestRoot(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+		_, stderr, err := execRoot(t, tf, "docs", "invite", "accept",
+			"https://evil.example.com"+docsInvitePathPrefix+token)
+		if err == nil {
+			t.Fatal("a link on a foreign origin must be refused")
+		}
+		if called {
+			t.Error("the CLI must not contact anything for a rejected link")
+		}
+		if !strings.Contains(stderr, "INVALID_INVITE_URL") {
+			t.Errorf("stderr should carry INVALID_INVITE_URL:\n%s", stderr)
+		}
+		if strings.Contains(stderr, token) {
+			t.Errorf("the invite token appears in the error envelope:\n%s", stderr)
+		}
+	})
+}
+
+// TestDocsInviteAcceptURL_WrapperIsInstalledOnTheSpecLeaf pins the wiring
+// itself, which every test above takes for granted.
+//
+// registerDocsInviteAcceptURL finds its target by walking docs → invite → accept
+// and used to return quietly when any step came up empty. That made link support
+// silently optional: rename the operationId, regroup the leaf, or drop the
+// x-octo-flag, and the wrapper would stop attaching with nothing failing. The
+// user-visible result is not "links are unsupported" but something worse — the
+// whole URL goes to the backend as if it were a token, and comes back 410.
+//
+// So this asserts the three facts that together mean the wrapper is live on the
+// command a user actually reaches: the spec declares the operation, the leaf
+// exists with the string flag the wrapper rewrites, and the leaf's help carries
+// the text only the wrapper appends. Any degradation that detaches the wrapper
+// fails here rather than in production.
+func TestDocsInviteAcceptURL_WrapperIsInstalledOnTheSpecLeaf(t *testing.T) {
+	tf := newTestFactoryWithReg()
+	tf.SetConfig(&config.Config{APIBaseURL: "https://octo.example.com", BotToken: "app_test", Format: "json"})
+
+	reg := tf.Factory.Registry()
+	if reg == nil {
+		t.Fatal("test factory has no registry")
+	}
+	if _, ok := reg.GetOperation(docsInviteAcceptOp); !ok {
+		t.Fatalf("the embedded spec no longer declares %s. If it was renamed, re-point "+
+			"cmd/docs_inviteurl.go at the new id: otherwise the invite-link wrapper attaches to nothing.",
+			docsInviteAcceptOp)
+	}
+
+	root := NewRootCmd(tf.Factory)
+	accept := docsInviteAcceptLeaf(root)
+	if accept == nil {
+		t.Fatalf("%s is declared but `docs invite accept` is not in the command tree", docsInviteAcceptOp)
+	}
+	flag := accept.Flags().Lookup(docsInviteTokenFlag)
+	if flag == nil {
+		t.Fatalf("`docs invite accept` has no --%s flag; the wrapper rewrites that slot", docsInviteTokenFlag)
+	}
+	if got := flag.Value.Type(); got != "string" {
+		t.Fatalf("--%s is a %s flag, not string; GetString would fail and the wrapper would refuse every value",
+			docsInviteTokenFlag, got)
+	}
+	if !strings.Contains(accept.Long, docsInviteLinkHelp) {
+		t.Errorf("`docs invite accept` help does not carry the invite-link paragraph, so the wrapper "+
+			"is not installed on this leaf; a pasted link would be sent to the backend verbatim.\nLong:\n%s",
+			accept.Long)
+	}
+}
+
+// TestRegisterDocsInviteAcceptURL_PanicsWhenTheLeafIsGone is the other half of
+// the invariant: when the spec still declares the operation but the tree does not
+// carry the leaf, registration must fail loudly instead of skipping. The panic is
+// the same policy registry.MustNew applies to embedded data
+// (internal/registry/loader.go:96) — unreachable from user input or the network,
+// reachable only by a change in this repo, and hit by every test that builds a
+// root command.
+func TestRegisterDocsInviteAcceptURL_PanicsWhenTheLeafIsGone(t *testing.T) {
+	tf := newTestFactoryWithReg()
+	// A root with no service commands at all: the operation is still declared by
+	// the embedded spec, so the leaf is missing rather than withdrawn.
+	bare := &cobra.Command{Use: "octo-cli"}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("registration silently skipped a missing accept leaf; link support would vanish unnoticed")
+		}
+		if !strings.Contains(fmt.Sprint(r), docsInviteAcceptOp) {
+			t.Errorf("the panic must name the operation that went missing; got %v", r)
+		}
+	}()
+	registerDocsInviteAcceptURL(bare, tf.Factory)
+}
+
+// TestNormalizeInviteTokenArg_FailsClosedOnAnUnreadableFlag pins the deny side of
+// the value check.
+//
+// This branch used to `return nil` — treating "I cannot read the value" as "the
+// value is fine" — which is fail-open on the one code path whose entire job is to
+// decide whether a caller-supplied string may be forwarded. If it ever fires for
+// real, the value is an unvalidated string that may be a whole URL pointed at
+// someone else's host. The only safe answer is to refuse.
+func TestNormalizeInviteTokenArg_FailsClosedOnAnUnreadableFlag(t *testing.T) {
+	tf := newTestFactoryWithReg()
+	tf.SetConfig(&config.Config{APIBaseURL: "https://octo.example.com", BotToken: "app_test", Format: "json"})
+
+	// A leaf whose invite-token flag is not a string: GetString on it errors,
+	// which is the condition the old code let through.
+	cmd := &cobra.Command{Use: "accept"}
+	cmd.Flags().Int(docsInviteTokenFlag, 0, "wrong type on purpose")
+	if err := cmd.Flags().Set(docsInviteTokenFlag, "7"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := normalizeInviteTokenArg(cmd, tf.Factory, nil)
+	if err == nil {
+		t.Fatal("an unreadable --invite-token must be refused, not forwarded unchecked")
+	}
+	if err.Code != "INVALID_INVITE_URL" {
+		t.Errorf("code = %q, want INVALID_INVITE_URL", err.Code)
+	}
+	if err.ExitCode() != 2 {
+		t.Errorf("exit code = %d, want 2", err.ExitCode())
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func NewRootCmd(f *cmdutil.Factory) *cobra.Command {
 	attachMailJMAPCommands(root, f)
 	registerDocsImportCmd(root, f)
 	registerDocsExportCmd(root, f)
+	registerDocsInviteAcceptURL(root, f)
 	registerDriveCmds(root, f)
 	withholdDisabledServices(root, f)
 

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -5,10 +5,17 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
+	"github.com/Mininglamp-OSS/octo-cli/internal/client"
+	"github.com/Mininglamp-OSS/octo-cli/internal/cmdutil"
+	"github.com/Mininglamp-OSS/octo-cli/internal/config"
+	"github.com/Mininglamp-OSS/octo-cli/internal/credential"
 	"github.com/Mininglamp-OSS/octo-cli/internal/output"
 	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
 )
@@ -42,6 +49,7 @@ func TestDocs_TreeShape(t *testing.T) {
 		"scene":       {"get", "edit", "export"},
 		"members":     {"list", "set", "remove"},
 		"share":       {"get", "set"},
+		"invite":      {"create", "list", "revoke", "accept"},
 		"comments":    {"list", "add", "edit", "delete"},
 		"versions":    {"list", "create", "state", "rename", "delete", "restore"},
 		"attachments": {"presign", "get", "resolve"},
@@ -69,24 +77,30 @@ func TestDocs_RegistryShape(t *testing.T) {
 
 	type want struct{ method, path string }
 	cases := map[string]want{
-		"docs.create":              {"POST", "/v1/bot/docs"},
-		"docs.list":                {"GET", "/v1/bot/docs"},
-		"docs.search":              {"POST", "/v1/bot/docs/search"},
-		"docs.get":                 {"GET", "/v1/bot/docs/{docId}"},
-		"docs.rename":              {"PATCH", "/v1/bot/docs/{docId}"},
-		"docs.delete":              {"DELETE", "/v1/bot/docs/{docId}"},
-		"docs.content.get":         {"GET", "/v1/bot/docs/{docId}/content"},
-		"docs.content.edit":        {"PATCH", "/v1/bot/docs/{docId}/content"},
-		"docs.sheet.get":           {"GET", "/v1/bot/docs/{docId}/sheet"},
-		"docs.sheet.edit":          {"PATCH", "/v1/bot/docs/{docId}/sheet"},
-		"docs.scene.get":           {"GET", "/v1/bot/docs/{docId}/scene"},
-		"docs.scene.edit":          {"PATCH", "/v1/bot/docs/{docId}/scene"},
-		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
-		"docs.members.set":         {"PUT", "/v1/bot/docs/{docId}/members"},
-		"docs.members.remove":      {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
-		"docs.share.get":           {"GET", "/v1/bot/docs/{docId}/share"},
-		"docs.share.set":           {"PUT", "/v1/bot/docs/{docId}/share"},
-		"docs.forward-grant":       {"POST", "/v1/bot/docs/{docId}/forward-grant"},
+		"docs.create":         {"POST", "/v1/bot/docs"},
+		"docs.list":           {"GET", "/v1/bot/docs"},
+		"docs.search":         {"POST", "/v1/bot/docs/search"},
+		"docs.get":            {"GET", "/v1/bot/docs/{docId}"},
+		"docs.rename":         {"PATCH", "/v1/bot/docs/{docId}"},
+		"docs.delete":         {"DELETE", "/v1/bot/docs/{docId}"},
+		"docs.content.get":    {"GET", "/v1/bot/docs/{docId}/content"},
+		"docs.content.edit":   {"PATCH", "/v1/bot/docs/{docId}/content"},
+		"docs.sheet.get":      {"GET", "/v1/bot/docs/{docId}/sheet"},
+		"docs.sheet.edit":     {"PATCH", "/v1/bot/docs/{docId}/sheet"},
+		"docs.scene.get":      {"GET", "/v1/bot/docs/{docId}/scene"},
+		"docs.scene.edit":     {"PATCH", "/v1/bot/docs/{docId}/scene"},
+		"docs.members.list":   {"GET", "/v1/bot/docs/{docId}/members"},
+		"docs.members.set":    {"PUT", "/v1/bot/docs/{docId}/members"},
+		"docs.members.remove": {"DELETE", "/v1/bot/docs/{docId}/members/{uid}"},
+		"docs.share.get":      {"GET", "/v1/bot/docs/{docId}/share"},
+		"docs.share.set":      {"PUT", "/v1/bot/docs/{docId}/share"},
+		"docs.forward-grant":  {"POST", "/v1/bot/docs/{docId}/forward-grant"},
+		"docs.invite.create":  {"POST", "/v1/bot/docs/{docId}/invites"},
+		"docs.invite.list":    {"GET", "/v1/bot/docs/{docId}/invites"},
+		// revoke is addressed by the token, not by an id: the docs backend stores
+		// no separate invite id, which is the one shape difference from drive.
+		"docs.invite.revoke":       {"DELETE", "/v1/bot/docs/{docId}/invites/{inviteToken}"},
+		"docs.invite.accept":       {"POST", "/v1/bot/docs/invites/{inviteToken}/accept"},
 		"docs.comments.list":       {"GET", "/v1/bot/docs/{docId}/comments"},
 		"docs.comments.add":        {"POST", "/v1/bot/docs/{docId}/comments"},
 		"docs.comments.edit":       {"PATCH", "/v1/bot/docs/{docId}/comments/{id}"},
@@ -658,6 +672,240 @@ func TestDocsShareSet_FlagAliases(t *testing.T) {
 		if set.Flags().Lookup(bad) != nil {
 			t.Errorf("docs share set: --%s must NOT exist (aliased to --scope/--role)", bad)
 		}
+	}
+}
+
+// --- invites ---
+//
+// The invite family is spec-driven like the rest of docs, but it is the first
+// docs surface whose path values are credential-equivalent, and its shape
+// deliberately diverges from drive's invite family on points a copy-paste would
+// get wrong. These tests pin each divergence on the wire rather than in prose.
+
+// TestDocsInviteCreate_BodyAndPath pins the create request: a POST to the
+// document's /invites collection carrying the three body fields under their
+// backend names. expiresInDays is the docs spelling — drive's invite create
+// takes expires_in_seconds, and sending that here would be ignored, silently
+// leaving the invite on the backend's 3-day default.
+func TestDocsInviteCreate_BodyAndPath(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.WriteHeader(201)
+		_, _ = w.Write([]byte(`{"inviteToken":"tok-fake-1","role":"reader","expiresAt":"2030-01-01T00:00:00.000Z"}`))
+	})
+	root.SetArgs([]string{"docs", "invite", "create", "d1",
+		"--role", "reader", "--expiresInDays", "5", "--maxUses", "3"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v1/bot/docs/d1/invites" {
+		t.Errorf("got %s %s, want POST /v1/bot/docs/d1/invites", gotMethod, gotPath)
+	}
+	if gotBody["role"] != "reader" {
+		t.Errorf("body role = %v, want reader", gotBody["role"])
+	}
+	if gotBody["expiresInDays"] != float64(5) {
+		t.Errorf("body expiresInDays = %v, want 5", gotBody["expiresInDays"])
+	}
+	if gotBody["maxUses"] != float64(3) {
+		t.Errorf("body maxUses = %v, want 3", gotBody["maxUses"])
+	}
+	if _, bad := gotBody["expires_in_seconds"]; bad {
+		t.Errorf("body carries drive's expires_in_seconds, which docs ignores: %v", gotBody)
+	}
+}
+
+// TestDocsInviteCreate_RoleVocabularyIsTheFullLadder pins the invite role set.
+//
+// An earlier round pinned reader|writer|admin here, transcribed from a local
+// octo-docs-backend checkout that was ~86 commits behind origin. On origin/main
+// parseRole (src/api/routes/invites.ts) accepts the whole Role union —
+// reader|commenter|writer|admin — so the narrow set turned a call the backend
+// accepts into a hard local exit 2 with no way through except `octo-cli api`.
+// The other half is equally load-bearing: an unrecognised value is a backend 400
+// ("role must be reader|commenter|writer|admin"), never a silent downgrade, so
+// the local gate must refuse it before it costs a round trip.
+func TestDocsInviteCreate_RoleVocabularyIsTheFullLadder(t *testing.T) {
+	for _, role := range []string{"reader", "commenter", "writer", "admin"} {
+		t.Run("accepts "+role, func(t *testing.T) {
+			var called bool
+			var gotRole any
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				var body map[string]any
+				_ = json.NewDecoder(r.Body).Decode(&body)
+				gotRole = body["role"]
+				w.WriteHeader(201)
+				_, _ = w.Write([]byte(`{"inviteToken":"tok-fake-1","role":"` + role + `"}`))
+			})
+			root.SetArgs([]string{"docs", "invite", "create", "d1", "--role", role})
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if !called {
+				t.Fatal("a role the backend accepts must reach the backend")
+			}
+			if gotRole != role {
+				t.Errorf("body role = %v, want %q sent through unchanged", gotRole, role)
+			}
+		})
+	}
+
+	for _, bad := range []string{"bogus", "owner"} {
+		t.Run("refuses "+bad, func(t *testing.T) {
+			var called bool
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) { called = true })
+			root.SetArgs([]string{"docs", "invite", "create", "d1", "--role", bad})
+			err := root.Execute()
+			var exitErr *output.ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != "ENUM_NOT_ALLOWED" {
+				t.Fatalf("error = %#v, want ENUM_NOT_ALLOWED: the backend answers 400 for an unknown role", err)
+			}
+			if called {
+				t.Error("the rejected role must not reach the backend")
+			}
+		})
+	}
+}
+
+// TestDocsInviteList_ReadPath pins the list request: a GET on the same
+// collection, with no request body.
+func TestDocsInviteList_ReadPath(t *testing.T) {
+	var gotMethod, gotPath string
+	var gotBody []byte
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"items":[{"inviteToken":"tok-fake-1","role":"writer","maxUses":0,"usedCount":2}]}`))
+	})
+	root.SetArgs([]string{"docs", "invite", "list", "d1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "GET" || gotPath != "/v1/bot/docs/d1/invites" {
+		t.Errorf("got %s %s, want GET /v1/bot/docs/d1/invites", gotMethod, gotPath)
+	}
+	if len(gotBody) != 0 {
+		t.Errorf("GET must send an empty request body; got %q", gotBody)
+	}
+}
+
+// TestDocsInviteRevoke_AddressedByToken pins the shape difference from drive:
+// docs revoke takes the invite TOKEN in the path (the docs backend stores no
+// separate invite id), so the flag form is --invite-token, not drive's
+// --invite-id. Both spellings of the value must reach the same URL.
+func TestDocsInviteRevoke_AddressedByToken(t *testing.T) {
+	const token = "tok-fake-1"
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"positional", []string{"docs", "invite", "revoke", "d1", token}},
+		{"flag form", []string{"docs", "invite", "revoke", "d1", "--invite-token", token}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotMethod, gotPath string
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				gotMethod, gotPath = r.Method, r.URL.Path
+				w.WriteHeader(200)
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			})
+			root.SetArgs(tc.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if gotMethod != "DELETE" || gotPath != "/v1/bot/docs/d1/invites/"+token {
+				t.Errorf("got %s %s, want DELETE /v1/bot/docs/d1/invites/%s", gotMethod, gotPath, token)
+			}
+		})
+	}
+
+	// The drive spelling must not exist here, or a caller following the drive
+	// recipe passes the token to an unrecognised flag.
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {})
+	revoke := findCmd(findCmd(findCmd(root, "docs"), "invite"), "revoke")
+	if revoke == nil {
+		t.Fatal("missing docs invite revoke leaf")
+	}
+	if revoke.Flags().Lookup("invite-token") == nil {
+		t.Error("docs invite revoke: expected --invite-token")
+	}
+	if revoke.Flags().Lookup("invite-id") != nil {
+		t.Error("docs invite revoke: --invite-id must NOT exist (docs addresses an invite by its token)")
+	}
+}
+
+// TestDocsInviteAccept_PathAndSpaceHeader pins accept: it hangs off the
+// collection-level /invites path with no docId — the token identifies the
+// document — and, like the rest of docs, sends no X-Space-Id.
+func TestDocsInviteAccept_PathAndSpaceHeader(t *testing.T) {
+	const token = "tok-fake-1"
+	var gotMethod, gotPath, gotSpace string
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotSpace = r.Header.Get("X-Space-Id")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"docId":"d1","documentName":"Plan","role":"writer"}`))
+	})
+	root.SetArgs([]string{"docs", "invite", "accept", token})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != "POST" || gotPath != "/v1/bot/docs/invites/"+token+"/accept" {
+		t.Errorf("got %s %s, want POST /v1/bot/docs/invites/%s/accept", gotMethod, gotPath, token)
+	}
+	if gotSpace != "" {
+		t.Errorf("X-Space-Id = %q; docs declares x-octo-space-header:false", gotSpace)
+	}
+}
+
+// TestDocsInvite_TokensAreMaskedInDryRun is the disclosure guard for the family.
+// Both token-addressed operations put a credential-equivalent value in the URL
+// path, and --dry-run prints that path — so without x-octo-secret on those two
+// parameters the CLI's own "safe to paste" output hands the document over.
+func TestDocsInvite_TokensAreMaskedInDryRun(t *testing.T) {
+	const token = "tok-fake-1"
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"revoke", []string{"docs", "invite", "revoke", "d1", token}},
+		{"accept", []string{"docs", "invite", "accept", token}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { called = true }))
+			t.Cleanup(srv.Close)
+
+			tf := cmdutil.NewTestFactory()
+			cfg := &config.Config{APIBaseURL: srv.URL, BotToken: "app_test", Format: "json"}
+			tf.SetConfig(cfg)
+			cred := &credential.BotCredential{Token: "app_test", Source: "test"}
+			tf.SetCredential(cred)
+			tf.SetClient(client.New(cfg, cred, client.Options{DryRun: true, ErrOut: io.Discard}))
+			tf.RegistryFunc = registry.MustNew
+
+			root := &cobra.Command{Use: "octo-cli", SilenceUsage: true, SilenceErrors: true}
+			RegisterServiceCommands(root, tf.Factory)
+			root.SetArgs(tc.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if called {
+				t.Error("--dry-run must not hit the network")
+			}
+			out := tf.Out.String()
+			if strings.Contains(out, token) {
+				t.Errorf("the invite token appears in plaintext in the dry-run envelope:\n%s", out)
+			}
+			if !strings.Contains(out, `"dry_run": true`) {
+				t.Errorf("not a dry-run envelope:\n%s", out)
+			}
+		})
 	}
 }
 

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -158,6 +158,15 @@ var requestSideVocabularies = []vocabulary{
 	{op: "docs.versions.list", in: "query", field: "kind",
 		want: []string{"all", "auto", "manual"},
 		why:  "octo-docs-backend version kind filter"},
+	{op: "docs.invite.create", in: "body", field: "role",
+		want: []string{"reader", "commenter", "writer", "admin"},
+		why: "octo-docs-backend origin/main src/api/routes/invites.ts parseRole accepts exactly " +
+			"reader|commenter|writer|admin (the Role union in src/permission/role.ts); it is the same ladder as " +
+			"docs.members.set, not a narrower invite-only set. An UNRECOGNISED value is a 400 from the route " +
+			"(\"role must be reader|commenter|writer|admin\"), not a downgrade — only an OMITTED role takes " +
+			"parseRole's writer default. An earlier round pinned three values on the strength of a local " +
+			"checkout that was ~86 commits behind origin, which is the exact failure mode the remote-ref rule " +
+			"in this file's header exists to prevent"},
 
 	// --- html ---
 	{op: "html.grant.add", in: "body", field: "role",
@@ -288,6 +297,9 @@ func TestEnum_NoEnabledVocabularyIsNarrowerThanItsBackend(t *testing.T) {
 	}{
 		{"docs.members.set", "body", "role", "commenter",
 			"role.ts isMemberRole accepts it; it is a stored role with rank 20, deliberately between reader and writer"},
+		{"docs.invite.create", "body", "role", "commenter",
+			"invites.ts parseRole accepts the whole Role union; the stored code 4 is historical numbering, not a rank — " +
+				"roleRank puts commenter at 20, between reader and writer"},
 		{"docs.forward-grant", "body", "role", "commenter",
 			"role.ts isForwardGrantRole accepts it"},
 		{"docs.search", "body[]", "docType", "html_ppt",

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -44,7 +44,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":        4,
 		"bot":         6,
 		"event":       2,
-		"docs":        32,
+		"docs":        36,
 		"drive":       42,
 		"html":        20,
 		"marketplace": 44,

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -794,8 +794,8 @@
     "/v1/bot/docs/{docId}/forward-grant": {
       "post": {
         "operationId": "docs.forward-grant",
-        "summary": "Grant (never downgrade) a single uid reader/writer access (needs admin)",
-        "description": "Max-merge grant used when forwarding a doc to a chat recipient. Only reader or writer is grantable here; admin is not forward-grantable.",
+        "summary": "Grant (never downgrade) a single uid reader/commenter/writer access (needs admin)",
+        "description": "Max-merge grant used when forwarding a doc to a chat recipient. Only reader, commenter or writer is grantable here; admin is not forward-grantable.",
         "x-octo-risk": "write",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
@@ -816,6 +816,147 @@
           }
         },
         "responses": { "200": { "description": "Grant result (final role + changed flag)" } }
+      }
+    },
+    "/v1/bot/docs/{docId}/invites": {
+      "post": {
+        "operationId": "docs.invite.create",
+        "summary": "Create a document invite link token (needs admin)",
+        "description": "Mints a high-entropy inviteToken that grants the chosen role to whoever accepts it. The backend returns the token, the granted role and the computed expiry — never a URL: the share link is built by the frontend from its own origin as {octo web origin}/docs/invite/<inviteToken>. Anyone holding the token can claim the role, so treat it as a credential: hand it over out of band and revoke it when done.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "role": { "type": "string", "enum": ["reader", "commenter", "writer", "admin"], "default": "writer", "description": "role the invite grants — the full member-role ladder, in increasing order of capability. Matches octo-docs-backend parseRole (src/api/routes/invites.ts), which accepts exactly reader|commenter|writer|admin. Omitting role entirely is what selects the writer default; an unrecognised value is rejected by the backend with 400 'role must be reader|commenter|writer|admin', never downgraded. Note that commenter ranks BETWEEN reader and writer (roleRank in src/permission/role.ts: reader 10, commenter 20, writer 30, admin 40) even though its stored numeric code is 4 for historical reasons — read the ladder, not the code" },
+                  "expiresInDays": { "type": "integer", "default": 3, "minimum": 1, "maximum": 7, "description": "invite lifetime in days. The backend clamps to [1, 7] silently (never 400) and a missing/non-integer value becomes the default 3; there is no permanent invite link" },
+                  "maxUses": { "type": "integer", "default": 0, "description": "how many times the invite may be accepted; 0 (the default) means unlimited. A negative or non-integer value is treated as 0 by the backend" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "A freshly minted invite. The docs backend addresses an invite by its token alone — there is no invite id to hand back, which is why revoke also takes the token.",
+                  "properties": {
+                    "inviteToken": { "type": "string", "x-octo-secret": true, "description": "the invite secret; pass it to invite accept, or embed it in {octo web origin}/docs/invite/<inviteToken>. x-octo-secret marks the name credential-equivalent, which is what keeps every CLI surface that masks spec-declared secrets (the revoke/accept path parameters, verbose and dry-run traces) treating it as one. The create response necessarily carries the value in full — it is the whole deliverable — so do not paste this output into a ticket or a shared channel" },
+                    "role": { "type": "string", "description": "role the invite grants, as the backend resolved it: reader, commenter, writer or admin. It echoes what was requested; only an omitted role resolves to the writer default (an unrecognised one is 400, not a downgrade)" },
+                    "expiresAt": { "type": "string", "description": "ISO-8601 expiry the backend computed from expiresInDays; always set (there is no permanent invite)" }
+                  }
+                }
+              }
+            }
+          },
+          "403": { "description": "forbidden (caller is not a doc admin)" },
+          "404": { "description": "not_found (missing or cross-space doc)" }
+        }
+      },
+      "get": {
+        "operationId": "docs.invite.list",
+        "summary": "List a document's live invites (needs admin)",
+        "description": "Returns the still-active invites as {items:[…]}, each with its inviteToken, granted role, maxUses (0 = unlimited), usedCount and expiry. There is no {data, pagination} envelope, so --page-all does not apply. Every listed inviteToken is credential-equivalent: this output hands the document over to anyone who reads it.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active invites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One live invite. Same token `invite create` returned, plus its usage counters.",
+                        "properties": {
+                          "inviteToken": { "type": "string", "x-octo-secret": true, "description": "the invite secret; pass it to invite accept or invite revoke. Credential-equivalent — anyone holding it can claim the role" },
+                          "role": { "type": "string", "description": "role this invite grants: reader, commenter, writer or admin" },
+                          "maxUses": { "type": "integer", "description": "accept limit; 0 means unlimited" },
+                          "usedCount": { "type": "integer", "description": "how many times it has been accepted so far" },
+                          "expiresAt": { "type": "string", "description": "ISO-8601 expiry" }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": { "description": "forbidden (caller is not a doc admin)" },
+          "404": { "description": "not_found (missing or cross-space doc)" }
+        }
+      }
+    },
+    "/v1/bot/docs/{docId}/invites/{inviteToken}": {
+      "delete": {
+        "operationId": "docs.invite.revoke",
+        "summary": "Revoke an invite (needs admin)",
+        "description": "Revocation is addressed by the inviteToken itself — the docs backend stores no separate invite id, so unlike `drive invite revoke` (which takes an invite_id) this command needs the same secret value the invitees were given. A token that does not belong to this document is 404. Members who already accepted keep their access; revoking only stops further accepts.",
+        "x-octo-risk": "high-risk-write",
+        "parameters": [
+          { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "inviteToken", "in": "path", "required": true, "schema": { "type": "string" }, "x-octo-secret": true, "x-octo-flag": "invite-token", "description": "inviteToken from invite create / invite list (docs has no separate invite id). The docs backend mints hex tokens, so the leading-\"-\" hazard of base64url ids does not apply here; --invite-token <token> (or a value after a \"--\" separator) is still available if that ever changes" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": { "ok": { "type": "boolean" } }
+                }
+              }
+            }
+          },
+          "403": { "description": "forbidden (caller is not a doc admin)" },
+          "404": { "description": "not_found (unknown token, or a token belonging to another document)" }
+        }
+      }
+    },
+    "/v1/bot/docs/invites/{inviteToken}/accept": {
+      "post": {
+        "operationId": "docs.invite.accept",
+        "summary": "Accept a document invite as the current identity (idempotent)",
+        "description": "Claims the invite for the credential in use and returns {docId, documentName, role}. Idempotent: accepting again — or accepting into a document you already belong to — is still 200 with the resulting role, and never downgrades a higher role already held. A token that is unknown, revoked, expired or exhausted is 410 invite_invalid, not 404. Accepts either the bare inviteToken or the whole web invite link ({octo web origin}/docs/invite/<inviteToken>); the link is parsed locally against the configured origin and is never fetched.",
+        "x-octo-risk": "write",
+        "parameters": [
+          { "name": "inviteToken", "in": "path", "required": true, "schema": { "type": "string" }, "x-octo-secret": true, "x-octo-flag": "invite-token", "description": "inviteToken from invite create / invite list, or the whole invite link. The docs backend mints hex tokens, so the leading-\"-\" hazard of base64url ids does not apply here; --invite-token <token> (or a value after a \"--\" separator) is still available if that ever changes" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Accepted (or already a member — the same shape either way)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "documentName": { "type": "string" },
+                    "role": { "type": "string", "description": "the role now held on the document, which may outrank the invite's role when a higher one was already held" }
+                  }
+                }
+              }
+            }
+          },
+          "410": { "description": "invite_invalid — unknown, revoked, expired or exhausted token, or the document is gone" }
+        }
       }
     },
     "/v1/bot/docs/{docId}/comments": {

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -25,7 +25,7 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 | Read/edit a rich-text **document body** (`doc_type: doc`): incremental block ops | **`doc.md`** |
 | Read/edit a **whiteboard** (`doc_type: board`): scene elements/files, image export | **`board.md`** |
 | Continue from a searchable **HTML document** (`doc_type: html`): resolve its slug, then use immutable versions/drafts/assets/comments | **`../octo-html/SKILL.md`** |
-| Cross-cutting features — **comments** (doc range or sheet cell), **versions** (snapshot/restore), **members & sharing**, **attachments** (presign/upload) | **`common.md`** |
+| Cross-cutting features — **comments** (doc range or sheet cell), **versions** (snapshot/restore), **members & sharing**, **invite links**, **attachments** (presign/upload) | **`common.md`** |
 
 > The first four split by `doc_type` (what kind of document you're handling);
 > `common.md` holds the features that apply across kinds. Read a reference with
@@ -48,7 +48,8 @@ addressed by `slug`, not `docId`: if a search hit does not include a slug, run
   `octo-cli config show`.
 - **Do not pass a space flag for docs.** The bot mount resolves the space
   server-side from the token and deliberately ignores any client-supplied space
-  header (anti-spoof). Role enforcement (reader / writer / admin) also happens
+  header (anti-spoof). Role enforcement (reader / commenter / writer / admin)
+  also happens
   server-side, so the CLI surfaces the backend's `403`/`404` envelopes unchanged.
 
 ## Document lifecycle

--- a/skills/octo-docs/common.md
+++ b/skills/octo-docs/common.md
@@ -6,6 +6,7 @@ you need:
 - [Comments](#comments) — add/list/reply/resolve, on a doc text range or a sheet cell
 - [Versions](#versions) — snapshot / preview / rename / delete / restore
 - [Members & sharing](#members--sharing) — roles, forward-grant
+- [Invite links](#invite-links) — create/list/revoke/accept a link that grants a role
 - [Attachments](#attachments) — presign + upload file/image bytes
 
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`. Auth & space rules are in
@@ -111,10 +112,10 @@ Schema: `octo-cli schema docs.versions.restore`.
 
 ```bash
 octo-cli docs members list   <docId>                             # admin
-octo-cli docs members set    <docId> --uid <uid> --role writer   # add/upsert; role: reader|writer|admin
+octo-cli docs members set    <docId> --uid <uid> --role writer   # add/upsert; role: reader|commenter|writer|admin
 octo-cli docs members remove <docId> <uid>                       # admin; owner cannot be removed
 
-# Grant-only forward access (never downgrades). Only reader|writer are grantable.
+# Grant-only forward access (never downgrades). Grantable: reader|commenter|writer (admin is not).
 octo-cli docs forward-grant  <docId> --uid <uid> --role reader
 
 # Space-level share scope — read/set who in the space can reach the doc.
@@ -139,6 +140,75 @@ Error codes: `400 invalid_scope` (unknown scope), `400 invalid_role`
 (anyone_in_space with a missing/invalid role), `403` (caller not admin/owner),
 `404` (missing or cross-space doc), `409` (archived doc). Schema:
 `octo-cli schema docs.share.set`.
+
+---
+
+## Invite links
+
+An invite is a **link token** that grants a role to whoever accepts it. Use it
+when you cannot name the recipients up front (`members set` needs a uid); use
+`members set` when you can.
+
+```bash
+# Create (admin). Prints {inviteToken, role, expiresAt}.
+octo-cli docs invite create <docId> [--role writer] [--expiresInDays 3] [--maxUses 0]
+
+# List the live invites of a doc (admin): token, role, maxUses, usedCount, expiresAt.
+octo-cli docs invite list <docId>
+
+# Revoke (admin). NOTE: addressed by the TOKEN — docs has no separate invite id.
+octo-cli docs invite revoke <docId> <inviteToken>
+octo-cli docs invite revoke <docId> --invite-token <inviteToken>   # token starting with "-"
+
+# Accept as the credential in use. Takes the bare token OR the whole invite link.
+octo-cli docs invite accept <inviteToken>
+octo-cli docs invite accept "$OCTO_API_BASE_URL/docs/invite/<inviteToken>"
+```
+
+**Role.** `reader` | `commenter` | `writer` | `admin` — the same member-role
+ladder as `docs members set`, in increasing order of capability. **Omitting**
+`--role` is what selects the `writer` default; an unrecognised value is rejected
+by the backend with `400 role must be reader|commenter|writer|admin`, and the CLI
+refuses it locally first (`ENUM_NOT_ALLOWED`, exit 2) so it costs no round trip.
+Note that `commenter` sits **between** `reader` and `writer` despite its stored
+numeric code being `4` — that number is historical, the rank is not.
+
+**Lifetime.** `--expiresInDays` is 1–7 days, default 3. There is no permanent
+invite link; a value outside the range is clamped by the backend without an
+error, so pass something in range if you care which. `--maxUses 0` (the default)
+means unlimited accepts.
+
+**Accept is idempotent.** Accepting twice, or accepting into a document you are
+already a member of, is still `200` with the resulting role, and never downgrades
+a higher role you already hold. An unknown, revoked, expired or exhausted token
+is **`410 invite_invalid`** — not 404. Revoking does not remove members who
+already accepted; it only stops further accepts.
+
+**The link form.** The web app serves invites at
+`{octo web origin}/docs/invite/<inviteToken>`, and `invite accept` takes that
+whole link so you can paste what someone sent you. The CLI **never fetches the
+link**: it parses out the token locally, requires the link's host to match the
+configured `OCTO_API_BASE_URL` origin, and calls the configured API. A link on
+any other host, with embedded credentials, with a percent-encoded path, or with
+extra path segments is refused (`INVALID_INVITE_URL`, exit 2).
+
+> **The inviteToken is a credential.** Anyone holding it can claim the role on
+> that document. Hand it over out of band, never paste `invite create` /
+> `invite list` output into a ticket or a shared channel, and revoke it when the
+> invite has served its purpose. The CLI masks the token in `--dry-run` and
+> `--verbose` traces for exactly this reason — but `invite create`'s success
+> output necessarily contains it in full, because it is the thing you asked for.
+
+```bash
+# Typical flow: mint a reader link good for a day, hand over the URL, revoke later.
+TOKEN=$(octo-cli docs invite create d_1 --role reader --expiresInDays 1 \
+  -q '.data.inviteToken' | tr -d '"')
+echo "$OCTO_API_BASE_URL/docs/invite/$TOKEN"    # hand this over out of band
+octo-cli docs invite revoke d_1 -- "$TOKEN"
+```
+
+Schemas: `octo-cli schema docs.invite.create` | `docs.invite.list` |
+`docs.invite.revoke` | `docs.invite.accept`.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the `docs invite` command family so a bot can hand out a document invite link, and — the half that was actually missing — **join a document by accepting one**:

```
octo-cli docs invite create <docId> [--role writer] [--expiresInDays 3] [--maxUses 0]
octo-cli docs invite list   <docId>
octo-cli docs invite revoke <docId> --invite-token <token>
octo-cli docs invite accept <token>            # or the whole invite link
```

All four are declared in `internal/registry/specs/docs.json` and generated by the existing registry engine. The docs backend's bot-side invite endpoints (`invitesRouter` on the bot chain, plus the bot accept route from docs-backend #61) were already live, so **this PR changes no backend and no frontend** — the gap was purely the CLI wrapper.

`invite accept` also takes the whole web invite link (`{octo web origin}/docs/invite/<token>`), because that is what a person actually has in hand.

## Linked Spec

Fixes #130. The issue's own sketch is followed except where the backend contradicted it — see COMPREHENSION (a).

## How verified

- `go build ./...`, `go vet ./...`, `gofmt -l ./cmd ./internal`, `go test ./... -count=1` — all clean.
- End-to-end against a live deployment with two bot credentials: bot A `invite create` → `invite list` → bot B `invite accept <full link>` → bot B's `docs get` shows the granted role → bot A's `members list` shows the new row with `source=invite` → repeat accept is still 200 (idempotent) → `invite revoke` → `list` empty → accept now `410 invite_invalid`. Repeated for `--role commenter`.
- Negative paths, locally, no request sent: a link on a foreign host is `INVALID_INVITE_URL`; `--role bogus` is `ENUM_NOT_ALLOWED`; `--dry-run` renders the token as `***REDACTED***`.
- Mutation-tested the new guards (each change made the intended test fail, then reverted): turning the missing-leaf `panic` back into a silent `return`; narrowing the role enum back to three values; renaming the `x-octo-flag` to `invite-id`; restoring the fail-open `return nil` in the flag read.

## COMPREHENSION

**(a) What this does to the load-bearing path (before → after).**

Before, `docs` had no invite surface at all — 32 operations, none of them invite — so a bot could only be added to a document by an admin who already knew its uid (`docs members set`). There was no way for a bot to join a document *itself*, which is the whole point of a link invite. After, four operations exist and the accept path produces a `doc_member` row with `source=invite` at the invite's role.

Two things about the shape are load-bearing and are **not** copies of `drive invite`:

1. **Role vocabulary.** `reader | commenter | writer | admin` — the full docs member ladder. An earlier revision of this branch pinned `reader|writer|admin` and documented "an unknown value is silently downgraded to writer". Both were wrong: they were transcribed from a local backend checkout ~86 commits behind `origin/main`. On `origin/main`, `parseRole` (`src/api/routes/invites.ts`) accepts all four and answers **400** for anything else; only an *omitted* role takes the `writer` default. A narrow enum here would be worse than useless, because the CLI's enum gate is a hard local exit 2 — it would have refused a call the backend accepts, with no way through but `octo-cli api`. Note `commenter` ranks *between* reader and writer (`roleRank` 10/20/30/40) even though its stored code is `4`; the number is historical, the rank is not.
2. **Revoke is addressed by the token**, not an id — the docs backend stores no separate invite id, unlike drive. So the flag is `--invite-token`, and following the drive recipe would hand the token to a flag that does not exist. The lifetime field is likewise `expiresInDays` (1–7, clamped silently) and not drive's `expires_in_seconds`.

The link-accepting behaviour is a *value* normalisation on the `inviteToken` slot only: the generated leaf still builds and sends the request, so path, mount, risk annotation and the secret list all keep coming from the spec.

**(b) What could break, and how.**

- **`drive share access` / `download` / `create`** — the real blast radius. `assertSameOrigin` and `assertShareIDSegment` gained a `linkPolicy` parameter so the invite surface could share them instead of holding a second copy that a future hardening would miss. The rule bodies are unchanged and `shareLinkPolicy` reproduces the previous strings exactly, so drive keeps `INVALID_SHARE_URL` and its wording; the existing share tests cover this and still pass.
- **Invite tokens are credential-equivalent.** Both token-addressed operations put the value in the URL path, and `--dry-run`/`--verbose` print paths. Both parameters are declared `x-octo-secret`, and every rejection path in the link parser is written not to echo the input — the last path segment of a nearly-correct link *is* the token. `invite create`'s success envelope necessarily contains the token in full; that output is not safe to paste anywhere.
- **The wrapper detaching silently.** `registerDocsInviteAcceptURL` finds its target by walking `docs → invite → accept`. It used to return quietly if any step came up empty, which made link support silently optional: rename the operationId or change the flag and a pasted link would be sent to the backend verbatim, coming back as a confusing 410. It now derives the expectation from the registry — spec doesn't declare the operation ⇒ nothing to wrap, return; spec declares it but the tree lacks the leaf / a runnable `RunE` / a string `--invite-token` ⇒ `panic`, the same policy `registry.MustNew` applies to embedded data. This is a build-time invariant: the command tree is built from the registry alone (not from the credential), and `withholdDisabledServices` runs *after* registration, so disabling `docs` removes the service after the wrapper has already attached. It cannot be provoked by user input, configuration or the network, and every test that builds a root command runs into it.
- **Reading a stale backend checkout.** The failure mode that produced the wrong enum in the first place. The `enum_vocab_test.go` entry now records the remote authority, per that file's own rule.

**(c) How I know it works.**

The end-to-end run in "How verified" is against a live deployment, not a mock — including the `source=invite` member row, idempotent re-accept, and the `410` after revoke. `commenter` was exercised specifically because it is the value the earlier revision wrongly excluded. The guards are mutation-tested, so each one is known to fail when the thing it protects regresses, rather than merely being present.

## Deployment prerequisites

None. No new environment variable, no migration, no backend or frontend change. `OCTO_API_BASE_URL` must be the Octo origin (already required by every other command) because the invite-link parser compares the link's host against it; passing a bare token does not need it.
