### PR TITLE
feat(html): promote the display title to a first-class --title flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ octo-cli docs export board-7 --export-format png -o ./board.png
 # HTML docs (octo-doc) — a SEPARATE backend from `docs`. Publish self-contained
 # interactive HTML as immutable versions, then edit a single stamped artifact.
 # Canonical create has no doc reference: omit --slug. The CLI generates a key.
-octo-cli html publish --html '<h1>hi</h1>' \
-  --mount-type group --group-no <group_no> --data '{"meta":{"title":"Launch page"}}'
+octo-cli html publish --html '<h1>hi</h1>' --title 'Launch page' \
+  --mount-type group --group-no <group_no>
 # Save data.slug from the publish response. For a new document data.slug == data.doc_id, mounted or
 # unmounted. Every later operation uses data.slug. Old documents keep their legacy
 # slug as data.slug; do not infer this from mount_type or doc_id being non-empty.
@@ -184,8 +184,9 @@ octo-cli html publish --html '<h1>hi</h1>' \
 # legacy slug is rejected and cannot create a document.
 octo-cli html list
 octo-cli html versions <doc-ref>
-octo-cli html draft create --html '<h1>wip</h1>'
-octo-cli html draft save <doc-ref> --data '{"html":"<h1>wip</h1>"}'   # then: html draft promote <doc-ref>
+octo-cli html draft create --html '<h1>wip</h1>' --title 'WIP page'
+octo-cli html draft save <doc-ref> --html '<h1>wip</h1>'             # then: html draft promote <doc-ref>
+# --title sets the display name (metadata, never identity) on publish/draft create/save/promote.
 octo-cli html share <doc-ref>                                        # mint a reader share code
 octo-cli html grant add <doc-ref> --data '{"uid":"u-1"}'             # per-uid authorization
 octo-cli html element get --slug <doc-ref> --aid <content-hash>      # wire flag remains named slug

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -563,6 +564,172 @@ func TestHTMLCanonicalDraftCreate(t *testing.T) {
 	}
 	if key, _ := gotBody["idempotency_key"].(string); gotPath != "/docs-html/v1/docs/draft" || key == "" {
 		t.Errorf("draft create request: path=%q body=%#v", gotPath, gotBody)
+	}
+}
+
+// TestHTMLTitleFlagPromotesTopLevelTitle pins the html domain's first-class
+// --title flag on every write operation. Before this, title existed only as a
+// nested property of the `meta` OBJECT, and registerBodyFlags/promotableKind
+// skip object properties outright — so html was the one domain with no --title
+// while the server has always read (and preferred) a top-level `title`.
+//
+// The assertion is deliberately two-sided: the emitted body must carry a
+// top-level "title", and it must NOT wrap it back into a `meta` object. The CLI
+// promotes the wire field as declared; the legacy meta.title path stays
+// reachable only through an explicit --data.
+func TestHTMLTitleFlagPromotesTopLevelTitle(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantPath string
+	}{
+		{
+			name:     "publish",
+			args:     []string{"html", "publish", "--html", "<h1>doc</h1>", "--title", "X"},
+			wantPath: "/docs-html/v1/docs",
+		},
+		{
+			name:     "draft create",
+			args:     []string{"html", "draft", "create", "--html", "<h1>wip</h1>", "--title", "X"},
+			wantPath: "/docs-html/v1/docs/draft",
+		},
+		{
+			name:     "draft save",
+			args:     []string{"html", "draft", "save", "doc-1", "--html", "<h1>wip</h1>", "--title", "X"},
+			wantPath: "/docs-html/v1/docs/doc-1/draft",
+		},
+		{
+			name:     "draft promote",
+			args:     []string{"html", "draft", "promote", "doc-1", "--title", "X"},
+			wantPath: "/docs-html/v1/docs/doc-1/draft/promote",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPath string
+			var gotBody map[string]any
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.EscapedPath()
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"slug":"doc-1","doc_id":"doc-1"}}`))
+			})
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if gotPath != tt.wantPath {
+				t.Errorf("path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if gotBody["title"] != "X" {
+				t.Errorf("body must carry a top-level title: %#v", gotBody)
+			}
+			if _, wrapped := gotBody["meta"]; wrapped {
+				t.Errorf("--title must not be wrapped into meta: %#v", gotBody)
+			}
+		})
+	}
+}
+
+// TestHTMLDraftPromoteBodyOptionality is the regression guard for adding a
+// requestBody to html.draft.promote purely so --title becomes available. A bare
+// promote must still send NO body at all — same bytes on the wire as before the
+// spec grew the field. A regression here would start sending `{}` (or fail
+// validation) on every existing promote call.
+//
+// What actually protects that is the EMPTY `required` list on the schema, not
+// the `required: false` flag on the requestBody: resolveBody returns a nil body
+// whenever the merged base is empty, so the only way to break a bare promote is
+// to make a field required. Flipping requestBody.required to true alone changes
+// nothing (bodySchemaValidator finds no required field to complain about); it is
+// adding `title` to schema.required that turns a bare promote into a
+// VALIDATION_ERROR. This test pins that boundary, so keep it green rather than
+// relying on the `required: false` declaration to hold the line.
+func TestHTMLDraftPromoteBodyOptionality(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantBody  string
+		wantCType string
+	}{
+		{
+			name:     "bare promote sends no body",
+			args:     []string{"html", "draft", "promote", "doc-1"},
+			wantBody: "",
+		},
+		{
+			name:      "promote with --title sends only title",
+			args:      []string{"html", "draft", "promote", "doc-1", "--title", "X"},
+			wantBody:  `{"title":"X"}`,
+			wantCType: "application/json",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRaw []byte
+			var gotCType string
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				gotRaw, _ = io.ReadAll(r.Body)
+				gotCType = r.Header.Get("Content-Type")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"slug":"doc-1","version":3}}`))
+			})
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if string(gotRaw) != tt.wantBody {
+				t.Errorf("request body = %q, want %q", string(gotRaw), tt.wantBody)
+			}
+			if gotCType != tt.wantCType {
+				t.Errorf("Content-Type = %q, want %q", gotCType, tt.wantCType)
+			}
+		})
+	}
+}
+
+// TestHTMLTitleFlagOverridesData pins the engine's documented precedence
+// (architecture §5.2: individual flags override --data) for the new field, and
+// records the observed shape of the legacy path: --data's `meta` object is left
+// untouched next to the promoted top-level title, because the CLI merges by
+// wire key and meta.title is a different key. The server resolves the two
+// (top-level title wins, meta.title is the back-compat fallback), so shipping
+// both is safe; only the same-key case is a CLI-side override.
+func TestHTMLTitleFlagOverridesData(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantMeta any
+	}{
+		{
+			name:     "legacy meta.title kept alongside the promoted title",
+			args:     []string{"html", "publish", "--data", `{"html":"x","meta":{"title":"legacy"}}`, "--title", "flag"},
+			wantMeta: map[string]any{"title": "legacy"},
+		},
+		{
+			name: "same-key --data title loses to the flag",
+			args: []string{"html", "publish", "--data", `{"html":"x","title":"from-data"}`, "--title", "flag"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody map[string]any
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewDecoder(r.Body).Decode(&gotBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"data":{"slug":"doc-1","doc_id":"doc-1"}}`))
+			})
+			root.SetArgs(tt.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if gotBody["title"] != "flag" {
+				t.Errorf("--title must win over --data: %#v", gotBody)
+			}
+			if !reflect.DeepEqual(gotBody["meta"], tt.wantMeta) {
+				t.Errorf("meta = %#v, want %#v", gotBody["meta"], tt.wantMeta)
+			}
+		})
 	}
 }
 

--- a/internal/registry/specs/html.json
+++ b/internal/registry/specs/html.json
@@ -102,9 +102,13 @@
                     "type": "integer",
                     "description": "optional explicit version; omit to auto-increment"
                   },
+                  "title": {
+                    "type": "string",
+                    "description": "Human display name shown in listings and the sidebar. Metadata only, NOT identity: identity is the document reference (data.slug / doc_id), so passing the same title again does not address an existing document and same-name republish is not supported. Legacy callers may still send the title inside the meta object; when both are present this top-level title wins."
+                  },
                   "meta": {
                     "type": "object",
-                    "description": "optional metadata (e.g. {\"title\":\"...\"})",
+                    "description": "optional metadata (e.g. {\"title\":\"...\"}); legacy fallback for the display name — prefer the top-level title, which wins when both are present",
                     "properties": {
                       "title": {
                         "type": "string"
@@ -225,9 +229,13 @@
                     "type": "string",
                     "description": "Optional caller key for retrying the same creation operation; otherwise the CLI generates one per invocation."
                   },
+                  "title": {
+                    "type": "string",
+                    "description": "Human display name for the new draft's document. Metadata only, NOT identity: identity is the returned document reference (data.slug / doc_id), so a repeated title never addresses an existing document. Legacy callers may still send the title inside the meta object; when both are present this top-level title wins."
+                  },
                   "meta": {
                     "type": "object",
-                    "description": "Optional document metadata such as display title.",
+                    "description": "Optional document metadata such as display title; legacy fallback for the display name — prefer the top-level title, which wins when both are present.",
                     "properties": {
                       "title": {
                         "type": "string"
@@ -436,6 +444,10 @@
                   "html": {
                     "type": "string",
                     "description": "the draft HTML body"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "Optional new human display name for the document. Metadata only, NOT identity: identity stays the document reference in the path, so retitling never creates or re-points a document. Omit to leave the current display name unchanged."
                   }
                 }
               }
@@ -473,6 +485,22 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "Optional human display name to stamp on the promoted version. Metadata only, NOT identity: identity stays the document reference in the path. Omit to keep the current display name; with nothing supplied the CLI sends no body at all, exactly as before this field existed."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Promoted",

--- a/skills/octo-html/SKILL.md
+++ b/skills/octo-html/SKILL.md
@@ -20,15 +20,15 @@ All commands call `$OCTO_API_BASE_URL/docs-html/v1/*` and return the standard
 ## Document-reference contract
 
 - **Canonical create has no document reference.** Omit `slug` and provide
-  `html`. The CLI generates `idempotency_key`; an explicit key is optional. A display name belongs in `meta.title`;
-  it is metadata, not identity.
+  `html`. The CLI generates `idempotency_key`; an explicit key is optional. Set a
+  display name with the first-class `--title` flag; it is metadata, not identity.
 - **Save `data.slug` from the response.** New documents always return
   `data.doc_id` and `data.slug`, with `data.slug == data.doc_id`, whether mounted
   or unmounted. Use `data.slug` for every later operation.
 - **Legacy documents keep their old reference.** For an old document, use its
   legacy slug wherever this skill says `<doc-ref>`.
 - **No alias identity and no same-name republish.** Creating again with the same
-  `meta.title` creates a different document. To publish another version, supply
+  `--title` creates a different document. To publish another version, supply
   the saved `data.slug` in the server's legacy-named `slug` field.
 - Do not infer a mode from `mount_type`, `registered`, `status`, or whether
   `data.doc_id` is non-empty. `registered` and `status` report operational state,
@@ -51,23 +51,37 @@ deployed before this CLI is released.
   capability; backend failures are normalized into the CLI's
   `{ok:false,error:{type,code,message,hint,detail}}` envelope.
 
+## Display name (`--title`)
+
+`html publish`, `html draft create`, `html draft save`, and `html draft promote`
+all take `--title "<name>"`. It sets the human display name shown in listings
+and the sidebar. It is **metadata, never identity** — the document reference
+(`data.slug` / `data.doc_id`) is the only identity, so passing the same title
+again does not address an existing document.
+
+On `publish` and `draft create` the legacy `meta.title` inside `--data` is still
+accepted as a fallback; when both are present the top-level `--title` wins.
+Prefer `--title`. On `draft save` / `draft promote`, omit `--title` to leave the
+current display name unchanged — a bare `html draft promote <doc-ref>` sends no
+body, exactly as before.
+
 ## 1. Create and publish
 
 ```bash
 # Canonical create: no --slug. The CLI generates the idempotency key.
-octo-cli html publish --data '{"html":"<html><body><h1>Runbook</h1></body></html>","meta":{"title":"Runbook"},"mount_type":"group","group_no":"<group_no>"}'
+octo-cli html publish --title 'Runbook' --data '{"html":"<html><body><h1>Runbook</h1></body></html>","mount_type":"group","group_no":"<group_no>"}'
 # → data: { doc_id, slug, version, url, share_url, size, aids,
 #           merged_comments, registered, status }
 # Save data.slug; for this new document data.slug == data.doc_id.
 
 # Unmounted creation follows the same identity contract and also gets doc_id.
-octo-cli html publish --data '{"html":"<html><body><h1>Private draft</h1></body></html>","meta":{"title":"Private draft"}}'
+octo-cli html publish --html '<html><body><h1>Private draft</h1></body></html>' --title 'Private draft'
 
 # Publish a later immutable version. Keep the wire field name `slug` and omit
 # idempotency_key. Pass ONLY a slug the server returned earlier: an unregistered
 # slug does not create a canonical document — it produces a legacy unregistered
 # one that never appears in the sidebar file list. Never invent a slug.
-octo-cli html publish --data '{"slug":"<doc-ref>","html":"<html><body><h1>Runbook v2</h1></body></html>","meta":{"title":"Runbook"}}'
+octo-cli html publish --slug '<doc-ref>' --title 'Runbook' --html '<html><body><h1>Runbook v2</h1></body></html>'
 
 # An explicit --idempotency-key <same-operation-key> is supported only for
 # retrying this exact creation operation. The CLI-generated key is created once
@@ -109,10 +123,12 @@ until promoted.
 
 ```bash
 # Create a canonical draft without a document reference. Save response data.slug.
-octo-cli html draft create --html '<html><body><h1>WIP</h1></body></html>'
+octo-cli html draft create --html '<html><body><h1>WIP</h1></body></html>' --title 'WIP runbook'
 
-octo-cli html draft save <doc-ref> --data '{"html":"<html><body><h1>WIP</h1></body></html>"}'
+# Retitle while saving, or leave --title off to keep the current display name.
+octo-cli html draft save <doc-ref> --html '<html><body><h1>WIP</h1></body></html>' --title 'Runbook (draft)'
 octo-cli html draft promote <doc-ref>
+octo-cli html draft promote <doc-ref> --title 'Runbook'
 ```
 
 ## 3. Sharing and grants


### PR DESCRIPTION
## Summary

Give the `html` domain a first-class `--title` flag on its write operations. Spec-only change: no engine code, no server change.

## Changes

- `internal/registry/specs/html.json`: declare a top-level `title` string on `html.publish`, `html.draft.create` and `html.draft.save`; give `html.draft.promote` the optional `requestBody` it never had (one optional `title`). `meta` is left untouched on publish/draft-create and its description now labels it the legacy fallback. `title` is not added to any `required` list and `x-octo-body-variants` is unchanged.
- `cmd/service/service_test.go`: 3 tests merged into the existing file — `--title` promotes a top-level wire field on all four operations (and is not re-wrapped into `meta`); `html draft promote` body optionality; `--data` vs `--title` precedence.
- `skills/octo-html/SKILL.md` + `README.md`: teach `--title` as the way to set a display name, keeping the identity guidance intact (title is metadata, never identity; no same-name republish).

## Motivation

`html` was the only write domain without `--title`. `docs create` / `docs rename` / `loop task create` / `matter create` / `summary create` all get one for free, because flags are auto-generated from the request body: `registerBodyFlags` walks `requestBody.properties`, and `promotableKind` promotes primitives only — an `object` property is skipped outright. `html.json` declared the display name solely as a nested property of the `meta` object, so the whole object was skipped and neither `--title` nor `--meta` was ever registered. An Agent had to hand-write `--data '{"html":...,"meta":{"title":"..."}}'`, which is easy to omit — and when it is omitted the sidebar file list shows a row with no usable label at all.

The server side already expects this. `readPublishBody` resolves `title := raw.Title; if title == "" && raw.Meta != nil { title = raw.Meta.Title }` — top-level wins, `meta.title` is the documented back-compat path for the CLI's `meta.json`. `handlePromote` likewise decodes an optional `{"title"}`. The capability existed on the wire with no way to reach it from the CLI.

## Testing

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `go build ./...` passes

Also run locally: `gofmt -l .` (empty), `make lint` → `0 issues`, `go test -race -count=1` on `cmd/service` / `internal/registry` / `skills`, and `go mod tidy` leaves `go.mod`/`go.sum` unchanged.

Binary checks against a real build:

- `--title` present in `--help` for `html publish`, `html draft create`, `html draft save`, `html draft promote`.
- `html publish --html '<h1>x</h1>' --title 'Runbook Q3' --dry-run` → body `{"html":"<h1>x</h1>","idempotency_key":"<generated>","title":"Runbook Q3"}`.
- `html draft promote <ref> --title 'Renamed' --dry-run` → body `{"title":"Renamed"}`.
- `html draft promote <ref> --dry-run` → byte-identical to the same command built from `main`; no body, no `Content-Type`.

Fail-before evidence:

- Removing the promote `requestBody` / publish `title` → `unknown flag: --title`, the new tests go red.
- Adding `title` to promote's `schema.required` → `bare promote sends no body` fails with `VALIDATION_ERROR: request body is missing required field(s): title`.
- Flipping only `requestBody.required` to `true` changes nothing, because the validator short-circuits an empty body when the schema declares no required fields. The regression guard pins the boundary that actually matters, and the test comment says so rather than crediting the `required: false` flag.

## COMPREHENSION

**(a) What it does to the load-bearing path.** Before: `registerBodyFlags` iterated `html.publish` / `html.draft.create` properties, hit `meta` as `type: object`, `promotableKind` returned `(0,false)`, and the property was skipped — so no `--title`. `html.draft.save` declared only `html`. `html.draft.promote` declared no `requestBody`, so the engine registered neither `--title` nor `--data`, and its server-side title override was unreachable. After: `title` is a promoted top-level `string` on all four, emitted as the wire key `title`. Existing call shapes are untouched: `meta.title` via `--data` still works and still reaches the server, and a bare promote still sends a genuinely bodyless POST (`resolveBody` returns `nil` for an empty merged base, `client.Do` only marshals a non-nil body).

**(b) What could break.** The only behavioural risk is `html.draft.promote`, which gained a request body where it previously had none — every existing bodyless promote must stay bodyless, or callers would start sending `{}` or hitting validation. Guarded by an explicit test asserting zero body bytes *and* an empty `Content-Type`, plus a byte-diff against a binary built from `main`. Dependents checked for spec-shape coupling: `cmd/service/enum_vocab_test.go` (html enum vocab — untouched, no title enum), `internal/registry/loader_test.go` (`html.publish` operation lookup), `skills/skills_test.go` (asserts required substrings present and stale identity strings absent in the embedded skill — still satisfied), `cmd/service/flagcollision_test.go` (`title` collides with no reserved, query, header or path flag on these four commands). Edge inputs verified: `--data '{}'` stays bodyless, `--data 'null'` still rejects, `--title ""` emits `{"title":""}` which the server treats as "keep the current title".

**(c) How I know it works.** The three new tests plus the fail-before/restore cycle above; `--help` and `--dry-run` against a real build for all four operations; the promote byte-diff against `main`; and full `build` / `vet` / `test -count=1` / `test -race` / `golangci-lint` green.

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [x] New commands added to README Command Reference table — no new commands; the existing README html examples now show `--title`
- [x] CLAUDE.md command list updated if commands changed — no command list change (flag only)
- [x] New features include tests
- [x] No unrelated changes included
