### PR TITLE
feat(marketplace): migrate CLI to the unified plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **`octo-cli marketplace expert` / `squad` families** — CRUD, `mine` lists,
-  taxonomy (`expert-category` / `expert-tag`), viewable `skillmd get`, presigned
-  `expert-skill-upload create` / `skill-download` for the Expert Marketplace
-  (专家/专家团). Required fields and member shape are validated client-side
-  before any request is sent: expert create requires
-  `name`/`summary`/`category`/`instruction`; squad create additionally requires
-  ≥ 1 `members[]` entry, each with `name`/`role`/`instruction` (errors name the
-  exact field, e.g. `members[0].instruction`). Value-level rules (non-empty
-  strings, size caps) remain backend-enforced. The install-to-Loop endpoints
-  (`POST /experts|squads/{id}/install`) are intentionally not exposed.
+- **`octo-cli marketplace plugin` family (unified plugin surface)** — one command
+  family over the backend's unified `/plugins/*` API, replacing the retired
+  per-type `skill` / `mcp` / `marketplace expert` / `marketplace squad` surfaces
+  (44 legacy ops → 18). Resource kind is selected with `--plugin-type`
+  (`skill` / `connector` / `expert` / `expert_team`; the old `mcp` maps to
+  `connector`, `squad` to `expert_team`): `plugin list` / `get` / `version list`
+  / `skillmd` / `download` / `upsert` / `delete` / `publish` / `install` /
+  `import`, plus `plugin-category list` / `plugin-tag list`. The skill
+  upload→parse→import pipeline (`skill-upload`, `skill-parse-task`) and icon
+  presign helpers are retained. Client-side gates before any request is sent:
+  `plugin list` requires `--scene-code` and `--plugin-type`; `plugin upsert`
+  requires a `plugin` document with `plugin_name` / `plugin_type` / `visibility`
+  and gates `plugin_type` and `visibility` (`space` / `private`; the retired
+  `public` is refused, matching `plugin import`); `mode` accepts only `mine`.
+  Value-level rules remain backend-enforced.
+- **`octo-cli marketplace plugin install`** — installs an `expert` /
+  `expert_team` plugin into a Loop workspace (`--workspace-id`, `--runtime-id`)
+  through the unified API. This exposes the install-to-Loop capability that the
+  retired per-type surface deliberately withheld; it is gated backend-side and
+  provisions through octo-fleet.
 - **`octo-cli loop` domain** — 126 registered commands generated from Fleet's
   Public API contract across tasks, executions, experts, expert teams,
   workspaces, runtimes, projects, skills, autopilots, attachments, comments,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`octo-cli marketplace plugin` family (unified plugin surface)** — one command
   family over the backend's unified `/plugins/*` API, replacing the retired
   per-type `skill` / `mcp` / `marketplace expert` / `marketplace squad` surfaces
-  (44 legacy ops → 17). Resource kind is selected with `--plugin-type`
+  (44 legacy ops → 25). Resource kind is selected with `--plugin-type`
   (`skill` / `connector` / `expert` / `expert_team`; the old `mcp` maps to
   `connector`, `squad` to `expert_team`): `plugin list` / `get` / `version list`
-  / `skillmd` / `download` / `upsert` / `delete` / `install` /
-  `import`, plus `plugin-category list` / `plugin-tag list`. The skill
+  / `skillmd` / `download` / `upsert` / `delete` / `install` / `import` /
+  `publish` / `delist`, plus the six-command `plugin review-request` workflow and
+  `plugin-category list` / `plugin-tag list`. The skill
   upload→parse→import pipeline (`skill-upload`, `skill-parse-task`) and icon
   presign helpers are retained. Client-side gates before any request is sent:
-  `plugin list` requires `--scene-code` and `--plugin-type`; `plugin upsert`
-  requires a full `plugin` document (`plugin_name` / `plugin_type` /
+  `plugin list` requires `--scene-code` and requires `--plugin-type` except for
+  the all-types `--mode mine` view; `plugin upsert` requires a full `plugin`
+  document (`plugin_name` / `plugin_type` /
   `visibility` / `manifest_json` / `plugin_json`) and gates `plugin_type`,
   `visibility` (`space` / `private`; the retired `public` is refused, matching
   `plugin import`), the `sort` vocabulary, and relations' `relation_type`
@@ -29,15 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `x-octo-retry: never` so ambiguous gateway failures surface as
   `RESULT_UNKNOWN` instead of auto-replaying a non-idempotent mutation.
   Value-level rules remain backend-enforced.
-- **The backend has no separate publish step.** After unification every
-  `plugin upsert` (and `plugin import`) IS a version snapshot — each save
-  appends an auto-increment `plugin_versions` row; `plugin.version` is the
-  human-readable `current_version` label, not a separate release action. The
-  op removed here is `skill.publish` (`POST /market/api/v1/bot/skills/publish`),
-  the only publish operation the previous spec carried; it is replaced by the
-  upload→parse→`plugin import` pipeline, which snapshots the version itself. A
-  fresh create attaches (and update self-heals) the default market placement so
-  a saved plugin is immediately listable.
+- **Marketplace publishing is an explicit, review-aware lifecycle.** `plugin
+  upsert` and skill `plugin import` save drafts and version snapshots. `plugin
+  publish` lists private content immediately, while Space-visible content opens
+  a review request and stays draft until a Space owner/admin approves it. The
+  `plugin review-request create|list|get|approve|reject|cancel` family exposes
+  frozen-submission review, and `plugin delist` takes published Space content
+  down without deleting it. Reads expose `listing_state`, `display_status`, and
+  `review_id` so callers can distinguish draft, pending, published, rejected,
+  and delisted states.
 - **`octo-cli marketplace plugin install`** — installs an `expert` / `expert_team`
   plugin into a Loop workspace (`--workspace-id`, `--runtime-id`) through the
   unified API. This exposes the install-to-Loop capability that the retired

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`octo-cli marketplace plugin` family (unified plugin surface)** — one command
   family over the backend's unified `/plugins/*` API, replacing the retired
   per-type `skill` / `mcp` / `marketplace expert` / `marketplace squad` surfaces
-  (44 legacy ops → 18). Resource kind is selected with `--plugin-type`
+  (44 legacy ops → 17). Resource kind is selected with `--plugin-type`
   (`skill` / `connector` / `expert` / `expert_team`; the old `mcp` maps to
   `connector`, `squad` to `expert_team`): `plugin list` / `get` / `version list`
-  / `skillmd` / `download` / `upsert` / `delete` / `publish` / `install` /
+  / `skillmd` / `download` / `upsert` / `delete` / `install` /
   `import`, plus `plugin-category list` / `plugin-tag list`. The skill
   upload→parse→import pipeline (`skill-upload`, `skill-parse-task`) and icon
   presign helpers are retained. Client-side gates before any request is sent:
   `plugin list` requires `--scene-code` and `--plugin-type`; `plugin upsert`
-  requires a `plugin` document with `plugin_name` / `plugin_type` / `visibility`
-  and gates `plugin_type` and `visibility` (`space` / `private`; the retired
-  `public` is refused, matching `plugin import`); `mode` accepts only `mine`.
+  requires a full `plugin` document (`plugin_name` / `plugin_type` /
+  `visibility` / `manifest_json` / `plugin_json`) and gates `plugin_type`,
+  `visibility` (`space` / `private`; the retired `public` is refused, matching
+  `plugin import`), the `sort` vocabulary, and relations' `relation_type`
+  (`expert_team_expert` / `expert_skill` / `expert_connector`);
+  `mode` accepts only `mine`. Write ops (`upsert` / `delete` / `install` /
+  `import`) set `x-octo-retry: never` so ambiguous gateway failures surface as
+  `RESULT_UNKNOWN` instead of auto-replaying a non-idempotent mutation.
   Value-level rules remain backend-enforced.
-- **`octo-cli marketplace plugin install`** — installs an `expert` /
-  `expert_team` plugin into a Loop workspace (`--workspace-id`, `--runtime-id`)
-  through the unified API. This exposes the install-to-Loop capability that the
-  retired per-type surface deliberately withheld; it is gated backend-side and
+- **The backend has no separate publish step.** After unification every
+  `plugin upsert` (and `plugin import`) IS a version snapshot — each save
+  appends an auto-increment `plugin_versions` row; `plugin.version` is the
+  human-readable `current_version` label, not a separate release action. The
+  previous spec carried a `plugin publish` op that the backend retired in
+  `refactor(plugin): drop formal publish; every save is a version snapshot`;
+  the CLI no longer exposes it, the agent docs no longer reference it, and a
+  fresh create attaches (and update self-heals) the default market placement so
+  a saved plugin is immediately listable.
+- **`octo-cli marketplace plugin install`** — installs an `expert` / `expert_team`
+  plugin into a Loop workspace (`--workspace-id`, `--runtime-id`) through the
+  unified API. This exposes the install-to-Loop capability that the retired
+  per-type surface deliberately withheld; it is gated backend-side and
   provisions through octo-fleet.
 - **`octo-cli loop` domain** — 126 registered commands generated from Fleet's
   Public API contract across tasks, executions, experts, expert teams,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `plugin import`), the `sort` vocabulary, and relations' `relation_type`
   (`expert_team_expert` / `expert_skill` / `expert_connector`);
   `mode` accepts only `mine`. Write ops (`upsert` / `delete` / `install` /
-  `import`) set `x-octo-retry: never` so ambiguous gateway failures surface as
+  `import`, plus the non-idempotent `skill-upload parse`) set
+  `x-octo-retry: never` so ambiguous gateway failures surface as
   `RESULT_UNKNOWN` instead of auto-replaying a non-idempotent mutation.
   Value-level rules remain backend-enforced.
 - **The backend has no separate publish step.** After unification every
   `plugin upsert` (and `plugin import`) IS a version snapshot — each save
   appends an auto-increment `plugin_versions` row; `plugin.version` is the
   human-readable `current_version` label, not a separate release action. The
-  previous spec carried a `plugin publish` op that the backend retired in
-  `refactor(plugin): drop formal publish; every save is a version snapshot`;
-  the CLI no longer exposes it, the agent docs no longer reference it, and a
+  op removed here is `skill.publish` (`POST /market/api/v1/bot/skills/publish`),
+  the only publish operation the previous spec carried; it is replaced by the
+  upload→parse→`plugin import` pipeline, which snapshots the version itself. A
   fresh create attaches (and update self-heals) the default market placement so
   a saved plugin is immediately listable.
 - **`octo-cli marketplace plugin install`** — installs an `expert` / `expert_team`
@@ -156,6 +157,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   membership deletion is an exact Space-qualified mutation. Requiring the
   principal Space prevents an ambiguous uid from deleting the wrong row when
   the same uid has memberships in multiple Spaces.
+- **BREAKING (marketplace): `plugin list` loses `--page-all`.** The retired
+  `skill.list` / `skill.mine.list` operations declared `x-octo-pagination` and
+  could be exhausted in one invocation. The unified `/plugins` endpoint is
+  offset-paged (`--page` / `--page-size`, default 20, max 100, out-of-range
+  rejected with 400 rather than clamped) and does not advertise the cursor
+  extension, so `--page-all` is not registered. Callers that relied on it must
+  walk `--page` until a short page. This matters most for the owned-name
+  duplicate check: `--q` is a substring match against `plugin_name` only, so a
+  single unpaged probe can report a false "not found".
+- **BREAKING (marketplace): `plugin upsert` replaces the plugin row; it does not
+  patch it.** There is no metadata-only PATCH on the unified API. The backend
+  rebuilds the whole plugin from the submitted document, preserving only
+  `created_at`, the version history and the creator identity — an omitted
+  `category_id`, `publisher` or `icon` is accepted as empty and clears the
+  stored value, and an omitted `relations` key soft-deletes every live relation.
+  `plugin import` deliberately has the opposite semantics (omitted fields fall
+  back to the existing row). The spec field descriptions and the
+  `octo-marketplace` skill docs now state both, and prescribe read-modify-write
+  via `plugin get`. Additionally, `manifest_json` must agree with the outer
+  `plugin` fields (`plugin_name`, `plugin_type`, and `labels` == `tags` in the
+  same order); every disagreement returns one opaque
+  `400 VALIDATION_ERROR {"field":"body","reason":"invalid"}`.
 - **`octo-cli html` adopts canonical create and document references** — create
   omits `slug`; the CLI generates `idempotency_key` once per invocation and
   reuses it across transport retries (an explicit key remains supported). It returns `data.doc_id` plus

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
   for that origin. Mail never uses a separate token or base-URL environment
   variable.
 
-## Command Structure (12 active domains, 315 operations)
+## Command Structure (12 active domains, 314 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@
   `/fleet/api`.
 - **Factory DI**: `internal/cmdutil.Factory` is the DI container; no package-level globals. Tests inject stubs through `ConfigFunc` / `CredentialFunc` / `ClientFunc` / `RegistryFunc`. `Factory.ErrorEmitted` tracks whether an error envelope was already written to stderr, preventing double-emit between RunE and the top-level main error handler.
 - **JSON envelope I/O**: `{ok, identity, data, _pagination, _rate_limit}` on stdout for success; `{ok:false, error:{type,code,message,hint,detail}}` on stderr for failure. Exit codes: auth=3, validation/config=2, rest=1.
-- **Pre-flight validation** (`cmd/service/run.go`, `cmd/service/enum.go`): the metadata-driven path checks the resolved request against the spec before any HTTP — required fields and `minItems` (`VALIDATION_ERROR`), spec `enum` vocabularies (`ENUM_NOT_ALLOWED`), `uint64` id range, and a refusal of empty or `.` / `..` path values (an empty value addresses the collection and a gateway that normalises dot segments retargets the request — and the engine emits `DELETE`). Loop Public API operations additionally enforce composition, closed-object and minimum-property constraints, Unicode string lengths, and maximum array sizes; those extended checks remain backend-enforced for legacy domains. Body checks walk the *merged* body, so `--data` is validated too, at every nesting depth and including `format: uint64` — `--data` is not a raw passthrough on this path, and it decodes with `UseNumber` so an id above 2^53 is never rounded before it is checked. A property present with an explicit `null` is checked, not skipped: it is refused wherever the schema constrains the value (an enum or a `uint64` format), because `null` matches no vocabulary member and decodes into a scalar field as the zero value — for a `parent_id` that is folder `0`, the documented root, i.e. a *valid* id addressing a place nobody named. A required field set to `null` is reported as missing instead, so both paths refuse it; a `null` on an unconstrained property is still forwarded, since a backend may accept it to clear the field. Enum and constant comparison is by canonical form, not `==`, because the same wire value arrives as `int`, `float64` or `json.Number` depending on how it was supplied; numbers compare by exact decimal text, so an integer vocabulary admits `1` but not `1.0` — the body keeps what the caller wrote, and a non-integer would fail at the backend on a value the local gate had called valid. Hand-written composites reuse the same walker via `service.ValidateRequestBody`, so a composite that replaces a generated leaf cannot enforce a weaker contract than the leaf did.
+- **Pre-flight validation** (`cmd/service/run.go`, `cmd/service/enum.go`): the metadata-driven path checks the resolved request against the spec before any HTTP — required fields and `minItems` (`VALIDATION_ERROR`), spec `enum` vocabularies (`ENUM_NOT_ALLOWED`), `uint64` id range, and a refusal of empty or `.` / `..` path values (an empty value addresses the collection and a gateway that normalises dot segments retargets the request — and the engine emits `DELETE`). Loop Public API operations and services that opt into `x-octo-strict-request-schema` (currently Marketplace) additionally enforce composition, closed-object and minimum-property constraints, Unicode string lengths and maximum array sizes; those extended checks remain backend-enforced for other legacy domains. Body checks walk the *merged* body, so `--data` is validated too, at every nesting depth and including `format: uint64` — `--data` is not a raw passthrough on this path, and it decodes with `UseNumber` so an id above 2^53 is never rounded before it is checked. A property present with an explicit `null` is checked, not skipped: it is refused wherever the schema constrains the value (an enum or a `uint64` format), because `null` matches no vocabulary member and decodes into a scalar field as the zero value — for a `parent_id` that is folder `0`, the documented root, i.e. a *valid* id addressing a place nobody named. A required field set to `null` is reported as missing instead, so both paths refuse it; a `null` on an unconstrained property is still forwarded, since a backend may accept it to clear the field. Enum and constant comparison is by canonical form, not `==`, because the same wire value arrives as `int`, `float64` or `json.Number` depending on how it was supplied; numbers compare by exact decimal text, so an integer vocabulary admits `1` but not `1.0` — the body keeps what the caller wrote, and a non-integer would fail at the backend on a value the local gate had called valid. Hand-written composites reuse the same walker via `service.ValidateRequestBody`, so a composite that replaces a generated leaf cannot enforce a weaker contract than the leaf did.
 
 ## Identity Model
 
@@ -41,7 +41,7 @@
   for that origin. Mail never uses a separate token or base-URL environment
   variable.
 
-## Command Structure (12 active domains, 314 operations)
+## Command Structure (12 active domains, 322 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -95,6 +95,17 @@ octo-cli html      list | get | publish | versions | rm     (octo-doc HTML docs;
                comment  list|add
                element  get|replace
                reply
+
+octo-cli marketplace plugin list|get|version list|skillmd|download|upsert|delete
+                         install|import|publish|delist
+                         review-request create|list|get|approve|reject|cancel
+               plugin-category list
+               plugin-tag list
+               mcp probe
+               skill-upload create|parse
+               skill-parse-task get
+               skill-icon-upload create
+               mcp-icon-upload create
 
 octo-cli mail      me
                auth login|status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
   for that origin. Mail never uses a separate token or base-URL environment
   variable.
 
-## Command Structure (12 active domains, 308 operations)
+## Command Structure (12 active domains, 315 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -129,7 +129,7 @@ func TestNewRootCmd_LeafStillRequiresAuth(t *testing.T) {
 //
 // The `-q` shorthand of `--jq` is deliberately absent from the reserved set:
 // pflag keeps shorthands in a separate namespace, so a spec param legitimately
-// named `q` (matter.list, marketplace skill.list) does not shadow it.
+// named `q` (matter.list, marketplace plugin.list) does not shadow it.
 func TestNewRootCmd_ReservedGlobalFlagNamesMatchPersistentFlags(t *testing.T) {
 	f := cmdutil.NewTestFactory()
 	f.SetConfig(&config.Config{Format: "json"})

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -177,22 +177,40 @@ var requestSideVocabularies = []vocabulary{
 		why:  "octo-docs-html reply status enum"},
 
 	// --- marketplace (unified plugin surface) ---
+	// Backend definitions pinned to octo-marketplace feat/unified-plugin-backend@99f6c28
+	// (the fork branch carrying the unified /plugins/* API this spec targets; not yet on
+	// Mininglamp-OSS/octo-marketplace main). Open that ref to verify a value.
 	{op: "mcp.probe", in: "body", field: "transport",
 		want: []string{"stdio", "streamable-http", "sse"},
 		why:  "octo-marketplace internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
 	{op: "plugin.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why: "octo-marketplace internal/model plugin types; the list handler rejects any other value. " +
+		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/model/plugin.go PluginType constants + internal/service/plugin/validation.go:71 validPluginType; the list handler rejects any other value. " +
 			"Legacy per-type surface maps mcp->connector and squad->expert_team"},
+	{op: "plugin.list", in: "query", field: "mode",
+		want: []string{"mine"},
+		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/api/handler/plugin/handler.go:297 — the list handler accepts only \"\" or \"mine\" and 400s on anything else, so the sole explicit value is \"mine\" (omit for the full catalog). " +
+			"Deliberately NOT [all,mine]: the unified backend rejects mode=all, unlike the retired per-type surface"},
 	{op: "plugin_category.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
 		why:  "same plugin_type set as plugin.list"},
 	{op: "plugin_tag.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
 		why:  "same plugin_type set as plugin.list (optional filter here)"},
+	{op: "plugin_tag.list", in: "query", field: "mode",
+		want: []string{"mine"},
+		why:  "same mode gate as plugin.list (handler.go:593 mirrors handler.go:297); \"\" or \"mine\" only"},
+	{op: "plugin.upsert", in: "body", field: "plugin.plugin_type",
+		want: []string{"skill", "connector", "expert", "expert_team"},
+		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/validation.go:71 validPluginType, enforced on every write via buildWrite (service.go:561). " +
+			"Same set as the read filters; typed here so the write path gates plugin_type client-side too"},
+	{op: "plugin.upsert", in: "body", field: "plugin.visibility",
+		want: []string{"space", "private"},
+		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/validation.go:80 validVisibility, enforced on create+update via buildWrite (service.go:561). " +
+			"A tenant caller on /plugins/upsert may set only space or private; system is admin-surface only and public is retired on the write path — same client set as plugin.import"},
 	{op: "plugin.import", in: "body", field: "visibility",
 		want: []string{"space", "private"},
-		why: "octo-marketplace internal/service/plugin/import.go rejects public on the import path " +
+		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/import.go rejects public on the import path " +
 			"(TestImportRejectsPublicVisibility); a skill import accepts only space (default) or private, " +
 			"and system is admin-only — so the client set is these two"},
 

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -176,53 +176,24 @@ var requestSideVocabularies = []vocabulary{
 		want: []string{"applied", "partial", "question"},
 		why:  "octo-docs-html reply status enum"},
 
-	// --- marketplace ---
-	{op: "marketplace.expert_category.list", in: "query", field: "kind",
-		want: []string{"agent", "squad"},
-		why: "octo-marketplace origin/feat/expert-marketplace@448636d internal/api/handler/expert/handler.go " +
-			"ListCategories: `if c.Query(\"kind\") == \"squad\"` selects squads, any other value (including absent) " +
-			"means agent — two values cover every input the backend distinguishes"},
-	{op: "marketplace.expert_tag.list", in: "query", field: "kind",
-		want: []string{"agent", "squad"},
-		why:  "same kind branch in ListTags (handler.go:807) as expert_category.list"},
-	{op: "marketplace.expert_tag.list", in: "query", field: "mode",
-		want: []string{"all", "mine"},
-		why: "octo-marketplace origin/feat/expert-marketplace@448636d internal/api/handler/expert/handler.go " +
-			"ListTags: `c.Query(\"mode\") == \"mine\"` restricts to caller-owned rows, any other value means all — " +
-			"mirrors the pinned mcp_category.list mode pair"},
-	{op: "mcp_category.list", in: "query", field: "mode",
-		want: []string{"all", "mine"},
-		why:  "marketplace swagger binding tag; generated from the backend's own definition"},
-	{op: "mcp.create", in: "body", field: "visibility",
-		want: []string{"public", "private"},
-		why: "octo-marketplace internal/service/mcp.go validatePublicCreateVisibility accepts only \"\"|public|private. " +
-			"model.Visibility has four values, but internal/model/mcp.go says \"system never appears in a client write\" " +
-			"and VisibilitySpace is unused by the mcp service — so the two-value set is right for an mcp write even " +
-			"though skill's is three"},
-	{op: "mcp.update", in: "body", field: "visibility",
-		want: []string{"public", "private"},
-		why:  "same validatePublicCreateVisibility gate as mcp.create; a system row additionally refuses any visibility patch"},
-	{op: "mcp.create", in: "body", field: "transport",
-		want: []string{"stdio", "streamable-http", "sse"},
-		why:  "octo-marketplace internal/model/mcp.go ValidTransport — exactly these three"},
-	{op: "mcp.update", in: "body", field: "transport",
-		want: []string{"stdio", "streamable-http", "sse"},
-		why:  "same ValidTransport gate"},
+	// --- marketplace (unified plugin surface) ---
 	{op: "mcp.probe", in: "body", field: "transport",
 		want: []string{"stdio", "streamable-http", "sse"},
-		why:  "same ValidTransport gate"},
-	{op: "skill.publish", in: "body", field: "visibility",
-		want: []string{"public", "private", "space"},
-		why: "octo-marketplace model.Visibility minus system (never a client write); the skill service does use " +
-			"VisibilitySpace (internal/service/skill/service.go), which is why skill's set is wider than mcp's"},
-	{op: "skill.update", in: "body", field: "visibility",
-		want: []string{"public", "private", "space"},
-		why:  "same set as skill.publish"},
-	{op: "skill.publish", in: "body", field: "publish_mode",
-		want: []string{"create"},
-		why: "backend-enforced single value: octo-marketplace internal/api/handler/upload/handler.go rejects anything " +
-			"else with \"only publish_mode=create is supported\". A one-value enum is the shape that made " +
-			"html.grant.add wrong, so this one was checked at source rather than assumed"},
+		why:  "octo-marketplace internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
+	{op: "plugin.list", in: "query", field: "plugin_type",
+		want: []string{"skill", "connector", "expert", "expert_team"},
+		why: "octo-marketplace internal/model plugin types; the list handler rejects any other value. " +
+			"Legacy per-type surface maps mcp->connector and squad->expert_team"},
+	{op: "plugin_category.list", in: "query", field: "plugin_type",
+		want: []string{"skill", "connector", "expert", "expert_team"},
+		why:  "same plugin_type set as plugin.list"},
+	{op: "plugin_tag.list", in: "query", field: "plugin_type",
+		want: []string{"skill", "connector", "expert", "expert_team"},
+		why:  "same plugin_type set as plugin.list (optional filter here)"},
+	{op: "plugin.import", in: "body", field: "visibility",
+		want: []string{"public", "space", "private"},
+		why: "octo-marketplace model.PluginVisibility minus system (never a client write); the skill import " +
+			"path accepts these three"},
 
 	// --- message ---
 	{op: "message.search", in: "body", field: "sort",

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -191,9 +191,10 @@ var requestSideVocabularies = []vocabulary{
 		want: []string{"skill", "connector", "expert", "expert_team"},
 		why:  "same plugin_type set as plugin.list (optional filter here)"},
 	{op: "plugin.import", in: "body", field: "visibility",
-		want: []string{"public", "space", "private"},
-		why: "octo-marketplace model.PluginVisibility minus system (never a client write); the skill import " +
-			"path accepts these three"},
+		want: []string{"space", "private"},
+		why: "octo-marketplace internal/service/plugin/import.go rejects public on the import path " +
+			"(TestImportRejectsPublicVisibility); a skill import accepts only space (default) or private, " +
+			"and system is admin-only — so the client set is these two"},
 
 	// --- message ---
 	{op: "message.search", in: "body", field: "sort",

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -177,42 +177,50 @@ var requestSideVocabularies = []vocabulary{
 		why:  "octo-docs-html reply status enum"},
 
 	// --- marketplace (unified plugin surface) ---
-	// Backend definitions pinned to octo-marketplace feat/unified-plugin-backend@99f6c28
-	// (the fork branch carrying the unified /plugins/* API this spec targets; not yet on
-	// Mininglamp-OSS/octo-marketplace main). Open that ref to verify a value.
+	// Backend definitions pinned to Mininglamp-OSS/octo-marketplace upstream/main@f921683
+	// (the unified /plugins/* API is now merged; re-verify against upstream/main
+	// before widening/narrowing any set here).
 	{op: "mcp.probe", in: "body", field: "transport",
 		want: []string{"stdio", "streamable-http", "sse"},
-		why:  "octo-marketplace internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
+		why:  "octo-marketplace upstream/main@f921683 internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
 	{op: "plugin.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/model/plugin.go PluginType constants + internal/service/plugin/validation.go:71 validPluginType; the list handler rejects any other value. " +
+		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:71 validPluginType; " +
+			"internal/api/handler/plugin/handler.go reads plugin_type from query and lets buildListQuery reject others. " +
 			"Legacy per-type surface maps mcp->connector and squad->expert_team"},
 	{op: "plugin.list", in: "query", field: "mode",
 		want: []string{"mine"},
-		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/api/handler/plugin/handler.go:297 — the list handler accepts only \"\" or \"mine\" and 400s on anything else, so the sole explicit value is \"mine\" (omit for the full catalog). " +
+		why: "octo-marketplace upstream/main@f921683 internal/api/handler/plugin/handler.go:284-286 — the list handler accepts only \"\" or \"mine\" and 400s on anything else, so the sole explicit value is \"mine\" (omit for the full catalog). " +
 			"Deliberately NOT [all,mine]: the unified backend rejects mode=all, unlike the retired per-type surface"},
+	{op: "plugin.list", in: "query", field: "sort",
+		want: []string{"newest", "oldest", "updated", "name", "placement", "views", "installs", "downloads", "comprehensive"},
+		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/service.go:202-205 — sort switch default=ErrInvalidRequest; " +
+			"placement requires a non-empty scene_code (service.go:207-209). Default ordering in the handler is \"newest\" only when none supplied."},
 	{op: "plugin_category.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why:  "same plugin_type set as plugin.list"},
+		why:  "same plugin_type set as plugin.list (categories filtered by scene+type)"},
 	{op: "plugin_tag.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
 		why:  "same plugin_type set as plugin.list (optional filter here)"},
 	{op: "plugin_tag.list", in: "query", field: "mode",
 		want: []string{"mine"},
-		why:  "same mode gate as plugin.list (handler.go:593 mirrors handler.go:297); \"\" or \"mine\" only"},
+		why:  "same mode gate as plugin.list (handler.go:541-544 mirrors handler.go:284-286); \"\" or \"mine\" only"},
 	{op: "plugin.upsert", in: "body", field: "plugin.plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/validation.go:71 validPluginType, enforced on every write via buildWrite (service.go:561). " +
+		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:71 validPluginType, enforced on every write via buildWrite (service.go:562). " +
 			"Same set as the read filters; typed here so the write path gates plugin_type client-side too"},
 	{op: "plugin.upsert", in: "body", field: "plugin.visibility",
 		want: []string{"space", "private"},
-		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/validation.go:80 validVisibility, enforced on create+update via buildWrite (service.go:561). " +
-			"A tenant caller on /plugins/upsert may set only space or private; system is admin-surface only and public is retired on the write path — same client set as plugin.import"},
+		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:80-90 validVisibility; system is admin-only and " +
+			"public is retired on the write path, so a tenant caller on /plugins/upsert may set only space or private — same client set as plugin.import"},
+	{op: "plugin.upsert", in: "body", field: "relations[].relation_type",
+		want: []string{"expert_team_expert", "expert_skill", "expert_connector"},
+		why: "octo-marketplace upstream/main@f921683 octo-plugin-lib@v0.1.0 plugin/types.go:40-42 (RelationExpertTeamExpert/RelationExpertSkill/RelationExpertConnector); " +
+			"validation.go:125 validRelationType enforces source->target typing (expert_team->expert, expert->skill, expert->connector)."},
 	{op: "plugin.import", in: "body", field: "visibility",
 		want: []string{"space", "private"},
-		why: "octo-marketplace feat/unified-plugin-backend@99f6c28 internal/service/plugin/import.go rejects public on the import path " +
-			"(TestImportRejectsPublicVisibility); a skill import accepts only space (default) or private, " +
-			"and system is admin-only — so the client set is these two"},
+		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/import.go routes through buildWrite which calls validVisibility (system admin only, public rejected); " +
+			"skill imports default to space and accept only space/private from a tenant caller."},
 
 	// --- message ---
 	{op: "message.search", in: "body", field: "sort",

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -177,24 +177,24 @@ var requestSideVocabularies = []vocabulary{
 		why:  "octo-docs-html reply status enum"},
 
 	// --- marketplace (unified plugin surface) ---
-	// Backend definitions pinned to Mininglamp-OSS/octo-marketplace upstream/main@f921683
-	// (the unified /plugins/* API is now merged; re-verify against upstream/main
-	// before widening/narrowing any set here).
+	// Backend definitions pinned to Mininglamp-OSS/octo-marketplace
+	// upstream/main@50a1be3 (Space review/listing v2). Re-verify against
+	// upstream/main before widening or narrowing any set here.
 	{op: "mcp.probe", in: "body", field: "transport",
 		want: []string{"stdio", "streamable-http", "sse"},
-		why:  "octo-marketplace upstream/main@f921683 internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
+		why:  "octo-marketplace upstream/main@50a1be3 internal/model/mcp.go ValidTransport — the retained connectivity probe still takes these three"},
 	{op: "plugin.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:71 validPluginType; " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/service/plugin/validation.go:71 validPluginType; " +
 			"internal/api/handler/plugin/handler.go reads plugin_type from query and lets buildListQuery reject others. " +
 			"Legacy per-type surface maps mcp->connector and squad->expert_team"},
 	{op: "plugin.list", in: "query", field: "mode",
 		want: []string{"mine"},
-		why: "octo-marketplace upstream/main@f921683 internal/api/handler/plugin/handler.go:284-286 — the list handler accepts only \"\" or \"mine\" and 400s on anything else, so the sole explicit value is \"mine\" (omit for the full catalog). " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/api/handler/plugin/handler.go:284-286 — the list handler accepts only \"\" or \"mine\" and 400s on anything else, so the sole explicit value is \"mine\" (omit for the full catalog). " +
 			"Deliberately NOT [all,mine]: the unified backend rejects mode=all, unlike the retired per-type surface"},
 	{op: "plugin.list", in: "query", field: "sort",
 		want: []string{"newest", "oldest", "updated", "name", "placement", "views", "installs", "downloads", "comprehensive"},
-		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/service.go:202-205 — sort switch default=ErrInvalidRequest; " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/service/plugin/service.go:202-205 — sort switch default=ErrInvalidRequest; " +
 			"placement requires a non-empty scene_code (service.go:207-209). Default ordering in the handler is \"newest\" only when none supplied."},
 	{op: "plugin_category.list", in: "query", field: "plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
@@ -207,20 +207,29 @@ var requestSideVocabularies = []vocabulary{
 		why:  "same mode gate as plugin.list (handler.go:541-544 mirrors handler.go:284-286); \"\" or \"mine\" only"},
 	{op: "plugin.upsert", in: "body", field: "plugin.plugin_type",
 		want: []string{"skill", "connector", "expert", "expert_team"},
-		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:71 validPluginType, enforced on every write via buildWrite (service.go:562). " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/service/plugin/validation.go:71 validPluginType, enforced on every write via buildWrite (service.go:562). " +
 			"Same set as the read filters; typed here so the write path gates plugin_type client-side too"},
 	{op: "plugin.upsert", in: "body", field: "plugin.visibility",
 		want: []string{"space", "private"},
-		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/validation.go:80-90 validVisibility; system is admin-only and " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/service/plugin/validation.go:80-90 validVisibility; system is admin-only and " +
 			"public is retired on the write path, so a tenant caller on /plugins/upsert may set only space or private — same client set as plugin.import"},
 	{op: "plugin.upsert", in: "body", field: "relations[].relation_type",
 		want: []string{"expert_team_expert", "expert_skill", "expert_connector"},
-		why: "octo-marketplace upstream/main@f921683 octo-plugin-lib@v0.1.0 plugin/types.go:40-42 (RelationExpertTeamExpert/RelationExpertSkill/RelationExpertConnector); " +
+		why: "octo-marketplace upstream/main@50a1be3 octo-plugin-lib@v0.1.0 plugin/types.go:40-42 (RelationExpertTeamExpert/RelationExpertSkill/RelationExpertConnector); " +
 			"validation.go:125 validRelationType enforces source->target typing (expert_team->expert, expert->skill, expert->connector)."},
 	{op: "plugin.import", in: "body", field: "visibility",
 		want: []string{"space", "private"},
-		why: "octo-marketplace upstream/main@f921683 internal/service/plugin/import.go routes through buildWrite which calls validVisibility (system admin only, public rejected); " +
+		why: "octo-marketplace upstream/main@50a1be3 internal/service/plugin/import.go routes through buildWrite which calls validVisibility (system admin only, public rejected); " +
 			"skill imports default to space and accept only space/private from a tenant caller."},
+	{op: "plugin.review_request.list", in: "query", field: "mode",
+		want: []string{"mine", "space"},
+		why:  "octo-marketplace upstream/main@50a1be3 internal/api/handler/plugin/review.go ListReviews accepts only the applicant's mine view or the privileged Space queue"},
+	{op: "plugin.review_request.list", in: "query", field: "status",
+		want: []string{"pending", "approved", "rejected", "canceled"},
+		why:  "octo-marketplace upstream/main@50a1be3 model.ReviewStatus and ListReviews' explicit status switch"},
+	{op: "plugin.review_request.create", in: "body", field: "relations[].relation_type",
+		want: []string{"expert_team_expert", "expert_skill", "expert_connector"},
+		why:  "octo-marketplace upstream/main@50a1be3 reviewSubmitRequest reuses relationRequest and SubmitReview maps the same relation-type matrix as plugin.upsert"},
 
 	// --- message ---
 	{op: "message.search", in: "body", field: "sort",

--- a/cmd/service/flags.go
+++ b/cmd/service/flags.go
@@ -215,7 +215,7 @@ var engineFlagNames = []string{
 // rootPersistentFlagNames are the global flags root registers as persistent
 // flags. Only long names are listed: `--jq`'s `-q` shorthand lives in pflag's
 // separate shorthand namespace, so a spec param legitimately named `q`
-// (matter.list, skill.list) does not shadow it and must stay registrable.
+// (matter.list, plugin.list) does not shadow it and must stay registrable.
 //
 // The list is spelled out here rather than read from the root command because
 // package cmd imports this package, not the other way round.

--- a/cmd/service/guards_test.go
+++ b/cmd/service/guards_test.go
@@ -30,9 +30,9 @@ func TestFlags_GlobalFlagNamesAreReserved(t *testing.T) {
 	}
 	// The `-q` shorthand of `--jq` must stay out: pflag keeps shorthands in a
 	// separate namespace, so a spec param named `q` (matter.list,
-	// marketplace skill.list) does not shadow it and must remain registrable.
+	// marketplace plugin.list) does not shadow it and must remain registrable.
 	if reservedFlagNames["q"] {
-		t.Error(`"q" must not be reserved: it is --jq's shorthand, and matter.list / skill.list ` +
+		t.Error(`"q" must not be reserved: it is --jq's shorthand, and matter.list / plugin.list ` +
 			`declare a query param named q that would lose its flag`)
 	}
 }

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -23,17 +23,25 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		method string
 		path   string
 	}{
-		"plugin.list":          {http.MethodGet, "/market/api/v1/plugins"},
-		"plugin.get":           {http.MethodGet, "/market/api/v1/plugins/detail"},
-		"plugin.version.list":  {http.MethodGet, "/market/api/v1/plugins/versions"},
-		"plugin.skillmd":       {http.MethodGet, "/market/api/v1/plugins/skill_md"},
-		"plugin.download":      {http.MethodGet, "/market/api/v1/plugins/download"},
-		"plugin_category.list": {http.MethodGet, "/market/api/v1/plugin_categories"},
-		"plugin_tag.list":      {http.MethodGet, "/market/api/v1/plugin_tags"},
-		"plugin.upsert":        {http.MethodPost, "/market/api/v1/plugins/upsert"},
-		"plugin.delete":        {http.MethodPost, "/market/api/v1/plugins/delete"},
-		"plugin.install":       {http.MethodPost, "/market/api/v1/plugins/install"},
-		"plugin.import":        {http.MethodPost, "/market/api/v1/plugins/import"},
+		"plugin.list":                   {http.MethodGet, "/market/api/v1/plugins"},
+		"plugin.get":                    {http.MethodGet, "/market/api/v1/plugins/detail"},
+		"plugin.version.list":           {http.MethodGet, "/market/api/v1/plugins/versions"},
+		"plugin.skillmd":                {http.MethodGet, "/market/api/v1/plugins/skill_md"},
+		"plugin.download":               {http.MethodGet, "/market/api/v1/plugins/download"},
+		"plugin_category.list":          {http.MethodGet, "/market/api/v1/plugin_categories"},
+		"plugin_tag.list":               {http.MethodGet, "/market/api/v1/plugin_tags"},
+		"plugin.upsert":                 {http.MethodPost, "/market/api/v1/plugins/upsert"},
+		"plugin.delete":                 {http.MethodPost, "/market/api/v1/plugins/delete"},
+		"plugin.install":                {http.MethodPost, "/market/api/v1/plugins/install"},
+		"plugin.import":                 {http.MethodPost, "/market/api/v1/plugins/import"},
+		"plugin.publish":                {http.MethodPost, "/market/api/v1/plugins/publish"},
+		"plugin.delist":                 {http.MethodPost, "/market/api/v1/plugins/delist"},
+		"plugin.review_request.list":    {http.MethodGet, "/market/api/v1/plugins/review_requests"},
+		"plugin.review_request.create":  {http.MethodPost, "/market/api/v1/plugins/review_requests"},
+		"plugin.review_request.get":     {http.MethodGet, "/market/api/v1/plugins/review_requests/{review_id}"},
+		"plugin.review_request.approve": {http.MethodPost, "/market/api/v1/plugins/review_requests/{review_id}/approve"},
+		"plugin.review_request.reject":  {http.MethodPost, "/market/api/v1/plugins/review_requests/{review_id}/reject"},
+		"plugin.review_request.cancel":  {http.MethodPost, "/market/api/v1/plugins/review_requests/{review_id}/cancel"},
 
 		// Retained helper pipelines (unchanged endpoints).
 		"mcp.probe":                {http.MethodPost, "/market/api/v1/mcps/_probe"},
@@ -69,11 +77,17 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 	// because the backend requires a pending task and answers a re-POST with 409
 	// CONFLICT instead of the original parse-task ID.
 	neverRetry := map[string]bool{
-		"plugin.upsert":      true,
-		"plugin.delete":      true,
-		"plugin.install":     true,
-		"plugin.import":      true,
-		"skill_upload.parse": true,
+		"plugin.upsert":                 true,
+		"plugin.delete":                 true,
+		"plugin.install":                true,
+		"plugin.import":                 true,
+		"plugin.publish":                true,
+		"plugin.delist":                 true,
+		"plugin.review_request.create":  true,
+		"plugin.review_request.approve": true,
+		"plugin.review_request.reject":  true,
+		"plugin.review_request.cancel":  true,
+		"skill_upload.parse":            true,
 	}
 	for id := range wants {
 		op, ok := r.GetOperation(id)
@@ -94,7 +108,6 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 	for _, gone := range []string{
 		"skill.list", "skill.get", "skill.download", "skill.publish",
 		"mcp.list", "mcp.create", "marketplace.expert.list", "marketplace.squad.create",
-		"plugin.publish",
 	} {
 		if _, ok := r.GetOperation(gone); ok {
 			t.Errorf("legacy operation %q must be retired", gone)
@@ -146,19 +159,19 @@ func TestMarketplacePluginListRequest(t *testing.T) {
 	}
 }
 
-// TestMarketplacePluginListRequiresSceneAndType pins that the backend-required
-// scene_code and plugin_type are enforced locally before any request is sent.
-// Both branches are exercised: the enforcement is per-flag, so covering only
-// one would leave the other free to regress.
-func TestMarketplacePluginListRequiresSceneAndType(t *testing.T) {
+// TestMarketplacePluginListRequiresSceneAndConditionallyType pins the latest
+// backend contract: scene_code is always required, while plugin_type is required
+// for the catalog grid but optional for mode=mine's all-types owner view.
+func TestMarketplacePluginListRequiresSceneAndConditionallyType(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		args []string
 		want string
 	}{
 		{"missing scene-code", []string{"--plugin-type", "skill"}, "scene-code"},
-		{"missing plugin-type", []string{"--scene-code", "default"}, "plugin-type"},
-		{"missing both", nil, "required"},
+		{"catalog missing plugin-type", []string{"--scene-code", "default"}, "plugin-type"},
+		{"catalog empty plugin-type", []string{"--scene-code", "default", "--plugin-type", ""}, "plugin-type"},
+		{"missing both", nil, "scene-code"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -170,6 +183,22 @@ func TestMarketplacePluginListRequiresSceneAndType(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("mine accepts all plugin types", func(t *testing.T) {
+		var gotQuery string
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+		})
+		root.SetArgs([]string{"marketplace", "plugin", "list", "--scene-code", "default", "--mode", "mine"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !strings.Contains(gotQuery, "mode=mine") || strings.Contains(gotQuery, "plugin_type=") {
+			t.Fatalf("query = %q, want mode=mine without plugin_type", gotQuery)
+		}
+	})
 }
 
 // TestMarketplacePluginDeleteRequest pins the destructive op's path, body and
@@ -365,6 +394,9 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 		{"missing manifest_json", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","plugin_json":{}}}`},
 		{"missing plugin_json", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","manifest_json":{}}}`},
 		{"unknown relation_type", `{"plugin":{"plugin_name":"x","plugin_type":"expert","visibility":"private","manifest_json":{},"plugin_json":{}},"relations":[{"target_plugin_id":"p2","relation_type":"bogus"}]}`},
+		{"unknown outer field", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","manifest_json":{},"plugin_json":{}},"typo":true}`},
+		{"unknown plugin field", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","manifest_json":{},"plugin_json":{},"publsher":"typo"}}`},
+		{"unknown relation field", `{"plugin":{"plugin_name":"x","plugin_type":"expert","visibility":"private","manifest_json":{},"plugin_json":{}},"relations":[{"target_plugin_id":"p2","relation_type":"expert_skill","typo":true}]}`},
 	} {
 		sent := false
 		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -379,10 +411,81 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 			t.Errorf("%s: no request should have left the client", tc.name)
 		}
 	}
+
+	// Existing plugins may carry a grandfathered pre-semver label. The backend
+	// permits an update that echoes that exact stored value, so the CLI must not
+	// reject it from schema metadata before the backend can compare against state.
+	var sentLegacyVersion bool
+	root, _, _ = rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		sentLegacyVersion = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"plugin":{"plugin_id":"p1"}}}`))
+	})
+	root.SetArgs([]string{"marketplace", "plugin", "upsert", "--data", `{"plugin":{"plugin_id":"p1","plugin_name":"x","plugin_type":"connector","visibility":"private","version":"legacy-v1","manifest_json":{},"plugin_json":{}}}`})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("grandfathered version must reach backend for stateful validation: %v", err)
+	}
+	if !sentLegacyVersion {
+		t.Fatal("grandfathered version request was not sent")
+	}
 }
 
 // TestMarketplaceSkillmdRequest pins the unified skill_md endpoint keyed by
 // plugin_id (experts/teams resolve the relation target first).
+func TestMarketplacePublicationLifecycleRequests(t *testing.T) {
+	t.Run("publish", func(t *testing.T) {
+		var gotPath string
+		var gotBody map[string]any
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"plugin_id":"p1","display_status":"pending_review","review_id":"r1"}}`))
+		})
+		root.SetArgs([]string{"marketplace", "plugin", "publish", "--plugin-id", "p1", "--version", "1.2.0", "--changelog", "review me"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if gotPath != "/market/api/v1/plugins/publish" || gotBody["plugin_id"] != "p1" || gotBody["version"] != "1.2.0" {
+			t.Fatalf("publish request = %s %#v", gotPath, gotBody)
+		}
+	})
+
+	t.Run("review list", func(t *testing.T) {
+		var gotQuery string
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+		})
+		root.SetArgs([]string{"marketplace", "plugin", "review-request", "list", "--mode", "space", "--status", "pending"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if !strings.Contains(gotQuery, "mode=space") || !strings.Contains(gotQuery, "status=pending") {
+			t.Fatalf("review list query = %q", gotQuery)
+		}
+	})
+
+	t.Run("reject", func(t *testing.T) {
+		var gotPath string
+		var gotBody map[string]any
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{}}`))
+		})
+		root.SetArgs([]string{"marketplace", "plugin", "review-request", "reject", "r1", "--reason", "missing docs"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if gotPath != "/market/api/v1/plugins/review_requests/r1/reject" || gotBody["reason"] != "missing docs" {
+			t.Fatalf("reject request = %s %#v", gotPath, gotBody)
+		}
+	})
+}
+
 func TestMarketplaceSkillmdRequest(t *testing.T) {
 	var gotMethod, gotPath, gotQuery string
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -481,7 +584,7 @@ func TestMarketplaceCommandTree(t *testing.T) {
 		t.Fatal("missing marketplace command")
 	}
 	domains := map[string][]string{
-		"plugin":            {"list", "get", "skillmd", "download", "upsert", "delete", "install", "import"},
+		"plugin":            {"list", "get", "skillmd", "download", "upsert", "delete", "install", "import", "publish", "delist"},
 		"plugin-category":   {"list"},
 		"plugin-tag":        {"list"},
 		"mcp":               {"probe"},
@@ -502,9 +605,19 @@ func TestMarketplaceCommandTree(t *testing.T) {
 			}
 		}
 	}
-	// `plugin version list` is a nested subgroup, checked separately.
-	if pv := findCmd(findCmd(marketplace, "plugin"), "version"); pv == nil || findCmd(pv, "list") == nil {
+	// Nested plugin subgroups are checked separately.
+	plugin := findCmd(marketplace, "plugin")
+	if pv := findCmd(plugin, "version"); pv == nil || findCmd(pv, "list") == nil {
 		t.Error("missing marketplace plugin version list command")
+	}
+	if reviews := findCmd(plugin, "review-request"); reviews == nil {
+		t.Error("missing marketplace plugin review-request command group")
+	} else {
+		for _, name := range []string{"create", "list", "get", "approve", "reject", "cancel"} {
+			if findCmd(reviews, name) == nil {
+				t.Errorf("missing marketplace plugin review-request %s command", name)
+			}
+		}
 	}
 	if got := childNames(marketplace); len(got) != len(domains) {
 		t.Errorf("marketplace domains = %v, want %d groups", got, len(domains))

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -12,8 +12,8 @@ import (
 // TestMarketplaceRegistryShape pins every unified-plugin operationId to its
 // method+path and the marketplace-wide invariants (OCTO_API_BASE_URL, space
 // header). The legacy per-type endpoints (/experts, /squads, /mcps, /skills)
-// are intentionally gone: they read frozen pre-migration tables, so the CLI now
-// drives the unified /plugins/* surface. Only the type-agnostic helper
+// are intentionally gone: they cannot read rows created after unification, so
+// the CLI drives the unified /plugins/* surface. Only the type-agnostic helper
 // pipelines (probe, skill upload/parse, icon presign) are retained verbatim.
 func TestMarketplaceRegistryShape(t *testing.T) {
 	r := registry.MustNew()
@@ -30,7 +30,6 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		"plugin_tag.list":      {http.MethodGet, "/market/api/v1/plugin_tags"},
 		"plugin.upsert":        {http.MethodPost, "/market/api/v1/plugins/upsert"},
 		"plugin.delete":        {http.MethodPost, "/market/api/v1/plugins/delete"},
-		"plugin.publish":       {http.MethodPost, "/market/api/v1/plugins/publish"},
 		"plugin.install":       {http.MethodPost, "/market/api/v1/plugins/install"},
 		"plugin.import":        {http.MethodPost, "/market/api/v1/plugins/import"},
 
@@ -62,11 +61,13 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		}
 	}
 
-	// The retired legacy operations must be gone so the CLI can never read the
-	// frozen per-type tables again.
+	// Unified plugin backend has no "frozen tables" — legacy handlers still
+	// exist server-side but cannot read rows created after unification, so the
+	// CLI is scoped to the unified surface only.
 	for _, gone := range []string{
 		"skill.list", "skill.get", "skill.download", "skill.publish",
 		"mcp.list", "mcp.create", "marketplace.expert.list", "marketplace.squad.create",
+		"plugin.publish",
 	} {
 		if _, ok := r.GetOperation(gone); ok {
 			t.Errorf("legacy operation %q must be retired", gone)
@@ -204,31 +205,6 @@ func TestMarketplacePluginInstallRequest(t *testing.T) {
 	}
 }
 
-// TestMarketplacePluginPublishRequest pins the publish body wiring.
-func TestMarketplacePluginPublishRequest(t *testing.T) {
-	var gotPath string
-	var gotBody map[string]any
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Errorf("decode body: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"version":"1.0.0"}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "plugin", "publish", "--plugin-id", "p1", "--version", "1.0.0", "--changelog", "init"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if gotPath != "/market/api/v1/plugins/publish" {
-		t.Errorf("path = %q", gotPath)
-	}
-	if gotBody["plugin_id"] != "p1" || gotBody["version"] != "1.0.0" || gotBody["changelog"] != "init" {
-		t.Errorf("body = %#v", gotBody)
-	}
-}
-
 // TestMarketplacePluginUpsertRequest pins the unified write path: a full
 // document passed via --data reaches POST /plugins/upsert with the plugin
 // object intact, and the newly-typed nested enums gate visibility/plugin_type
@@ -248,7 +224,7 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 	})
 	root.SetArgs([]string{
 		"marketplace", "plugin", "upsert",
-		"--data", `{"plugin":{"plugin_name":"deep miner","plugin_type":"connector","visibility":"private"}}`,
+		"--data", `{"plugin":{"plugin_name":"deep miner","plugin_type":"connector","visibility":"private","manifest_json":{},"plugin_json":{"connector":{"type":"stdio"},"mcpServers":{}}}}`,
 	})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
@@ -269,9 +245,12 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 		name string
 		data string
 	}{
-		{"public visibility", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"public"}}`},
-		{"unknown plugin_type", `{"plugin":{"plugin_name":"x","plugin_type":"nonsense","visibility":"private"}}`},
-		{"missing plugin_type", `{"plugin":{"plugin_name":"x","visibility":"private"}}`},
+		{"public visibility", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"public","manifest_json":{},"plugin_json":{}}}`},
+		{"unknown plugin_type", `{"plugin":{"plugin_name":"x","plugin_type":"nonsense","visibility":"private","manifest_json":{},"plugin_json":{}}}`},
+		{"missing plugin_type", `{"plugin":{"plugin_name":"x","visibility":"private","manifest_json":{},"plugin_json":{}}}`},
+		{"missing manifest_json", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","plugin_json":{}}}`},
+		{"missing plugin_json", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"private","manifest_json":{}}}`},
+		{"unknown relation_type", `{"plugin":{"plugin_name":"x","plugin_type":"expert","visibility":"private","manifest_json":{},"plugin_json":{}},"relations":[{"target_plugin_id":"p2","relation_type":"bogus"}]}`},
 	} {
 		sent := false
 		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -364,7 +343,7 @@ func TestMarketplaceCommandTree(t *testing.T) {
 		t.Fatal("missing marketplace command")
 	}
 	domains := map[string][]string{
-		"plugin":            {"list", "get", "skillmd", "download", "upsert", "delete", "publish", "install", "import"},
+		"plugin":            {"list", "get", "skillmd", "download", "upsert", "delete", "install", "import"},
 		"plugin-category":   {"list"},
 		"plugin-tag":        {"list"},
 		"mcp":               {"probe"},

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -229,6 +229,65 @@ func TestMarketplacePluginPublishRequest(t *testing.T) {
 	}
 }
 
+// TestMarketplacePluginUpsertRequest pins the unified write path: a full
+// document passed via --data reaches POST /plugins/upsert with the plugin
+// object intact, and the newly-typed nested enums gate visibility/plugin_type
+// client-side so the retired `public` value and unknown types never leave.
+func TestMarketplacePluginUpsertRequest(t *testing.T) {
+	// Happy path: the full document is forwarded and the plugin sub-document
+	// survives verbatim.
+	var gotMethod, gotPath string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"plugin":{"plugin_id":"p1"}}}`))
+	})
+	root.SetArgs([]string{
+		"marketplace", "plugin", "upsert",
+		"--data", `{"plugin":{"plugin_name":"deep miner","plugin_type":"connector","visibility":"private"}}`,
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/plugins/upsert" {
+		t.Errorf("got %s %s, want POST /market/api/v1/plugins/upsert", gotMethod, gotPath)
+	}
+	plugin, ok := gotBody["plugin"].(map[string]any)
+	if !ok || plugin["plugin_name"] != "deep miner" || plugin["plugin_type"] != "connector" || plugin["visibility"] != "private" {
+		t.Errorf("body.plugin = %#v", gotBody["plugin"])
+	}
+
+	// Each of these documents must be rejected locally before any request is
+	// sent: the retired `public` visibility (the gate must not be bypassable
+	// from upsert the way it is blocked on import), an unknown plugin_type, and
+	// a document missing a required nested field.
+	for _, tc := range []struct {
+		name string
+		data string
+	}{
+		{"public visibility", `{"plugin":{"plugin_name":"x","plugin_type":"connector","visibility":"public"}}`},
+		{"unknown plugin_type", `{"plugin":{"plugin_name":"x","plugin_type":"nonsense","visibility":"private"}}`},
+		{"missing plugin_type", `{"plugin":{"plugin_name":"x","visibility":"private"}}`},
+	} {
+		sent := false
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			sent = true
+			t.Errorf("%s: request must not be sent", tc.name)
+		})
+		root.SetArgs([]string{"marketplace", "plugin", "upsert", "--data", tc.data})
+		if err := root.Execute(); err == nil {
+			t.Errorf("%s: expected a local validation error, got nil", tc.name)
+		}
+		if sent {
+			t.Errorf("%s: no request should have left the client", tc.name)
+		}
+	}
+}
+
 // TestMarketplaceSkillmdRequest pins the unified skill_md endpoint keyed by
 // plugin_id (experts/teams resolve the relation target first).
 func TestMarketplaceSkillmdRequest(t *testing.T) {

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -58,6 +60,31 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 		}
 		if !op.SpaceHeader {
 			t.Errorf("%s must send the space header", id)
+		}
+	}
+
+	// Non-idempotent operations must opt out of transport retries: an ambiguous
+	// gateway failure has to surface as RESULT_UNKNOWN rather than replay a
+	// mutation the backend may already have committed. skill_upload.parse counts
+	// because the backend requires a pending task and answers a re-POST with 409
+	// CONFLICT instead of the original parse-task ID.
+	neverRetry := map[string]bool{
+		"plugin.upsert":      true,
+		"plugin.delete":      true,
+		"plugin.install":     true,
+		"plugin.import":      true,
+		"skill_upload.parse": true,
+	}
+	for id := range wants {
+		op, ok := r.GetOperation(id)
+		if !ok {
+			continue
+		}
+		switch {
+		case neverRetry[id] && op.RetryMode != "never":
+			t.Errorf("%s retry mode = %q, want never", id, op.RetryMode)
+		case !neverRetry[id] && op.RetryMode == "never":
+			t.Errorf("%s retry mode = never, want the default retry policy", id)
 		}
 	}
 
@@ -121,13 +148,82 @@ func TestMarketplacePluginListRequest(t *testing.T) {
 
 // TestMarketplacePluginListRequiresSceneAndType pins that the backend-required
 // scene_code and plugin_type are enforced locally before any request is sent.
+// Both branches are exercised: the enforcement is per-flag, so covering only
+// one would leave the other free to regress.
 func TestMarketplacePluginListRequiresSceneAndType(t *testing.T) {
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		t.Errorf("request must not be sent when required flags are missing")
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing scene-code", []string{"--plugin-type", "skill"}, "scene-code"},
+		{"missing plugin-type", []string{"--scene-code", "default"}, "plugin-type"},
+		{"missing both", nil, "required"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("request must not be sent when required flags are missing")
+			})
+			root.SetArgs(append([]string{"marketplace", "plugin", "list"}, tc.args...))
+			if err := root.Execute(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("execute error = %v, want an error mentioning %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestMarketplacePluginDeleteRequest pins the destructive op's path, body and
+// space header. plugin.delete is the one op that cannot be re-driven to check
+// its own outcome, so its wiring is pinned explicitly.
+func TestMarketplacePluginDeleteRequest(t *testing.T) {
+	var gotMethod, gotPath, gotSpace string
+	var body map[string]any
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotSpace = r.Method, r.URL.Path, r.Header.Get("X-Space-Id")
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{}}`))
 	})
-	root.SetArgs([]string{"marketplace", "plugin", "list", "--plugin-type", "skill"})
-	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "scene-code") {
-		t.Fatalf("execute error = %v, want a required scene-code error", err)
+
+	root.SetArgs([]string{"marketplace", "plugin", "delete", "--plugin-id", "p1"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/plugins/delete" {
+		t.Errorf("request = %s %s, want POST /market/api/v1/plugins/delete", gotMethod, gotPath)
+	}
+	if body["plugin_id"] != "p1" {
+		t.Errorf("body plugin_id = %v, want p1", body["plugin_id"])
+	}
+	if gotSpace != "space-1" {
+		t.Errorf("X-Space-Id = %q, want space-1", gotSpace)
+	}
+}
+
+// TestMarketplacePluginVersionListRequest pins the nested `plugin version list`
+// command onto the versions path with its pagination query.
+func TestMarketplacePluginVersionListRequest(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
+	})
+
+	root.SetArgs([]string{
+		"marketplace", "plugin", "version", "list",
+		"--plugin-id", "p1", "--page", "2", "--page-size", "50",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/plugins/versions" {
+		t.Errorf("request = %s %s, want GET /market/api/v1/plugins/versions", gotMethod, gotPath)
+	}
+	for _, want := range []string{"plugin_id=p1", "page=2", "page_size=50"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want it to contain %q", gotQuery, want)
+		}
 	}
 }
 
@@ -211,7 +307,11 @@ func TestMarketplacePluginInstallRequest(t *testing.T) {
 // client-side so the retired `public` value and unknown types never leave.
 func TestMarketplacePluginUpsertRequest(t *testing.T) {
 	// Happy path: the full document is forwarded and the plugin sub-document
-	// survives verbatim.
+	// survives verbatim. The document is backend-realistic on purpose —
+	// manifest_json.plugin_name/plugin_type/labels agree with the outer fields,
+	// which the backend requires on every write. The CLI does not enforce that
+	// invariant (it has no cross-field validator), so this pins the wire shape a
+	// real call takes rather than a stub the server would reject with 400.
 	var gotMethod, gotPath string
 	var gotBody map[string]any
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -224,7 +324,7 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 	})
 	root.SetArgs([]string{
 		"marketplace", "plugin", "upsert",
-		"--data", `{"plugin":{"plugin_name":"deep miner","plugin_type":"connector","visibility":"private","manifest_json":{},"plugin_json":{"connector":{"type":"stdio"},"mcpServers":{}}}}`,
+		"--data", `{"plugin":{"plugin_name":"deep miner","plugin_type":"connector","visibility":"private","tags":["cli","mcp"],"manifest_json":{"plugin_name":"deep miner","plugin_type":"connector","labels":["cli","mcp"]},"plugin_json":{"connector":{"type":"stdio"},"mcpServers":{}}}}`,
 	})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
@@ -235,6 +335,20 @@ func TestMarketplacePluginUpsertRequest(t *testing.T) {
 	plugin, ok := gotBody["plugin"].(map[string]any)
 	if !ok || plugin["plugin_name"] != "deep miner" || plugin["plugin_type"] != "connector" || plugin["visibility"] != "private" {
 		t.Errorf("body.plugin = %#v", gotBody["plugin"])
+	}
+	// The manifest must reach the backend unmodified: the CLI must not helpfully
+	// re-derive or reorder labels, because the comparison there is order-
+	// sensitive canonical JSON.
+	manifest, ok := plugin["manifest_json"].(map[string]any)
+	if !ok {
+		t.Fatalf("body.plugin.manifest_json = %#v, want an object", plugin["manifest_json"])
+	}
+	if manifest["plugin_name"] != "deep miner" || manifest["plugin_type"] != "connector" {
+		t.Errorf("manifest_json = %#v, want it forwarded verbatim", manifest)
+	}
+	labels, _ := manifest["labels"].([]any)
+	if len(labels) != 2 || labels[0] != "cli" || labels[1] != "mcp" {
+		t.Errorf("manifest_json.labels = %#v, want [cli mcp] in order", manifest["labels"])
 	}
 
 	// Each of these documents must be rejected locally before any request is
@@ -313,6 +427,30 @@ func TestMarketplaceDownloadRequest(t *testing.T) {
 	}
 	if gotSpace != "space-1" {
 		t.Errorf("X-Space-Id = %q, want space-1", gotSpace)
+	}
+}
+
+// TestMarketplaceDownloadWritesOutputFile pins that x-octo-binary-response on
+// plugin.download actually registers -o and streams the reconstructed zip to
+// disk. The skill install flow documented in skills.md depends on it, and the
+// path-only test above would still pass if -o silently stopped being wired.
+func TestMarketplaceDownloadWritesOutputFile(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write([]byte("PK\x03\x04payload"))
+	})
+
+	out := filepath.Join(t.TempDir(), "skill.zip")
+	root.SetArgs([]string{"marketplace", "plugin", "download", "--plugin-id", "p1", "-o", out})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read %s: %v", out, err)
+	}
+	if string(got) != "PK\x03\x04payload" {
+		t.Errorf("downloaded bytes = %q, want the streamed zip payload", got)
 	}
 }
 

--- a/cmd/service/marketplace_test.go
+++ b/cmd/service/marketplace_test.go
@@ -3,67 +3,44 @@ package service
 import (
 	"encoding/json"
 	"net/http"
-	"reflect"
 	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/Mininglamp-OSS/octo-cli/internal/registry"
 )
 
+// TestMarketplaceRegistryShape pins every unified-plugin operationId to its
+// method+path and the marketplace-wide invariants (OCTO_API_BASE_URL, space
+// header). The legacy per-type endpoints (/experts, /squads, /mcps, /skills)
+// are intentionally gone: they read frozen pre-migration tables, so the CLI now
+// drives the unified /plugins/* surface. Only the type-agnostic helper
+// pipelines (probe, skill upload/parse, icon presign) are retained verbatim.
 func TestMarketplaceRegistryShape(t *testing.T) {
 	r := registry.MustNew()
 	wants := map[string]struct {
 		method string
 		path   string
 	}{
-		"skill_category.list":      {http.MethodGet, "/market/api/v1/skill_categories"},
-		"mcp_category.list":        {http.MethodGet, "/market/api/v1/mcp_categories"},
-		"skill.list":               {http.MethodGet, "/market/api/v1/skills"},
-		"skill.mine.list":          {http.MethodGet, "/market/api/v1/skills/mine"},
-		"skill.tag.list":           {http.MethodGet, "/market/api/v1/skills/tags"},
-		"skill.publish":            {http.MethodPost, "/market/api/v1/bot/skills/publish"},
-		"skill.get":                {http.MethodGet, "/market/api/v1/skills/{skill_id}"},
-		"skill.update":             {http.MethodPatch, "/market/api/v1/skills/{skill_id}"},
-		"skill.delete":             {http.MethodDelete, "/market/api/v1/skills/{skill_id}"},
-		"skill.skillmd.get":        {http.MethodGet, "/market/api/v1/skills/{skill_id}/skill_md"},
-		"skill.download":           {http.MethodGet, "/market/api/v1/skills/{skill_id}/download"},
-		"skill.reupload.create":    {http.MethodPost, "/market/api/v1/skills/{skill_id}/reuploads"},
-		"skill.version.list":       {http.MethodGet, "/market/api/v1/skills/{skill_id}/versions"},
+		"plugin.list":          {http.MethodGet, "/market/api/v1/plugins"},
+		"plugin.get":           {http.MethodGet, "/market/api/v1/plugins/detail"},
+		"plugin.version.list":  {http.MethodGet, "/market/api/v1/plugins/versions"},
+		"plugin.skillmd":       {http.MethodGet, "/market/api/v1/plugins/skill_md"},
+		"plugin.download":      {http.MethodGet, "/market/api/v1/plugins/download"},
+		"plugin_category.list": {http.MethodGet, "/market/api/v1/plugin_categories"},
+		"plugin_tag.list":      {http.MethodGet, "/market/api/v1/plugin_tags"},
+		"plugin.upsert":        {http.MethodPost, "/market/api/v1/plugins/upsert"},
+		"plugin.delete":        {http.MethodPost, "/market/api/v1/plugins/delete"},
+		"plugin.publish":       {http.MethodPost, "/market/api/v1/plugins/publish"},
+		"plugin.install":       {http.MethodPost, "/market/api/v1/plugins/install"},
+		"plugin.import":        {http.MethodPost, "/market/api/v1/plugins/import"},
+
+		// Retained helper pipelines (unchanged endpoints).
+		"mcp.probe":                {http.MethodPost, "/market/api/v1/mcps/_probe"},
 		"skill_upload.create":      {http.MethodPost, "/market/api/v1/skill_uploads"},
 		"skill_upload.parse":       {http.MethodPost, "/market/api/v1/skill_uploads/{skill_upload_id}/parse"},
 		"skill_parse_task.get":     {http.MethodGet, "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}"},
 		"skill_icon_upload.create": {http.MethodPost, "/market/api/v1/skill_icon_uploads"},
-		"mcp.list":                 {http.MethodGet, "/market/api/v1/mcps"},
-		"mcp.mine.list":            {http.MethodGet, "/market/api/v1/mcps/mine"},
-		"mcp.create":               {http.MethodPost, "/market/api/v1/mcps"},
-		"mcp.probe":                {http.MethodPost, "/market/api/v1/mcps/_probe"},
-		"mcp.get":                  {http.MethodGet, "/market/api/v1/mcps/{mcp_id}"},
-		"mcp.update":               {http.MethodPatch, "/market/api/v1/mcps/{mcp_id}"},
-		"mcp.delete":               {http.MethodDelete, "/market/api/v1/mcps/{mcp_id}"},
 		"mcp_icon_upload.create":   {http.MethodPost, "/market/api/v1/mcp_icon_uploads"},
-
-		// Expert Marketplace (docs/api/expert-v1.md): experts + squads + the
-		// dedicated expert taxonomy and skill-package upload surface.
-		"marketplace.expert.list":                {http.MethodGet, "/market/api/v1/experts"},
-		"marketplace.expert.create":              {http.MethodPost, "/market/api/v1/experts"},
-		"marketplace.expert.mine.list":           {http.MethodGet, "/market/api/v1/experts/mine"},
-		"marketplace.expert.get":                 {http.MethodGet, "/market/api/v1/experts/{expert_id}"},
-		"marketplace.expert.update":              {http.MethodPatch, "/market/api/v1/experts/{expert_id}"},
-		"marketplace.expert.delete":              {http.MethodDelete, "/market/api/v1/experts/{expert_id}"},
-		"marketplace.expert.skillmd.get":         {http.MethodGet, "/market/api/v1/experts/{expert_id}/skill_md"},
-		"marketplace.expert.skill_download":      {http.MethodGet, "/market/api/v1/experts/{expert_id}/skill_download"},
-		"marketplace.squad.list":                 {http.MethodGet, "/market/api/v1/squads"},
-		"marketplace.squad.create":               {http.MethodPost, "/market/api/v1/squads"},
-		"marketplace.squad.mine.list":            {http.MethodGet, "/market/api/v1/squads/mine"},
-		"marketplace.squad.get":                  {http.MethodGet, "/market/api/v1/squads/{squad_id}"},
-		"marketplace.squad.update":               {http.MethodPatch, "/market/api/v1/squads/{squad_id}"},
-		"marketplace.squad.delete":               {http.MethodDelete, "/market/api/v1/squads/{squad_id}"},
-		"marketplace.squad.skillmd.get":          {http.MethodGet, "/market/api/v1/squads/{squad_id}/skill_md"},
-		"marketplace.squad.skill_download":       {http.MethodGet, "/market/api/v1/squads/{squad_id}/skill_download"},
-		"marketplace.expert_category.list":       {http.MethodGet, "/market/api/v1/expert_categories"},
-		"marketplace.expert_tag.list":            {http.MethodGet, "/market/api/v1/expert_tags"},
-		"marketplace.expert_skill_upload.create": {http.MethodPost, "/market/api/v1/expert_skill_uploads"},
 	}
 
 	if got := len(r.ListOperations("marketplace")); got != len(wants) {
@@ -84,68 +61,48 @@ func TestMarketplaceRegistryShape(t *testing.T) {
 			t.Errorf("%s must send the space header", id)
 		}
 	}
-}
 
-func TestMarketplaceSkillSearchRequest(t *testing.T) {
-	var gotPath, gotQuery string
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[],"pagination":{"has_more":false}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "skill", "list", "--q", "deep miner", "--tag", "cli", "--sort", "latest", "--page-size", "20"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if gotPath != "/market/api/v1/skills" {
-		t.Errorf("path = %q", gotPath)
-	}
-	for _, want := range []string{"q=deep+miner", "tag=cli", "sort=latest", "page_size=20"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query = %q, want %q", gotQuery, want)
+	// The retired legacy operations must be gone so the CLI can never read the
+	// frozen per-type tables again.
+	for _, gone := range []string{
+		"skill.list", "skill.get", "skill.download", "skill.publish",
+		"mcp.list", "mcp.create", "marketplace.expert.list", "marketplace.squad.create",
+	} {
+		if _, ok := r.GetOperation(gone); ok {
+			t.Errorf("legacy operation %q must be retired", gone)
 		}
 	}
-	if strings.Contains(gotQuery, "offset=") {
-		t.Errorf("query = %q, must not use removed offset pagination", gotQuery)
-	}
 }
 
-// TestMarketplaceExpertListRequest pins the query-flag wiring for the new
-// offset-paginated expert list AND the envelope flattening the skill docs rely
-// on: a backend {data:[...],pagination:{...}} response surfaces items at CLI
-// .data (already an array) and pagination at ._pagination.
-func TestMarketplaceExpertListRequest(t *testing.T) {
+// TestMarketplacePluginListRequest pins the unified list path, the required
+// scene_code+plugin_type query flags, and the {data:[...],pagination} envelope
+// flattening (items at .data, pagination at ._pagination).
+func TestMarketplacePluginListRequest(t *testing.T) {
 	var gotMethod, gotPath, gotQuery string
 	root, tf, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[{"expert_id":"e1"}],"pagination":{"total":1,"page":2,"page_size":20}}`))
+		_, _ = w.Write([]byte(`{"data":[{"plugin_id":"p1"}],"pagination":{"total":1,"page":2,"page_size":20}}`))
 	})
 
 	root.SetArgs([]string{
-		"marketplace", "expert", "list",
-		"--keyword", "架构", "--category", "dev-tools", "--tag", "可靠性",
-		"--visibility", "public", "--created-by-type", "human",
-		"--sort", "updated", "--page", "2", "--page-size", "20",
+		"marketplace", "plugin", "list",
+		"--scene-code", "default", "--plugin-type", "skill",
+		"--q", "deep miner", "--tag", "cli", "--category-id", "dev-tools",
+		"--sort", "newest", "--page", "2", "--page-size", "20",
 	})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/experts" {
-		t.Errorf("got %s %s, want GET /market/api/v1/experts", gotMethod, gotPath)
+	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/plugins" {
+		t.Errorf("got %s %s, want GET /market/api/v1/plugins", gotMethod, gotPath)
 	}
-	for _, want := range []string{
-		"keyword=%E6%9E%B6%E6%9E%84", "category=dev-tools", "tag=%E5%8F%AF%E9%9D%A0%E6%80%A7",
-		"visibility=public", "created_by_type=human", "sort=updated", "page=2", "page_size=20",
-	} {
+	for _, want := range []string{"scene_code=default", "plugin_type=skill", "q=deep+miner", "tag=cli", "category_id=dev-tools", "sort=newest", "page=2", "page_size=20"} {
 		if !strings.Contains(gotQuery, want) {
 			t.Errorf("query = %q, want %q", gotQuery, want)
 		}
 	}
 
-	// Envelope flattening: items at .data (array), pagination at ._pagination.
 	var env struct {
 		Data       []map[string]any `json:"data"`
 		Pagination map[string]any   `json:"_pagination"`
@@ -153,7 +110,7 @@ func TestMarketplaceExpertListRequest(t *testing.T) {
 	if err := json.Unmarshal(tf.Out.Bytes(), &env); err != nil {
 		t.Fatalf("parse envelope: %v -- out=%s", err, tf.Out.String())
 	}
-	if len(env.Data) != 1 || env.Data[0]["expert_id"] != "e1" {
+	if len(env.Data) != 1 || env.Data[0]["plugin_id"] != "p1" {
 		t.Errorf(".data must be the item array, got %s", tf.Out.String())
 	}
 	if env.Pagination["total"] == nil {
@@ -161,9 +118,44 @@ func TestMarketplaceExpertListRequest(t *testing.T) {
 	}
 }
 
-// TestMarketplaceExpertCreateRequest pins the create path/method and that the
-// --data JSON body is forwarded verbatim.
-func TestMarketplaceExpertCreateRequest(t *testing.T) {
+// TestMarketplacePluginListRequiresSceneAndType pins that the backend-required
+// scene_code and plugin_type are enforced locally before any request is sent.
+func TestMarketplacePluginListRequiresSceneAndType(t *testing.T) {
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("request must not be sent when required flags are missing")
+	})
+	root.SetArgs([]string{"marketplace", "plugin", "list", "--plugin-type", "skill"})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "scene-code") {
+		t.Fatalf("execute error = %v, want a required scene-code error", err)
+	}
+}
+
+// TestMarketplacePluginGetRequest pins the detail path and its query flags.
+func TestMarketplacePluginGetRequest(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"plugin":{"plugin_id":"p1"}}}`))
+	})
+
+	root.SetArgs([]string{"marketplace", "plugin", "get", "--plugin-id", "p1", "--include-relations"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/plugins/detail" {
+		t.Errorf("got %s %s, want GET /market/api/v1/plugins/detail", gotMethod, gotPath)
+	}
+	for _, want := range []string{"plugin_id=p1", "include_relations=true"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query = %q, want %q", gotQuery, want)
+		}
+	}
+}
+
+// TestMarketplacePluginImportRequest pins the skill finalize path and that the
+// promoted body flags (parse_task_id etc.) reach the JSON body.
+func TestMarketplacePluginImportRequest(t *testing.T) {
 	var gotMethod, gotPath string
 	var gotBody map[string]any
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
@@ -172,140 +164,74 @@ func TestMarketplaceExpertCreateRequest(t *testing.T) {
 			t.Errorf("decode body: %v", err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"expert_id":"e1"}}`))
+		_, _ = w.Write([]byte(`{"data":{"plugin":{"plugin_id":"p1"}}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "expert", "create", "--data", `{"name":"后端架构师","summary":"x","category":"研发工具","instruction":"你是资深后端架构师"}`})
+	root.SetArgs([]string{"marketplace", "plugin", "import", "--parse-task-id", "task-1", "--name", "全栈清单", "--version", "1.0.0"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/experts" {
-		t.Errorf("got %s %s, want POST /market/api/v1/experts", gotMethod, gotPath)
+	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/plugins/import" {
+		t.Errorf("got %s %s, want POST /market/api/v1/plugins/import", gotMethod, gotPath)
 	}
-	if gotBody["name"] != "后端架构师" || gotBody["summary"] != "x" ||
-		gotBody["category"] != "研发工具" || gotBody["instruction"] != "你是资深后端架构师" {
+	if gotBody["parse_task_id"] != "task-1" || gotBody["name"] != "全栈清单" || gotBody["version"] != "1.0.0" {
 		t.Errorf("body = %#v", gotBody)
 	}
 }
 
-// TestMarketplaceSquadCreateRequest pins the happy path through the strict
-// nested member schema: a valid --data body (members with name/role/instruction)
-// must pass local validation and reach the wire intact.
-func TestMarketplaceSquadCreateRequest(t *testing.T) {
-	var gotMethod, gotPath string
+// TestMarketplacePluginInstallRequest pins the install body wiring.
+func TestMarketplacePluginInstallRequest(t *testing.T) {
+	var gotPath string
 	var gotBody map[string]any
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotMethod, gotPath = r.Method, r.URL.Path
+		gotPath = r.URL.Path
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"squad_id":"s1"}}`))
+		_, _ = w.Write([]byte(`{"data":{"agent_id":"a1"}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "squad", "create", "--data", `{
-		"name": "研发交付团",
-		"summary": "x",
-		"category": "研发工具",
-		"dependencies": {"blocking": ["git-mcp"], "recommended": []},
-		"members": [
-			{"name": "架构师", "role": "评审", "instruction": "评审服务边界", "is_leader": true},
-			{"member_key": "m2", "name": "后端", "role": "实现", "instruction": "实现接口", "skills": [{"name": "清单"}]}
-		]
-	}`})
+	root.SetArgs([]string{"marketplace", "plugin", "install", "--plugin-id", "p1", "--workspace-id", "ws", "--runtime-id", "rt"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/squads" {
-		t.Errorf("got %s %s, want POST /market/api/v1/squads", gotMethod, gotPath)
+	if gotPath != "/market/api/v1/plugins/install" {
+		t.Errorf("path = %q", gotPath)
 	}
-	members, _ := gotBody["members"].([]any)
-	if len(members) != 2 {
-		t.Fatalf("members = %#v, want 2 entries forwarded verbatim", gotBody["members"])
-	}
-	second, _ := members[1].(map[string]any)
-	if second["member_key"] != "m2" || second["instruction"] != "实现接口" {
-		t.Errorf("members[1] = %#v", second)
+	if gotBody["plugin_id"] != "p1" || gotBody["workspace_id"] != "ws" || gotBody["runtime_id"] != "rt" {
+		t.Errorf("body = %#v", gotBody)
 	}
 }
 
-// TestMarketplaceExpertSquadCreateRequiredFields pins the client-side schema
-// validation that mirrors the backend's write rules: expert create requires
-// category + instruction, and squad create requires >= 1 member each carrying
-// name/role/instruction. All three must fail locally, before any request.
-func TestMarketplaceExpertSquadCreateRequiredFields(t *testing.T) {
-	cases := []struct {
-		name string
-		args []string
-		want string
-	}{
-		{
-			name: "expert create without category/instruction",
-			args: []string{"marketplace", "expert", "create", "--data", `{"name":"后端架构师","summary":"x"}`},
-			want: "category",
-		},
-		{
-			name: "squad create with empty members",
-			args: []string{"marketplace", "squad", "create", "--data", `{"name":"研发团","summary":"x","category":"研发工具","members":[]}`},
-			want: "at least 1 item",
-		},
-		{
-			name: "squad member without instruction",
-			args: []string{"marketplace", "squad", "create", "--data", `{"name":"研发团","summary":"x","category":"研发工具","members":[{"name":"架构师","role":"评审"}]}`},
-			want: "members[0].instruction",
-		},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			var backendHits atomic.Int32
-			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-				backendHits.Add(1)
-			})
-			root.SetArgs(tc.args)
-			err := root.Execute()
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("execute error = %v, want validation error containing %q", err, tc.want)
-			}
-			if backendHits.Load() != 0 {
-				t.Error("request must not be sent when local body validation fails")
-			}
-		})
-	}
-}
-
-// TestMarketplaceExpertSkillUploadRequest pins the presign endpoint and that
-// its promoted --file-name / --file-size flags reach the body.
-func TestMarketplaceExpertSkillUploadRequest(t *testing.T) {
-	var gotMethod, gotPath string
+// TestMarketplacePluginPublishRequest pins the publish body wiring.
+func TestMarketplacePluginPublishRequest(t *testing.T) {
+	var gotPath string
 	var gotBody map[string]any
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotMethod, gotPath = r.Method, r.URL.Path
+		gotPath = r.URL.Path
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"upload_object_key":"expert-uploads/x"}}`))
+		_, _ = w.Write([]byte(`{"data":{"version":"1.0.0"}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "expert-skill-upload", "create", "--file-name", "skill.zip", "--file-size", "12345"})
+	root.SetArgs([]string{"marketplace", "plugin", "publish", "--plugin-id", "p1", "--version", "1.0.0", "--changelog", "init"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodPost || gotPath != "/market/api/v1/expert_skill_uploads" {
-		t.Errorf("got %s %s, want POST /market/api/v1/expert_skill_uploads", gotMethod, gotPath)
+	if gotPath != "/market/api/v1/plugins/publish" {
+		t.Errorf("path = %q", gotPath)
 	}
-	if gotBody["file_name"] != "skill.zip" {
-		t.Errorf("file_name = %#v", gotBody["file_name"])
-	}
-	if n, ok := gotBody["file_size"].(float64); !ok || int(n) != 12345 {
-		t.Errorf("file_size = %#v, want 12345", gotBody["file_size"])
+	if gotBody["plugin_id"] != "p1" || gotBody["version"] != "1.0.0" || gotBody["changelog"] != "init" {
+		t.Errorf("body = %#v", gotBody)
 	}
 }
 
-// TestMarketplaceExpertSkillmdRequest pins the only non-obvious flag mapping in
-// the expert surface: query param `i` is fronted by `--index` via x-octo-flag.
-// A rename of that override would otherwise sail through the shape tests.
-func TestMarketplaceExpertSkillmdRequest(t *testing.T) {
+// TestMarketplaceSkillmdRequest pins the unified skill_md endpoint keyed by
+// plugin_id (experts/teams resolve the relation target first).
+func TestMarketplaceSkillmdRequest(t *testing.T) {
 	var gotMethod, gotPath, gotQuery string
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
@@ -313,67 +239,47 @@ func TestMarketplaceExpertSkillmdRequest(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":{"content":"# SKILL"}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "expert", "skillmd", "get", "e1", "--index", "2"})
+	root.SetArgs([]string{"marketplace", "plugin", "skillmd", "--plugin-id", "p1"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/experts/e1/skill_md" {
-		t.Errorf("got %s %s, want GET /market/api/v1/experts/e1/skill_md", gotMethod, gotPath)
+	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/plugins/skill_md" {
+		t.Errorf("got %s %s, want GET /market/api/v1/plugins/skill_md", gotMethod, gotPath)
 	}
-	if !strings.Contains(gotQuery, "i=2") {
-		t.Errorf("query = %q, want i=2 (--index maps to wire param i)", gotQuery)
+	if !strings.Contains(gotQuery, "plugin_id=p1") {
+		t.Errorf("query = %q, want plugin_id=p1", gotQuery)
 	}
 }
 
-// TestMarketplaceSquadSkillDownloadRequest pins the squad-only `--member`
-// selector alongside the `--index`→`i` mapping on the download path.
-func TestMarketplaceSquadSkillDownloadRequest(t *testing.T) {
-	var gotMethod, gotPath, gotQuery string
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"download_url":"https://example.invalid/x.zip"}}`))
+// TestMarketplaceDownloadRequest pins the unified download path, the plugin_id
+// query, and the space header on the binary-response endpoint.
+func TestMarketplaceDownloadRequest(t *testing.T) {
+	var gotPath, gotQuery, gotSpace string
+	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotSpace = r.Header.Get("X-Space-Id")
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write([]byte("PK\x03\x04"))
 	})
 
-	root.SetArgs([]string{"marketplace", "squad", "skill-download", "s1", "--member", "m1", "--index", "0"})
+	root.SetArgs([]string{"marketplace", "plugin", "download", "--plugin-id", "p1"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotMethod != http.MethodGet || gotPath != "/market/api/v1/squads/s1/skill_download" {
-		t.Errorf("got %s %s, want GET /market/api/v1/squads/s1/skill_download", gotMethod, gotPath)
+	if gotPath != "/market/api/v1/plugins/download" {
+		t.Errorf("path = %q", gotPath)
 	}
-	for _, want := range []string{"i=0", "member=m1"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query = %q, want %q", gotQuery, want)
-		}
+	if !strings.Contains(gotQuery, "plugin_id=p1") {
+		t.Errorf("query = %q, want plugin_id=p1", gotQuery)
 	}
-}
-
-func TestMarketplaceMCPSearchFiltersRequest(t *testing.T) {
-	var gotQuery map[string][]string
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.Query()
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "mcp", "list", "--transport", "stdio", "--visibility", "public", "--source", "space", "--created-by-type", "bot", "--tag", "cli", "--tag", "devops", "--sort", "relevance"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	want := map[string][]string{
-		"transport":       {"stdio"},
-		"visibility":      {"public"},
-		"source":          {"space"},
-		"created_by_type": {"bot"},
-		"tag":             {"cli", "devops"},
-		"sort":            {"relevance"},
-	}
-	if !reflect.DeepEqual(gotQuery, want) {
-		t.Errorf("query = %#v, want %#v", gotQuery, want)
+	if gotSpace != "space-1" {
+		t.Errorf("X-Space-Id = %q, want space-1", gotSpace)
 	}
 }
 
+// TestMarketplaceLocalPrefixOverride pins the local-dev prefix rewrite:
+// /market/api/v1/... maps to the standalone service's /api/v1/... routes.
 func TestMarketplaceLocalPrefixOverride(t *testing.T) {
 	t.Setenv("OCTO_MARKETPLACE_API_PREFIX", "")
 	var gotPath string
@@ -383,95 +289,12 @@ func TestMarketplaceLocalPrefixOverride(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":[],"pagination":{"total":0,"page":1,"page_size":20}}`))
 	})
 
-	root.SetArgs([]string{"marketplace", "mcp", "list"})
+	root.SetArgs([]string{"marketplace", "plugin", "list", "--scene-code", "default", "--plugin-type", "connector"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
-	if gotPath != "/api/v1/mcps" {
-		t.Fatalf("path = %q, want /api/v1/mcps", gotPath)
-	}
-}
-
-func TestMarketplaceMCPCategoryFiltersRequest(t *testing.T) {
-	var gotQuery string
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotQuery = r.URL.RawQuery
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":[]}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "mcp-category", "list", "--mode", "mine", "--created-by-type", "bot"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	for _, want := range []string{"mode=mine", "created_by_type=bot"} {
-		if !strings.Contains(gotQuery, want) {
-			t.Errorf("query = %q, want %q", gotQuery, want)
-		}
-	}
-}
-
-func TestMarketplaceBotSkillPublishRequest(t *testing.T) {
-	var gotPath string
-	var gotBody map[string]any
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Errorf("decode body: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"skill_id":"skill-1"}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "skill", "publish", "--skill-upload-id", "upload-1", "--visibility", "space", "--changelog", "Initial release"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if gotPath != "/market/api/v1/bot/skills/publish" {
-		t.Errorf("path = %q", gotPath)
-	}
-	if gotBody["skill_upload_id"] != "upload-1" || gotBody["visibility"] != "space" || gotBody["changelog"] != "Initial release" {
-		t.Errorf("body = %#v", gotBody)
-	}
-}
-
-func TestMarketplaceHumanSkillCreateIsHidden(t *testing.T) {
-	r := registry.MustNew()
-	if _, ok := r.GetOperation("skill.create"); ok {
-		t.Fatal("skill.create must not be exposed by the Bot-only CLI")
-	}
-
-	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {})
-	skill := findCmd(findCmd(root, "marketplace"), "skill")
-	if skill == nil {
-		t.Fatal("missing marketplace skill command group")
-	}
-	if findCmd(skill, "create") != nil {
-		t.Fatal("marketplace skill create must be hidden; Bots must use skill publish")
-	}
-}
-
-func TestMarketplaceMCPUpdateRequest(t *testing.T) {
-	var gotMethod, gotPath string
-	var gotBody map[string]any
-	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
-		gotMethod, gotPath = r.Method, r.URL.Path
-		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Errorf("decode body: %v", err)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"mcp_id":"mcp-1"}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "mcp", "update", "mcp-1", "--slogan", "Updated"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
-	}
-	if gotMethod != http.MethodPatch || gotPath != "/market/api/v1/mcps/mcp-1" {
-		t.Errorf("request = %s %s", gotMethod, gotPath)
-	}
-	if gotBody["slogan"] != "Updated" {
-		t.Errorf("body = %#v", gotBody)
+	if gotPath != "/api/v1/plugins" {
+		t.Fatalf("path = %q, want /api/v1/plugins", gotPath)
 	}
 }
 
@@ -482,21 +305,14 @@ func TestMarketplaceCommandTree(t *testing.T) {
 		t.Fatal("missing marketplace command")
 	}
 	domains := map[string][]string{
-		"skill-category":    {"list"},
-		"mcp-category":      {"list"},
-		"skill":             {"list", "mine", "tag", "publish", "get", "update", "delete", "download", "reupload", "version", "skillmd"},
+		"plugin":            {"list", "get", "skillmd", "download", "upsert", "delete", "publish", "install", "import"},
+		"plugin-category":   {"list"},
+		"plugin-tag":        {"list"},
+		"mcp":               {"probe"},
 		"skill-upload":      {"create", "parse"},
 		"skill-parse-task":  {"get"},
 		"skill-icon-upload": {"create"},
-		"mcp":               {"list", "mine", "create", "probe", "get", "update", "delete"},
 		"mcp-icon-upload":   {"create"},
-
-		// Expert Marketplace command groups.
-		"expert":              {"list", "create", "mine", "get", "update", "delete", "skillmd", "skill-download"},
-		"squad":               {"list", "create", "mine", "get", "update", "delete", "skillmd", "skill-download"},
-		"expert-category":     {"list"},
-		"expert-tag":          {"list"},
-		"expert-skill-upload": {"create"},
 	}
 	for domain, children := range domains {
 		domainCmd := findCmd(marketplace, domain)
@@ -510,78 +326,43 @@ func TestMarketplaceCommandTree(t *testing.T) {
 			}
 		}
 	}
+	// `plugin version list` is a nested subgroup, checked separately.
+	if pv := findCmd(findCmd(marketplace, "plugin"), "version"); pv == nil || findCmd(pv, "list") == nil {
+		t.Error("missing marketplace plugin version list command")
+	}
 	if got := childNames(marketplace); len(got) != len(domains) {
-		t.Errorf("marketplace domains = %v, want %v", got, domains)
+		t.Errorf("marketplace domains = %v, want %d groups", got, len(domains))
 	}
 }
 
-func TestMarketplaceSkillTagsAreStrings(t *testing.T) {
+// TestMarketplacePluginTypeEnum pins the plugin_type enum the list/detail
+// filters accept, matching the backend's four unified types.
+func TestMarketplacePluginTypeEnum(t *testing.T) {
 	r := registry.MustNew()
-	for _, id := range []string{"skill.publish", "skill.update"} {
-		op, ok := r.GetOperation(id)
-		if !ok || op.RequestBody == nil {
-			t.Fatalf("%s request body not found", id)
-		}
-		tags, ok := op.RequestBody.Properties["tags"]
-		if !ok || tags.Type != "array" || tags.Items == nil || tags.Items.Type != "string" {
-			t.Errorf("%s tags schema = %+v, want string array", id, tags)
-		}
-		if tags.MaxItems != 10 || tags.Items.MaxLength != 10 {
-			t.Errorf("%s tags limits = maxItems %d, item maxLength %d; want 10 and 10", id, tags.MaxItems, tags.Items.MaxLength)
+	op, ok := r.GetOperation("plugin.list")
+	if !ok {
+		t.Fatal("plugin.list not found")
+	}
+	var enum []any
+	for i := range op.Parameters {
+		if op.Parameters[i].Name == "plugin_type" {
+			enum = op.Parameters[i].Enum
 		}
 	}
-}
-
-func TestMarketplaceVisibilityEnumsMatchBackend(t *testing.T) {
-	r := registry.MustNew()
-	for _, tc := range []struct {
-		id   string
-		want []string
-	}{
-		{"skill.update", []string{"public", "private", "space"}},
-		{"skill.publish", []string{"public", "private", "space"}},
-		{"mcp.create", []string{"public", "private"}},
-		{"mcp.update", []string{"public", "private"}},
-	} {
-		op, ok := r.GetOperation(tc.id)
-		if !ok || op.RequestBody == nil {
-			t.Fatalf("%s request body not found", tc.id)
-		}
-		visibility, ok := op.RequestBody.Properties["visibility"]
-		if !ok {
-			t.Fatalf("%s visibility schema not found", tc.id)
-		}
-		got := make([]string, 0, len(visibility.Enum))
-		for _, value := range visibility.Enum {
-			got = append(got, value.(string))
-		}
-		if !reflect.DeepEqual(got, tc.want) {
-			t.Errorf("%s visibility enum = %v, want %v", tc.id, visibility.Enum, tc.want)
-		}
+	if enum == nil {
+		t.Fatal("plugin_type parameter not found")
 	}
-}
-
-func TestMarketplaceDownloadRequest(t *testing.T) {
-	var gotPath, gotQuery, gotSpace string
-	root, _, _ := rootWithServiceSpaced(t, "space-1", func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotQuery = r.URL.RawQuery
-		gotSpace = r.Header.Get("X-Space-Id")
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"data":{"download_url":"https://example.invalid/skill.zip","file_sha256":"abc"}}`))
-	})
-
-	root.SetArgs([]string{"marketplace", "skill", "download", "skill-1", "--response-format", "json"})
-	if err := root.Execute(); err != nil {
-		t.Fatalf("execute: %v", err)
+	got := make([]string, 0, len(enum))
+	for _, v := range enum {
+		got = append(got, v.(string))
 	}
-	if gotPath != "/market/api/v1/skills/skill-1/download" {
-		t.Errorf("path = %q", gotPath)
+	want := map[string]bool{"skill": true, "connector": true, "expert": true, "expert_team": true}
+	if len(got) != len(want) {
+		t.Fatalf("plugin_type enum = %v, want the four unified types", got)
 	}
-	if !strings.Contains(gotQuery, "format=json") {
-		t.Errorf("query = %q, want format=json", gotQuery)
-	}
-	if gotSpace != "space-1" {
-		t.Errorf("X-Space-Id = %q, want space-1", gotSpace)
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected plugin_type %q", g)
+		}
 	}
 }

--- a/cmd/service/run.go
+++ b/cmd/service/run.go
@@ -410,6 +410,9 @@ func marketplacePath(service, path string) string {
 // spec-declared enum is enforced before the request leaves — query and body
 // enums are checked at the same strictness so the two do not diverge.
 func buildQuery(cobraCmd *cobra.Command, rt *operationRuntime) (url.Values, *output.ExitError) {
+	if err := validateConditionalQueryRequirements(cobraCmd, rt); err != nil {
+		return nil, err
+	}
 	q := url.Values{}
 	for flagName, qf := range rt.queryFlags {
 		if !cobraCmd.Flags().Changed(flagName) {
@@ -453,6 +456,41 @@ func buildQuery(cobraCmd *cobra.Command, rt *operationRuntime) (url.Values, *out
 		}
 	}
 	return q, nil
+}
+
+func validateConditionalQueryRequirements(cobraCmd *cobra.Command, rt *operationRuntime) *output.ExitError {
+	for i := range rt.detail.Parameters {
+		p := &rt.detail.Parameters[i]
+		if p.In != "query" || p.RequiredUnlessQuery == nil {
+			continue
+		}
+		flagName := paramFlagName(p)
+		peer := findParam(rt.detail, p.RequiredUnlessQuery.Name, "query")
+		// Registry construction validates this metadata. Keep the runtime check
+		// defensive for tests that inject OperationDetail directly.
+		if peer == nil || peer.Type != "string" {
+			return output.ErrValidation("operation has invalid conditional query metadata", "update the embedded API specification")
+		}
+		peerFlag := paramFlagName(peer)
+		peerValue, err := cobraCmd.Flags().GetString(peerFlag)
+		if err != nil {
+			return output.ErrValidation("operation has invalid conditional query metadata", "update the embedded API specification")
+		}
+		excepted := cobraCmd.Flags().Changed(peerFlag) && peerValue == p.RequiredUnlessQuery.Value
+		if excepted {
+			continue
+		}
+		if cobraCmd.Flags().Changed(flagName) {
+			value, valueErr := cobraCmd.Flags().GetString(flagName)
+			if valueErr == nil && value != "" {
+				continue
+			}
+		}
+		return output.ErrValidation(
+			fmt.Sprintf("--%s is required unless --%s is %q", flagName, peerFlag, p.RequiredUnlessQuery.Value),
+			fmt.Sprintf("pass a non-empty --%s, or set --%s to %s", flagName, peerFlag, p.RequiredUnlessQuery.Value))
+	}
+	return nil
 }
 
 // addSliceQueryValues emits every element of a repeated query flag, holding each to the
@@ -727,7 +765,7 @@ func validateRequiredBodyFields(rt *operationRuntime, base map[string]any) error
 	if rt.detail.Multipart {
 		return nil
 	}
-	enforcePublicAPIConstraints := rt.detail.Service == "loop"
+	enforcePublicAPIConstraints := rt.detail.Service == "loop" || rt.detail.StrictRequestSchema
 	if len(base) == 0 && !rt.detail.RequestBodyRequired {
 		return nil
 	}
@@ -762,7 +800,7 @@ func topLevelBodyFlagNames(rt *operationRuntime) map[string]string {
 // flags AND --data — because --data is not a raw passthrough on this path.
 type bodySchemaValidator struct {
 	flagFor                     map[string]string // wire field name → promoted flag name (top level only)
-	enforcePublicAPIConstraints bool              // extended JSON Schema constraints (Loop Public API only)
+	enforcePublicAPIConstraints bool              // extended JSON Schema constraints (Loop or explicit service opt-in)
 }
 
 // validate reports the first violation found, or nil. Enum violations carry

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -73,8 +73,8 @@ func attachOperation(svcCmd *cobra.Command, f *cmdutil.Factory, d *registry.Oper
 	}
 	// Most specs use an operationId whose first segment matches the registry
 	// service (docs.create under service docs). A multi-domain backend may expose
-	// several resource families from one service, for example skill.list and
-	// mcp.list under service marketplace. Preserve that first segment as a
+	// several resource families from one service, for example plugin.list and
+	// mcp.probe under service marketplace. Preserve that first segment as a
 	// resource group when it differs from the service name so both operations
 	// become addressable instead of colliding as marketplace list.
 	start := 1

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -301,7 +301,7 @@ func TestRegisterServiceCommands_PreservesForeignOperationDomain(t *testing.T) {
 	if marketplace == nil {
 		t.Fatal("missing marketplace service command")
 	}
-	for _, domain := range []string{"skill", "mcp"} {
+	for _, domain := range []string{"plugin", "mcp"} {
 		if findCmd(marketplace, domain) == nil {
 			t.Errorf("marketplace must preserve %q from the operationId", domain)
 		}

--- a/internal/registry/loader.go
+++ b/internal/registry/loader.go
@@ -56,16 +56,73 @@ func New() (*Registry, error) {
 	if err := checkDuplicateOperationIDs(r.specs); err != nil {
 		return nil, err
 	}
+	for service, doc := range r.specs {
+		if err := validateConditionalQueryMetadata(doc); err != nil {
+			return nil, fmt.Errorf("registry: service %s: %w", service, err)
+		}
+	}
 	return r, nil
 }
 
-// checkDuplicateOperationIDs rejects an operationId claimed by more than one
-// spec. The id namespace is global: GetOperation resolves an id by iterating
-// the service map, so a duplicate would make command routing depend on Go's
-// randomized map order — a different backend could win on every process start.
-// Mirrors the duplicate-service guard above: a collision between embedded
-// specs is a build-time bug, surfaced on first registry load. Hidden and
-// disabled operations are included because GetOperation still resolves them.
+// validateConditionalQueryMetadata makes the opt-in extension fail closed at
+// registry load rather than silently weakening a required-parameter guard.
+func validateConditionalQueryMetadata(doc map[string]any) error {
+	var validationErr error
+	walkOperations(doc, func(path, method string, op map[string]any) {
+		if validationErr == nil {
+			validationErr = validateOperationConditionalQueries(doc, path, method, op)
+		}
+	})
+	return validationErr
+}
+
+func validateOperationConditionalQueries(doc map[string]any, path, method string, op map[string]any) error {
+	params := operationParameters(doc, path, op)
+	queryTypes := make(map[string]string, len(params))
+	for i := range params {
+		if params[i].In == "query" {
+			queryTypes[params[i].Name] = params[i].Type
+		}
+	}
+	for _, raw := range rawOperationParameters(doc, path, op) {
+		pm, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		ext, declared := pm["x-octo-required-unless-query"]
+		if !declared {
+			continue
+		}
+		conditional, ok := ext.(map[string]any)
+		name, nameOK := conditional["name"].(string)
+		_, valueOK := conditional["value"].(string)
+		dependent, dependentOK := pm["name"].(string)
+		if !ok || !nameOK || strings.TrimSpace(name) == "" || !valueOK || !dependentOK || dependent == "" {
+			return fmt.Errorf("%s %s has malformed x-octo-required-unless-query", strings.ToUpper(method), path)
+		}
+		peerType, exists := queryTypes[name]
+		if !exists || peerType != "string" || name == dependent {
+			return fmt.Errorf("%s %s conditional query %q must name a distinct string query parameter", strings.ToUpper(method), path, name)
+		}
+	}
+	return nil
+}
+
+func rawOperationParameters(doc map[string]any, path string, op map[string]any) []any {
+	var result []any
+	if paths, ok := doc["paths"].(map[string]any); ok {
+		if item, ok := paths[path].(map[string]any); ok {
+			if params, ok := item["parameters"].([]any); ok {
+				result = append(result, params...)
+			}
+		}
+	}
+	if params, ok := op["parameters"].([]any); ok {
+		result = append(result, params...)
+	}
+	return result
+}
+
 func checkDuplicateOperationIDs(specs map[string]map[string]any) error {
 	owner := map[string]string{}
 	services := make([]string, 0, len(specs))
@@ -172,6 +229,13 @@ type OperationInfo struct {
 	Risk    string `json:"risk,omitempty"`
 }
 
+// ConditionalQueryRequirement describes x-octo-required-unless-query: the
+// parameter carrying it is required unless the named peer query equals Value.
+type ConditionalQueryRequirement struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
 // ParamInfo describes a single parameter on a path or operation (one entry in
 // an OpenAPI `parameters` array). Covers path, query, and header parameters;
 // the `In` field records which. Type/Default/Enum come from the nested
@@ -192,6 +256,11 @@ type ParamInfo struct {
 	MinLength int    `json:"min_length,omitempty"`
 	MaxLength int    `json:"max_length,omitempty"`
 	Pattern   string `json:"pattern,omitempty"`
+	// RequiredUnlessQuery makes an otherwise optional query parameter required
+	// unless another query parameter equals the declared value. It is populated
+	// by x-octo-required-unless-query for contracts such as Marketplace's
+	// plugin_type, which is optional only when mode=mine.
+	RequiredUnlessQuery *ConditionalQueryRequirement `json:"required_unless_query,omitempty"`
 	// Secret records the x-octo-secret extension. A secret parameter's value is
 	// masked in --verbose traces and --dry-run output (share/invite tokens,
 	// share passwords) so a credential-equivalent value never lands in a log.
@@ -229,10 +298,10 @@ type SchemaInfo struct {
 	Description          string                `json:"description,omitempty"`
 	WriteOnly            bool                  `json:"write_only,omitempty"`
 	// These constraints are surfaced for schema introspection. The generic CLI
-	// validator enforces Required, MinItems and Enum for every service. Loop
-	// Public API operations additionally enforce closed-object and minimum-
-	// property constraints, MinLength, MaxLength and MaxItems. Pattern
-	// remains descriptive and is left to the backend.
+	// validator enforces Required, MinItems and Enum for every service. Loop and
+	// explicitly strict services additionally enforce closed-object and minimum-
+	// property constraints, MinLength, MaxLength and MaxItems. Pattern stays
+	// descriptive because stateful backend exceptions cannot be represented here.
 	MinLength     int    `json:"min_length,omitempty"`
 	MaxLength     int    `json:"max_length,omitempty"`
 	MinItems      int    `json:"min_items,omitempty"`
@@ -282,10 +351,15 @@ type BodyVariant struct {
 // binary response).
 type OperationDetail struct {
 	OperationInfo
-	Parameters          []ParamInfo     `json:"parameters,omitempty"`
-	RequestBody         *SchemaInfo     `json:"request_body,omitempty"`
-	RequestBodyRequired bool            `json:"request_body_required,omitempty"`
-	ResponseSchema      *SchemaInfo     `json:"response_schema,omitempty"`
+	Parameters          []ParamInfo `json:"parameters,omitempty"`
+	RequestBody         *SchemaInfo `json:"request_body,omitempty"`
+	RequestBodyRequired bool        `json:"request_body_required,omitempty"`
+	ResponseSchema      *SchemaInfo `json:"response_schema,omitempty"`
+	// StrictRequestSchema opts a service into the extended JSON Schema request
+	// checks (closed objects, lengths, patterns and size constraints) that Loop's
+	// Public API always uses. It lets another strongly typed API request the same
+	// local guarantees without changing historical domains.
+	StrictRequestSchema bool            `json:"strict_request_schema,omitempty"`
 	Pagination          *PaginationInfo `json:"pagination,omitempty"`
 	// BaseURLEnv is retained in schema output for compatibility with existing
 	// specs and tooling. Runtime routing is unified through OCTO_API_BASE_URL and
@@ -460,9 +534,10 @@ func buildDetail(service string, doc map[string]any, pathStr, method string, op 
 			Summary: stringOf(op["summary"]),
 			Risk:    stringOf(op["x-octo-risk"]),
 		},
-		BaseURLEnv:  stringOf(doc["x-octo-base-url"]),
-		Credential:  stringOf(doc["x-octo-credential"]),
-		SpaceHeader: boolOf(doc["x-octo-space-header"]),
+		BaseURLEnv:          stringOf(doc["x-octo-base-url"]),
+		Credential:          stringOf(doc["x-octo-credential"]),
+		SpaceHeader:         boolOf(doc["x-octo-space-header"]),
+		StrictRequestSchema: truthy(doc["x-octo-strict-request-schema"]),
 	}
 	_, d.SpaceHeaderSet = doc["x-octo-space-header"]
 
@@ -562,6 +637,12 @@ func operationParameters(doc map[string]any, pathStr string, op map[string]any) 
 				Description: stringOf(pm["description"]),
 				FlagName:    stringOf(pm["x-octo-flag"]),
 				Secret:      truthy(pm["x-octo-secret"]),
+			}
+			if conditional, ok := pm["x-octo-required-unless-query"].(map[string]any); ok {
+				name, value := stringOf(conditional["name"]), stringOf(conditional["value"])
+				if name != "" {
+					parameter.RequiredUnlessQuery = &ConditionalQueryRequirement{Name: name, Value: value}
+				}
 			}
 			if schema, ok := pm["schema"].(map[string]any); ok {
 				parameter.Type = stringOf(schema["type"])

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -33,8 +33,8 @@ func TestGetSpecReturnsNilForUnknown(t *testing.T) {
 
 func TestAllDomainOperationCounts(t *testing.T) {
 	// Caller-facing operation counts per service. Operations marked
-	// x-octo-cli-hidden remain in the embedded backend spec but are excluded
-	// here; marketplace skill.create is one such Web-only operation.
+	// x-octo-cli-hidden remain in an embedded backend spec but are excluded
+	// here; Loop workspace mutations are examples.
 	r := MustNew()
 	expected := map[string]int{
 		"matter":      14,
@@ -47,7 +47,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"docs":        32,
 		"drive":       43,
 		"html":        21,
-		"marketplace": 17,
+		"marketplace": 25,
 		"mail":        18,
 		"summary":     4,
 		"loop":        126,
@@ -204,6 +204,58 @@ func TestLoopTaskUpdateIncludesReviewStatus(t *testing.T) {
 	if !reflect.DeepEqual(status.Enum, want) {
 		t.Fatalf("task.update status enum = %#v, want %#v", status.Enum, want)
 	}
+}
+
+func TestConditionalQueryMetadataRejectsMalformedContracts(t *testing.T) {
+	base := func(extension any, peerSchema map[string]any) map[string]any {
+		return map[string]any{
+			"paths": map[string]any{
+				"/items": map[string]any{
+					"get": map[string]any{
+						"operationId": "item.list",
+						"parameters": []any{
+							map[string]any{"name": "kind", "in": "query", "schema": map[string]any{"type": "string"}, "x-octo-required-unless-query": extension},
+							map[string]any{"name": "mode", "in": "query", "schema": peerSchema},
+						},
+					},
+				},
+			},
+		}
+	}
+	for _, tc := range []struct {
+		name string
+		doc  map[string]any
+	}{
+		{"extension is not an object", base("mode=mine", map[string]any{"type": "string"})},
+		{"missing peer", base(map[string]any{"name": "other", "value": "mine"}, map[string]any{"type": "string"})},
+		{"non-string peer", base(map[string]any{"name": "mode", "value": "1"}, map[string]any{"type": "integer"})},
+		{"missing string value", base(map[string]any{"name": "mode"}, map[string]any{"type": "string"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateConditionalQueryMetadata(tc.doc); err == nil {
+				t.Fatal("malformed conditional query metadata was accepted")
+			}
+		})
+	}
+}
+
+func TestMarketplaceConditionalQueryMetadata(t *testing.T) {
+	r := MustNew()
+	op, ok := r.GetOperation("plugin.list")
+	if !ok {
+		t.Fatal("plugin.list not found")
+	}
+	for _, p := range op.Parameters {
+		if p.Name != "plugin_type" || p.In != "query" {
+			continue
+		}
+		want := &ConditionalQueryRequirement{Name: "mode", Value: "mine"}
+		if !reflect.DeepEqual(p.RequiredUnlessQuery, want) {
+			t.Fatalf("plugin_type conditional requirement = %#v, want %#v", p.RequiredUnlessQuery, want)
+		}
+		return
+	}
+	t.Fatal("plugin.list plugin_type query not found")
 }
 
 func TestLoopAutopilotUsesPublicTypedContract(t *testing.T) {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -47,7 +47,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"docs":        32,
 		"drive":       43,
 		"html":        21,
-		"marketplace": 44,
+		"marketplace": 18,
 		"mail":        18,
 		"summary":     4,
 		"loop":        126,
@@ -562,7 +562,7 @@ func TestServiceSpaceHeaderContract(t *testing.T) {
 	}{
 		{"message", "message.send", true},
 		{"matter", "matter.create", true},
-		{"marketplace", "skill.get", true},
+		{"marketplace", "plugin.get", true},
 		{"summary", "summary.list", false},
 		{"docs", "docs.create", false},
 		{"bot", "bot.register", false},

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -47,7 +47,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"docs":        32,
 		"drive":       43,
 		"html":        21,
-		"marketplace": 18,
+		"marketplace": 17,
 		"mail":        18,
 		"summary":     4,
 		"loop":        126,

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -58,7 +58,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Search keyword"
+            "description": "Search keyword. Case-folded substring match against plugin_name ONLY — not the display name, description, tags or publisher. A skill imported with a display --name is therefore not findable by that name."
           },
           {
             "name": "tag",
@@ -115,7 +115,7 @@
             "schema": {
               "type": "integer"
             },
-            "description": "Page size, default 20, max 100"
+            "description": "Page size, default 20, max 100. Out-of-range values are rejected with 400, not clamped. There is no --page-all on this offset-paged endpoint: walk --page yourself until a short page."
           }
         ],
         "responses": {
@@ -200,7 +200,7 @@
             "schema": {
               "type": "integer"
             },
-            "description": "Page size, default 20, max 100"
+            "description": "Page size, default 20, max 100. Out-of-range values are rejected with 400, not clamped. There is no --page-all on this offset-paged endpoint: walk --page yourself until a short page."
           }
         ],
         "responses": {
@@ -412,14 +412,15 @@
                 "properties": {
                   "plugin": {
                     "type": "object",
-                    "description": "Plugin write document. Pass the full document for both create and update; the backend validates name, plugin_type, visibility, manifest_json and plugin_json on every write. A save is a version snapshot (auto-increment label); plugin.version sets the current_version display label and defaults to 1.0.0.",
+                    "description": "Plugin write document. UPDATE IS A FULL REPLACE, NOT A PATCH: the backend rebuilds the whole row from this document and preserves only created_at, the version history and the creator identity. An omitted category_id, publisher or icon is accepted as empty and CLEARS the stored value — there is no metadata-only PATCH, so always read-modify-write (plugin get -> edit the document -> plugin upsert) rather than sending just the fields you changed. Note plugin.import has the opposite semantics (it falls back to the existing row), so do not carry habits across. manifest_json and plugin_json are required on every write and must agree with the outer fields (see manifest_json). A save is a version snapshot (auto-increment label); plugin.version sets the current_version display label, defaults to 1.0.0, and is preserved when left blank on update.",
                     "properties": {
                       "plugin_id": {
                         "type": "string",
                         "description": "Set to update an existing plugin; omit to create"
                       },
                       "plugin_name": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Must be byte-identical to manifest_json.plugin_name after trimming, or the write is rejected."
                       },
                       "plugin_type": {
                         "type": "string",
@@ -428,7 +429,8 @@
                           "connector",
                           "expert",
                           "expert_team"
-                        ]
+                        ],
+                        "description": "Must equal manifest_json.plugin_type, or the write is rejected. Legacy names map as mcp -> connector, squad -> expert_team."
                       },
                       "visibility": {
                         "type": "string",
@@ -439,19 +441,23 @@
                         "description": "space or private. public is retired on the write path; system is minted only by the admin surface, not this tenant CLI."
                       },
                       "category_id": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Omitting this on update clears the stored category (and the default market placement's category). Echo the current value to keep it."
                       },
                       "tags": {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "description": "Must match manifest_json.labels exactly, INCLUDING ORDER — the backend compares the two as canonical JSON arrays, not as sets. Entries are trimmed and de-duplicated on this side only, so a labels array carrying duplicates or untrimmed values is rejected even when the equivalent tags value normalizes cleanly."
                       },
                       "publisher": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Omitting this on update clears the stored publisher. Echo the current value to keep it."
                       },
                       "icon": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Omitting this on update clears the stored icon. Echo the current value to keep it."
                       },
                       "version": {
                         "type": "string",
@@ -459,7 +465,7 @@
                       },
                       "manifest_json": {
                         "type": "object",
-                        "description": "Type-specific manifest document (required on every write)"
+                        "description": "Type-specific manifest document (required on every write). It must agree with the outer plugin fields: manifest_json.plugin_name == plugin.plugin_name, manifest_json.plugin_type == plugin.plugin_type, and manifest_json.labels == plugin.tags in the same order. Every disagreement returns the same opaque 400 VALIDATION_ERROR with details {\"field\":\"body\",\"reason\":\"invalid\"} and no indication of which field differed, so check all three before retrying."
                       },
                       "plugin_json": {
                         "type": "object",
@@ -513,7 +519,7 @@
                         "relation_type"
                       ]
                     },
-                    "description": "Relation rows. EVERY upsert replaces the relation set — resubmit the complete list even on metadata-only edits; omitting the key soft-deletes all relations on save."
+                    "description": "Relation rows. EVERY upsert replaces the relation set — resubmit the complete list even on metadata-only edits; omitting the key is identical to sending [] and soft-deletes every live relation (team members, attached skills, attached connectors) on save. The key stays optional because skills and connectors never carry relations, so nothing here is validated locally: on an expert or expert_team, forgetting it destroys the whole membership graph without any client-side error. Echo relation_id for rows you want to keep verbatim."
                   }
                 },
                 "required": [
@@ -627,7 +633,7 @@
       "post": {
         "operationId": "plugin.import",
         "summary": "Import a skill plugin from a completed parse task",
-        "description": "Finalize a skill upload: pass the parse_task_id from the upload+parse pipeline. Omit plugin_id to create, or set it to update an existing skill plugin.",
+        "description": "Finalize a skill upload: pass the parse_task_id from the upload+parse pipeline. Omit plugin_id to create, or set it to update an existing skill plugin. Unlike plugin.upsert, this path is NOT a full replace: on update an omitted plugin_name, name, description, category_id, visibility or icon falls back to the existing row rather than clearing it.",
         "x-octo-risk": "write",
         "x-octo-retry": "never",
         "requestBody": {
@@ -645,10 +651,12 @@
                     "description": "Set to update an existing skill plugin; omit to create"
                   },
                   "plugin_name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Registry identifier written to the plugin_name column and to manifest_json.plugin_name. Distinct from name, not a synonym. Leave it empty and it inherits name; there is no fallback in the other direction. On update an omitted value falls back to the existing row."
                   },
                   "name": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Human display name written to manifest_json.name and to the SKILL.md frontmatter. Distinct from plugin_name, not a synonym. On update an omitted value falls back to the existing row. Note plugin list --q searches plugin_name only, so a display name set here is not searchable."
                   },
                   "description": {
                     "type": "string"
@@ -890,7 +898,7 @@
     },
     "/market/api/v1/skill_uploads/{skill_upload_id}/parse": {
       "post": {
-        "description": "Start parsing a previously initialized Skill archive upload.",
+        "description": "Start parsing a previously initialized Skill archive upload. Not idempotent: the task must be pending, so a re-POST against an already-parsed upload returns 409 CONFLICT rather than the original parse-task ID. Poll skill_parse_task.get instead of re-triggering.",
         "operationId": "skill_upload.parse",
         "parameters": [
           {
@@ -1003,6 +1011,7 @@
         "tags": [
           "skill_upload"
         ],
+        "x-octo-retry": "never",
         "x-octo-risk": "write"
       }
     },

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Octo Marketplace API",
     "version": "1.0.0",
-    "description": "Unified plugin marketplace API. All catalog operations go through /plugins/*; the legacy per-type endpoints (/experts, /squads, /mcps, /skills) are retired here because they read frozen pre-migration tables.",
+    "description": "Unified plugin marketplace API. All catalog operations go through /plugins/*; the legacy per-type endpoints (/experts, /squads, /mcps, /skills) are retired on this client because the unified model is the source of truth and legacy handlers do not read rows created after unification.",
     "contact": {
       "name": "OCTO API Team",
       "url": "https://github.com/Mininglamp-OSS/octo-marketplace"
@@ -17,7 +17,7 @@
       "get": {
         "operationId": "plugin.list",
         "summary": "List marketplace plugins",
-        "description": "List plugins visible in the current Space, filtered by scene and type. Replaces the legacy /experts, /squads, /mcps, /skills list endpoints (all now read frozen legacy tables).",
+        "description": "List plugins visible in the current Space, filtered by scene and type. A non-empty scene_code joins the visible placement table so only catalog-placed plugins appear. Replaces the legacy /experts, /squads, /mcps, /skills list endpoints.",
         "x-octo-risk": "read",
         "parameters": [
           {
@@ -86,9 +86,20 @@
             "name": "sort",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "newest",
+                "oldest",
+                "updated",
+                "name",
+                "placement",
+                "views",
+                "installs",
+                "downloads",
+                "comprehensive"
+              ]
             },
-            "description": "newest (default) / oldest / updated / name / placement / views / installs / downloads / comprehensive"
+            "description": "Sort order (default newest); placement requires scene_code"
           },
           {
             "name": "page",
@@ -388,8 +399,8 @@
     "/market/api/v1/plugins/upsert": {
       "post": {
         "operationId": "plugin.upsert",
-        "summary": "Create or update a plugin",
-        "description": "Create (plugin.plugin_id empty) or update a plugin. Body: {\"plugin\":{plugin_name,plugin_type,visibility,manifest_json,plugin_json,tags,category_id,icon},\"relations\":[...]}. Pass the full document with --data. For skills prefer the upload+import flow instead.",
+        "summary": "Create or update a plugin (every save is a version snapshot)",
+        "description": "Create (plugin.plugin_id empty) or update a plugin. Every save appends an auto-increment plugin_versions snapshot and a default market placement is attached/self-healed so the plugin is visible in scene-scoped lists. Pass --data with the full write document {\"plugin\":{...},\"relations\":[...]}. For skills prefer the upload+import flow (which finalizes through upsert).",
         "x-octo-risk": "write",
         "x-octo-retry": "never",
         "requestBody": {
@@ -401,7 +412,7 @@
                 "properties": {
                   "plugin": {
                     "type": "object",
-                    "description": "Plugin write document. Pass the full document for both create and update; the backend validates name, plugin_type and visibility on every write.",
+                    "description": "Plugin write document. Pass the full document for both create and update; the backend validates name, plugin_type, visibility, manifest_json and plugin_json on every write. A save is a version snapshot (auto-increment label); plugin.version sets the current_version display label and defaults to 1.0.0.",
                     "properties": {
                       "plugin_id": {
                         "type": "string",
@@ -442,27 +453,67 @@
                       "icon": {
                         "type": "string"
                       },
+                      "version": {
+                        "type": "string",
+                        "description": "Current-version label; defaults to 1.0.0. Independent of the per-save auto-increment snapshot label."
+                      },
                       "manifest_json": {
                         "type": "object",
-                        "description": "Type-specific manifest document"
+                        "description": "Type-specific manifest document (required on every write)"
                       },
                       "plugin_json": {
                         "type": "object",
-                        "description": "Type-specific plugin package document"
+                        "description": "Type-specific plugin package document (required on every write)"
                       }
                     },
                     "required": [
                       "plugin_name",
                       "plugin_type",
-                      "visibility"
+                      "visibility",
+                      "manifest_json",
+                      "plugin_json"
                     ]
                   },
                   "relations": {
                     "type": "array",
                     "items": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "relation_id": {
+                          "type": "string",
+                          "description": "Empty to create; a live relation's ID to update; live relations omitted are deleted."
+                        },
+                        "source_plugin_id": {
+                          "type": "string",
+                          "description": "Must address the plugin being upserted when supplied."
+                        },
+                        "target_plugin_id": {
+                          "type": "string",
+                          "description": "Target plugin id (required)."
+                        },
+                        "relation_type": {
+                          "type": "string",
+                          "enum": [
+                            "expert_team_expert",
+                            "expert_skill",
+                            "expert_connector"
+                          ],
+                          "description": "Relation type. The matrix is fixed: expert_team -> expert (expert_team_expert); expert -> skill (expert_skill); expert -> connector (expert_connector)."
+                        },
+                        "sort_order": {
+                          "type": "integer"
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "Optional type-specific payload (e.g. is_leader for team members)."
+                        }
+                      },
+                      "required": [
+                        "target_plugin_id",
+                        "relation_type"
+                      ]
                     },
-                    "description": "Optional relation rows"
+                    "description": "Relation rows. EVERY upsert replaces the relation set — resubmit the complete list even on metadata-only edits; omitting the key soft-deletes all relations on save."
                   }
                 },
                 "required": [
@@ -490,7 +541,9 @@
       "post": {
         "operationId": "plugin.delete",
         "summary": "Delete a plugin",
+        "description": "Soft-delete a caller-owned plugin. The name frees for reuse. This is a non-idempotent mutation when the response is ambiguous, so the client does not auto-retry.",
         "x-octo-risk": "write",
+        "x-octo-retry": "never",
         "requestBody": {
           "required": true,
           "content": {
@@ -505,59 +558,6 @@
                 },
                 "required": [
                   "plugin_id"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/market/api/v1/plugins/publish": {
-      "post": {
-        "operationId": "plugin.publish",
-        "summary": "Publish a plugin version",
-        "description": "Release an immutable version and rebuild placements. Body: {plugin_id, version, changelog?, placements?}.",
-        "x-octo-risk": "write",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "plugin_id": {
-                    "type": "string"
-                  },
-                  "version": {
-                    "type": "string",
-                    "description": "Semver version string (immutable once published)"
-                  },
-                  "changelog": {
-                    "type": "string"
-                  },
-                  "placements": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    },
-                    "description": "Placement rows; omit for the default placement"
-                  }
-                },
-                "required": [
-                  "plugin_id",
-                  "version"
                 ]
               }
             }
@@ -1285,6 +1285,13 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "Bearer": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
     "schemas": {
       "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_ProbeResponse": {
         "properties": {

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -12,6 +12,7 @@
   "x-octo-service": "marketplace",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": true,
+  "x-octo-strict-request-schema": true,
   "paths": {
     "/market/api/v1/plugins": {
       "get": {
@@ -41,8 +42,11 @@
                 "expert_team"
               ]
             },
-            "description": "Plugin type. Note the type mapping from the old per-type surface: mcp -> connector, squad -> expert_team.",
-            "required": true
+            "description": "Plugin type. Required for the catalog grid; optional only with mode=mine, which lists all caller-owned types. Legacy mappings: mcp -> connector, squad -> expert_team.",
+            "x-octo-required-unless-query": {
+              "name": "mode",
+              "value": "mine"
+            }
           },
           {
             "name": "category_id",
@@ -396,11 +400,77 @@
         }
       }
     },
-    "/market/api/v1/plugins/upsert": {
+    "/market/api/v1/plugins/publish": {
       "post": {
-        "operationId": "plugin.upsert",
-        "summary": "Create or update a plugin (every save is a version snapshot)",
-        "description": "Create (plugin.plugin_id empty) or update a plugin. Every save appends an auto-increment plugin_versions snapshot and a default market placement is attached/self-healed so the plugin is visible in scene-scoped lists. Pass --data with the full write document {\"plugin\":{...},\"relations\":[...]}. For skills prefer the upload+import flow (which finalizes through upsert).",
+        "operationId": "plugin.publish",
+        "summary": "Publish a plugin",
+        "description": "Publish a caller-owned plugin. A private plugin's listing state becomes published immediately but remains owner-only. Publishing a space-visible plugin opens a Space review request and leaves the plugin as a draft until approval; the response carries review_id for that branch.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "plugin_id": { "type": "string", "minLength": 1, "description": "Nonblank plugin id" },
+                  "version": { "type": "string", "pattern": "^\\d{1,9}\\.\\d{1,9}\\.\\d{1,9}$", "description": "Optional MAJOR.MINOR.PATCH label for the Space-review branch; defaults to the draft current version. Ignored when publishing a private plugin." },
+                  "changelog": { "type": "string", "description": "Optional review changelog, at most 1000 Unicode characters on the Space-review branch; ignored for private publish" }
+                },
+                "required": ["plugin_id"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Published immediately or submitted for review", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/delist": {
+      "post": {
+        "operationId": "plugin.delist",
+        "summary": "Delist a plugin",
+        "description": "Take a published Space-visible standalone plugin out of the marketplace. Requires the Space owner or admin role. Any pending review is canceled; the plugin remains editable and may be published again.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "plugin_id": { "type": "string", "minLength": 1, "description": "Nonblank plugin id" },
+                  "reason": { "type": "string", "maxLength": 1000 }
+                },
+                "required": ["plugin_id"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Delisted", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/review_requests": {
+      "get": {
+        "operationId": "plugin.review_request.list",
+        "summary": "List plugin review requests",
+        "description": "mode=mine lists the caller's submissions; mode=space lists the Space review queue and requires Space owner/admin authority.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "mode", "in": "query", "required": true, "schema": { "type": "string", "enum": ["mine", "space"] }, "description": "List the caller's submissions or the Space queue" },
+          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["pending", "approved", "rejected", "canceled"] }, "description": "Filter by review status" },
+          { "name": "page", "in": "query", "schema": { "type": "integer", "minimum": 1 }, "description": "Page number, default 1" },
+          { "name": "page_size", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100 }, "description": "Page size, default 20, max 100" }
+        ],
+        "responses": { "200": { "description": "Review request page", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      },
+      "post": {
+        "operationId": "plugin.review_request.create",
+        "summary": "Submit a plugin for Space review",
+        "description": "Freeze a Space-visible plugin version for review. Supply parse_task_id for a skill zip, manifest_json plus plugin_json for declared documents, or neither only for the first listing of an unlisted Space-intent draft. parse_task_id is mutually exclusive with the document pair. An omitted relations key inherits the live graph; a present array replaces the reviewed graph.",
         "x-octo-risk": "write",
         "x-octo-retry": "never",
         "requestBody": {
@@ -410,8 +480,119 @@
               "schema": {
                 "type": "object",
                 "properties": {
+                  "plugin_id": { "type": "string", "minLength": 1 },
+                  "version": { "type": "string", "pattern": "^\\d{1,9}\\.\\d{1,9}\\.\\d{1,9}$", "description": "Required MAJOR.MINOR.PATCH label; must not move backward or duplicate a published version" },
+                  "changelog": { "type": "string", "maxLength": 1000 },
+                  "parse_task_id": { "type": "string", "description": "Completed skill parse task; skill plugins only" },
+                  "manifest_json": { "type": "object", "description": "Frozen type-specific manifest; provide together with plugin_json" },
+                  "plugin_json": { "type": "object", "description": "Frozen type-specific package; provide together with manifest_json" },
+                  "relations": {
+                    "type": "array",
+                    "maxItems": 200,
+                    "description": "When present, replaces the graph in the frozen review snapshot; when omitted, inherits the live graph",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "relation_id": { "type": "string" },
+                        "source_plugin_id": { "type": "string" },
+                        "target_plugin_id": { "type": "string" },
+                        "relation_type": { "type": "string", "enum": ["expert_team_expert", "expert_skill", "expert_connector"] },
+                        "sort_order": { "type": "integer" },
+                        "data": { "type": "object" }
+                      },
+                      "required": ["target_plugin_id", "relation_type"]
+                    }
+                  }
+                },
+                "required": ["plugin_id", "version"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Review request created", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/review_requests/{review_id}": {
+      "get": {
+        "operationId": "plugin.review_request.get",
+        "summary": "Get a plugin review request",
+        "description": "Return one request with its frozen document preview and relation graph.",
+        "x-octo-risk": "read",
+        "parameters": [
+          { "name": "review_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Review request id" }
+        ],
+        "responses": { "200": { "description": "Review request detail", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/review_requests/{review_id}/approve": {
+      "post": {
+        "operationId": "plugin.review_request.approve",
+        "summary": "Approve a plugin review request",
+        "description": "Apply the frozen submission and publish it. Requires Space owner/admin authority.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "parameters": [
+          { "name": "review_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Review request id" }
+        ],
+        "responses": { "200": { "description": "Approved plugin detail", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/review_requests/{review_id}/reject": {
+      "post": {
+        "operationId": "plugin.review_request.reject",
+        "summary": "Reject a plugin review request",
+        "description": "Reject a pending request. Requires Space owner/admin authority and a nonblank reason.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "parameters": [
+          { "name": "review_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Review request id" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": { "reason": { "type": "string", "minLength": 1, "maxLength": 1000, "description": "Nonblank rejection reason (after trimming)" } },
+                "required": ["reason"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Rejected", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/review_requests/{review_id}/cancel": {
+      "post": {
+        "operationId": "plugin.review_request.cancel",
+        "summary": "Cancel a plugin review request",
+        "description": "Withdraw the caller's own pending request.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "parameters": [
+          { "name": "review_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Review request id" }
+        ],
+        "responses": { "200": { "description": "Canceled", "content": { "application/json": { "schema": { "type": "object" } } } } }
+      }
+    },
+    "/market/api/v1/plugins/upsert": {
+      "post": {
+        "operationId": "plugin.upsert",
+        "summary": "Create or update a plugin (every save is a version snapshot)",
+        "description": "Create (plugin.plugin_id empty) or update an editable plugin. A create is a draft; an update preserves the current listing state. Published Space plugins reject direct edits and must submit a frozen review request instead. Every accepted save appends a plugin_versions snapshot. Pass --data with the full write document {\"plugin\":{...},\"relations\":[...]}. For skill drafts prefer upload+import.",
+        "x-octo-risk": "write",
+        "x-octo-retry": "never",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
                   "plugin": {
                     "type": "object",
+                    "additionalProperties": false,
                     "description": "Plugin write document. UPDATE IS A FULL REPLACE, NOT A PATCH: the backend rebuilds the whole row from this document and preserves only created_at, the version history and the creator identity. An omitted category_id, publisher or icon is accepted as empty and CLEARS the stored value — there is no metadata-only PATCH, so always read-modify-write (plugin get -> edit the document -> plugin upsert) rather than sending just the fields you changed. Note plugin.import has the opposite semantics (it falls back to the existing row), so do not carry habits across. manifest_json and plugin_json are required on every write and must agree with the outer fields (see manifest_json). A save is a version snapshot (auto-increment label); plugin.version sets the current_version display label, defaults to 1.0.0, and is preserved when left blank on update.",
                     "properties": {
                       "plugin_id": {
@@ -461,7 +642,8 @@
                       },
                       "version": {
                         "type": "string",
-                        "description": "Current-version label; defaults to 1.0.0. Independent of the per-save auto-increment snapshot label."
+                        "pattern": "^\\d{1,9}\\.\\d{1,9}\\.\\d{1,9}$",
+                        "description": "MAJOR.MINOR.PATCH current-version label. Omit to keep the existing label on update (or default to 1.0.0 on create); a new label cannot move backward."
                       },
                       "manifest_json": {
                         "type": "object",
@@ -484,6 +666,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
+                      "additionalProperties": false,
                       "properties": {
                         "relation_id": {
                           "type": "string",
@@ -556,6 +739,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "plugin_id": {
                     "type": "string",
@@ -595,6 +779,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "plugin_id": {
                     "type": "string"
@@ -642,6 +827,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "additionalProperties": false,
                 "properties": {
                   "parse_task_id": {
                     "type": "string"
@@ -681,7 +867,9 @@
                     "type": "string"
                   },
                   "version": {
-                    "type": "string"
+                    "type": "string",
+                    "pattern": "^\\d{1,9}\\.\\d{1,9}\\.\\d{1,9}$",
+                    "description": "MAJOR.MINOR.PATCH version label; cannot move backward"
                   },
                   "changelog": {
                     "type": "string"

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -602,7 +602,6 @@
                   "visibility": {
                     "type": "string",
                     "enum": [
-                      "public",
                       "space",
                       "private"
                     ]

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -75,9 +75,12 @@
             "name": "mode",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "mine"
+              ]
             },
-            "description": "Set to \"mine\" to list only the caller-owned plugins"
+            "description": "Set to \"mine\" to list only the caller-owned plugins; omit to list the full catalog"
           },
           {
             "name": "sort",
@@ -352,9 +355,12 @@
             "name": "mode",
             "in": "query",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "mine"
+              ]
             },
-            "description": "Set to \"mine\" to only aggregate the caller-owned plugins"
+            "description": "Set to \"mine\" to only aggregate the caller-owned plugins; omit to aggregate the full catalog"
           },
           {
             "name": "limit",
@@ -385,6 +391,7 @@
         "summary": "Create or update a plugin",
         "description": "Create (plugin.plugin_id empty) or update a plugin. Body: {\"plugin\":{plugin_name,plugin_type,visibility,manifest_json,plugin_json,tags,category_id,icon},\"relations\":[...]}. Pass the full document with --data. For skills prefer the upload+import flow instead.",
         "x-octo-risk": "write",
+        "x-octo-retry": "never",
         "requestBody": {
           "required": true,
           "content": {
@@ -394,7 +401,61 @@
                 "properties": {
                   "plugin": {
                     "type": "object",
-                    "description": "Plugin write document (plugin_name, plugin_type, visibility, manifest_json, plugin_json, tags, category_id, icon)"
+                    "description": "Plugin write document. Pass the full document for both create and update; the backend validates name, plugin_type and visibility on every write.",
+                    "properties": {
+                      "plugin_id": {
+                        "type": "string",
+                        "description": "Set to update an existing plugin; omit to create"
+                      },
+                      "plugin_name": {
+                        "type": "string"
+                      },
+                      "plugin_type": {
+                        "type": "string",
+                        "enum": [
+                          "skill",
+                          "connector",
+                          "expert",
+                          "expert_team"
+                        ]
+                      },
+                      "visibility": {
+                        "type": "string",
+                        "enum": [
+                          "space",
+                          "private"
+                        ],
+                        "description": "space or private. public is retired on the write path; system is minted only by the admin surface, not this tenant CLI."
+                      },
+                      "category_id": {
+                        "type": "string"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "publisher": {
+                        "type": "string"
+                      },
+                      "icon": {
+                        "type": "string"
+                      },
+                      "manifest_json": {
+                        "type": "object",
+                        "description": "Type-specific manifest document"
+                      },
+                      "plugin_json": {
+                        "type": "object",
+                        "description": "Type-specific plugin package document"
+                      }
+                    },
+                    "required": [
+                      "plugin_name",
+                      "plugin_type",
+                      "visibility"
+                    ]
                   },
                   "relations": {
                     "type": "array",
@@ -521,6 +582,7 @@
         "operationId": "plugin.install",
         "summary": "Install an expert / expert_team plugin into a Loop workspace",
         "x-octo-risk": "write",
+        "x-octo-retry": "never",
         "requestBody": {
           "required": true,
           "content": {
@@ -567,6 +629,7 @@
         "summary": "Import a skill plugin from a completed parse task",
         "description": "Finalize a skill upload: pass the parse_task_id from the upload+parse pipeline. Omit plugin_id to create, or set it to update an existing skill plugin.",
         "x-octo-risk": "write",
+        "x-octo-retry": "never",
         "requestBody": {
           "required": true,
           "content": {

--- a/internal/registry/specs/marketplace.json
+++ b/internal/registry/specs/marketplace.json
@@ -1,1554 +1,107 @@
 {
   "openapi": "3.1.0",
   "info": {
+    "title": "Octo Marketplace API",
+    "version": "1.0.0",
+    "description": "Unified plugin marketplace API. All catalog operations go through /plugins/*; the legacy per-type endpoints (/experts, /squads, /mcps, /skills) are retired here because they read frozen pre-migration tables.",
     "contact": {
       "name": "OCTO API Team",
       "url": "https://github.com/Mininglamp-OSS/octo-marketplace"
-    },
-    "description": "Skill and MCP marketplace API for OCTO.",
-    "title": "Octo Marketplace API",
-    "version": "1.0.0"
+    }
   },
   "x-octo-service": "marketplace",
   "x-octo-base-url": "OCTO_API_BASE_URL",
   "x-octo-space-header": true,
   "paths": {
-
-    "/market/api/v1/experts": {
+    "/market/api/v1/plugins": {
       "get": {
-        "description": "List experts visible in the current Space (system + public + own private).",
-        "operationId": "marketplace.expert.list",
+        "operationId": "plugin.list",
+        "summary": "List marketplace plugins",
+        "description": "List plugins visible in the current Space, filtered by scene and type. Replaces the legacy /experts, /squads, /mcps, /skills list endpoints (all now read frozen legacy tables).",
+        "x-octo-risk": "read",
         "parameters": [
           {
-            "description": "Case-insensitive substring match on name/summary/category/creator_name",
+            "name": "scene_code",
             "in": "query",
-            "name": "keyword",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Marketplace scene code (use \"default\")",
+            "required": true
           },
           {
-            "description": "Category id; repeat to OR-combine; 'all' disables the filter",
+            "name": "plugin_type",
             "in": "query",
-            "name": "category",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag name; repeat to AND-combine",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "system / public / private; repeat to OR-combine",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "human / bot / import; repeat to OR-combine",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "updated (recently edited first); anything else falls back to creation-time DESC",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "One-based page number (default 1)",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "pagination": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "List experts",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      },
-      "post": {
-        "description": "Publish a new standalone expert owned by the caller. Send the flat ExpertAgentDetail body (name/summary/category/instruction required) via --data.",
-        "operationId": "marketplace.expert.create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "summary",
-                  "category",
-                  "instruction"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Display name (unique per Space; required)"
-                  },
-                  "summary": {
-                    "type": "string",
-                    "description": "One-line summary (required)"
-                  },
-                  "category": {
-                    "type": "string",
-                    "description": "Category NAME, resolved from expert-category list (required; empty or unknown is rejected)"
-                  },
-                  "tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Tag names"
-                  },
-                  "publisher": {
-                    "type": "string",
-                    "description": "Publisher label"
-                  },
-                  "instruction": {
-                    "type": "string",
-                    "description": "System instruction for the expert (required; must be non-empty)"
-                  },
-                  "mcp_config": {
-                    "type": "string",
-                    "description": "Raw mcpServers config as a JSON string"
-                  },
-                  "skills": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    },
-                    "description": "Agent-Skill packages: [{name, upload_object_key?, content?, file_name?, file_size?}]"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Expert (flat ExpertAgentDetail minus server-only fields)",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "description": "DUPLICATE"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Create expert",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/experts/mine": {
-      "get": {
-        "description": "Every expert owned by the caller in their Space regardless of visibility.",
-        "operationId": "marketplace.expert.mine.list",
-        "parameters": [
-          {
-            "description": "Case-insensitive substring match on name/summary/category/creator_name",
-            "in": "query",
-            "name": "keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category id; repeat to OR-combine; 'all' disables the filter",
-            "in": "query",
-            "name": "category",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag name; repeat to AND-combine",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "system / public / private; repeat to OR-combine",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "human / bot / import; repeat to OR-combine",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "updated (recently edited first); anything else falls back to creation-time DESC",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "One-based page number (default 1)",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "pagination": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "List owned experts",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/experts/{expert_id}": {
-      "get": {
-        "description": "Full ExpertAgentDetail if visible; otherwise 404.",
-        "operationId": "marketplace.expert.get",
-        "parameters": [
-          {
-            "description": "expert_id",
-            "in": "path",
-            "name": "expert_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get expert",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      },
-      "patch": {
-        "description": "Owner-only partial update. Send mutable fields via --data.",
-        "operationId": "marketplace.expert.update",
-        "parameters": [
-          {
-            "description": "expert_id",
-            "in": "path",
-            "name": "expert_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Display name (unique per Space)"
-                  },
-                  "summary": {
-                    "type": "string",
-                    "description": "One-line summary"
-                  },
-                  "category": {
-                    "type": "string",
-                    "description": "Category NAME, resolved from expert-category list"
-                  },
-                  "tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Tag names"
-                  },
-                  "publisher": {
-                    "type": "string",
-                    "description": "Publisher label"
-                  },
-                  "instruction": {
-                    "type": "string",
-                    "description": "System instruction for the expert"
-                  },
-                  "mcp_config": {
-                    "type": "string",
-                    "description": "Raw mcpServers config as a JSON string"
-                  },
-                  "skills": {
-                    "type": "array",
-                    "items": {
-                      "type": "object"
-                    },
-                    "description": "Agent-Skill packages: [{name, upload_object_key?, content?, file_name?, file_size?}]"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Partial ExpertAgentDetail (mutable fields only)",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Update expert",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "write"
-      },
-      "delete": {
-        "description": "Owner-only soft delete; the name frees up for reuse.",
-        "operationId": "marketplace.expert.delete",
-        "parameters": [
-          {
-            "description": "expert_id",
-            "in": "path",
-            "name": "expert_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Delete expert",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/experts/{expert_id}/skill_md": {
-      "get": {
-        "description": "Return the stored SKILL.md text for the skill at index i.",
-        "operationId": "marketplace.expert.skillmd.get",
-        "parameters": [
-          {
-            "description": "expert_id",
-            "in": "path",
-            "name": "expert_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Skill index within the record (server default 0 when omitted)",
-            "in": "query",
-            "name": "i",
-            "x-octo-flag": "index",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get expert skill SKILL.md",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/experts/{expert_id}/skill_download": {
-      "get": {
-        "description": "Return a short-lived presigned GET URL for the skill package at index i.",
-        "operationId": "marketplace.expert.skill_download",
-        "parameters": [
-          {
-            "description": "expert_id",
-            "in": "path",
-            "name": "expert_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Skill index within the record (server default 0 when omitted)",
-            "in": "query",
-            "name": "i",
-            "x-octo-flag": "index",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get expert skill package download URL",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/squads": {
-      "get": {
-        "description": "List squads visible in the current Space.",
-        "operationId": "marketplace.squad.list",
-        "parameters": [
-          {
-            "description": "Case-insensitive substring match on name/summary/category/creator_name",
-            "in": "query",
-            "name": "keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category id; repeat to OR-combine; 'all' disables the filter",
-            "in": "query",
-            "name": "category",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag name; repeat to AND-combine",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "system / public / private; repeat to OR-combine",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "human / bot / import; repeat to OR-combine",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "updated (recently edited first); anything else falls back to creation-time DESC",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "One-based page number (default 1)",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "pagination": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "List squads",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "read"
-      },
-      "post": {
-        "description": "Publish a new squad owned by the caller. Body carries generic fields (name/summary/category required) + leader/strategies/dependencies/permission/members (>=1 member with name/role/instruction). Send via --data.",
-        "operationId": "marketplace.squad.create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": [
-                  "name",
-                  "summary",
-                  "category",
-                  "members"
-                ],
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Display name (unique per Space; required)"
-                  },
-                  "summary": {
-                    "type": "string",
-                    "description": "One-line summary (required)"
-                  },
-                  "category": {
-                    "type": "string",
-                    "description": "Category NAME, resolved from expert-category list --kind squad (required; empty or unknown is rejected)"
-                  },
-                  "tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Tag names"
-                  },
-                  "publisher": {
-                    "type": "string",
-                    "description": "Publisher label"
-                  },
-                  "leader": {
-                    "type": "string",
-                    "description": "Leader display label (free text; defaults to the leading member's name). Which member leads is set by members[].is_leader, else the first member."
-                  },
-                  "strategies": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Collaboration strategies"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "description": "Permission mode"
-                  },
-                  "dependencies": {
-                    "$ref": "#/components/schemas/SquadDependencies"
-                  },
-                  "members": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "$ref": "#/components/schemas/SquadMemberWrite"
-                    },
-                    "description": "≥ 1 member (required); each needs name/role/instruction"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Squad (flat ExpertSquadDetail minus server-only fields)",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "description": "DUPLICATE"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Create squad",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/squads/mine": {
-      "get": {
-        "description": "Every squad owned by the caller in their Space regardless of visibility.",
-        "operationId": "marketplace.squad.mine.list",
-        "parameters": [
-          {
-            "description": "Case-insensitive substring match on name/summary/category/creator_name",
-            "in": "query",
-            "name": "keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category id; repeat to OR-combine; 'all' disables the filter",
-            "in": "query",
-            "name": "category",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag name; repeat to AND-combine",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "system / public / private; repeat to OR-combine",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "human / bot / import; repeat to OR-combine",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "updated (recently edited first); anything else falls back to creation-time DESC",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "One-based page number (default 1)",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    },
-                    "pagination": {
-                      "type": "object"
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "List owned squads",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/squads/{squad_id}": {
-      "get": {
-        "description": "Full ExpertSquadDetail (with members) if visible; otherwise 404.",
-        "operationId": "marketplace.squad.get",
-        "parameters": [
-          {
-            "description": "squad_id",
-            "in": "path",
-            "name": "squad_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get squad",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "read"
-      },
-      "patch": {
-        "description": "Owner-only partial update. Sending members replaces the whole array. Send via --data.",
-        "operationId": "marketplace.squad.update",
-        "parameters": [
-          {
-            "description": "squad_id",
-            "in": "path",
-            "name": "squad_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Display name (unique per Space)"
-                  },
-                  "summary": {
-                    "type": "string",
-                    "description": "One-line summary"
-                  },
-                  "category": {
-                    "type": "string",
-                    "description": "Category NAME, resolved from expert-category list --kind squad"
-                  },
-                  "tags": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Tag names"
-                  },
-                  "publisher": {
-                    "type": "string",
-                    "description": "Publisher label"
-                  },
-                  "leader": {
-                    "type": "string",
-                    "description": "Leader display label (free text; defaults to the leading member's name). Which member leads is set by members[].is_leader, else the first member."
-                  },
-                  "strategies": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    },
-                    "description": "Collaboration strategies"
-                  },
-                  "permission": {
-                    "type": "string",
-                    "description": "Permission mode"
-                  },
-                  "dependencies": {
-                    "$ref": "#/components/schemas/SquadDependencies"
-                  },
-                  "members": {
-                    "type": "array",
-                    "minItems": 1,
-                    "items": {
-                      "$ref": "#/components/schemas/SquadMemberWrite"
-                    },
-                    "description": "Full member list REPLACES the stored array (≥ 1 member; each needs name/role/instruction)"
-                  }
-                }
-              }
-            }
-          },
-          "description": "Partial ExpertSquadDetail (mutable fields only)",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Update squad",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "write"
-      },
-      "delete": {
-        "description": "Owner-only soft delete; the name frees up for reuse.",
-        "operationId": "marketplace.squad.delete",
-        "parameters": [
-          {
-            "description": "squad_id",
-            "in": "path",
-            "name": "squad_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Delete squad",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/squads/{squad_id}/skill_md": {
-      "get": {
-        "description": "Return the stored SKILL.md text for member's skill at index i.",
-        "operationId": "marketplace.squad.skillmd.get",
-        "parameters": [
-          {
-            "description": "squad_id",
-            "in": "path",
-            "name": "squad_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Squad member_key (required; the backend has no default member)",
-            "in": "query",
-            "name": "member",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Skill index within the record (server default 0 when omitted)",
-            "in": "query",
-            "name": "i",
-            "x-octo-flag": "index",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get squad member skill SKILL.md",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/squads/{squad_id}/skill_download": {
-      "get": {
-        "description": "Return a short-lived presigned GET URL for member's skill package at index i.",
-        "operationId": "marketplace.squad.skill_download",
-        "parameters": [
-          {
-            "description": "squad_id",
-            "in": "path",
-            "name": "squad_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Squad member_key (required; the backend has no default member)",
-            "in": "query",
-            "name": "member",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Skill index within the record (server default 0 when omitted)",
-            "in": "query",
-            "name": "i",
-            "x-octo-flag": "index",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Get squad member skill package download URL",
-        "tags": [
-          "squad"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/expert_categories": {
-      "get": {
-        "description": "Every live category with a count of records visible to the caller of the requested kind.",
-        "operationId": "marketplace.expert_category.list",
-        "parameters": [
-          {
-            "description": "agent (experts) | squad (expert_squads); default agent",
-            "in": "query",
-            "name": "kind",
             "schema": {
               "type": "string",
               "enum": [
-                "agent",
-                "squad"
+                "skill",
+                "connector",
+                "expert",
+                "expert_team"
               ]
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  }
-                }
-              }
-            }
+            },
+            "description": "Plugin type. Note the type mapping from the old per-type surface: mcp -> connector, squad -> expert_team.",
+            "required": true
           },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
           {
-            "Bearer": []
-          }
-        ],
-        "summary": "List expert categories",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/expert_tags": {
-      "get": {
-        "description": "Tag suggestions aggregated from records visible to the caller, sorted by descending count.",
-        "operationId": "marketplace.expert_tag.list",
-        "parameters": [
-          {
-            "description": "agent (experts) | squad (expert_squads); default agent",
+            "name": "category_id",
             "in": "query",
-            "name": "kind",
             "schema": {
-              "type": "string",
-              "enum": [
-                "agent",
-                "squad"
-              ]
-            }
+              "type": "string"
+            },
+            "description": "Filter by category id"
           },
           {
-            "description": "Case-insensitive substring match on tag name",
-            "in": "query",
             "name": "q",
+            "in": "query",
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "Search keyword"
           },
           {
-            "description": "Max results, clamped to [1,100]; default 50",
+            "name": "tag",
             "in": "query",
-            "name": "limit",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "description": "Repeated tag names; all must match"
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set to \"mine\" to list only the caller-owned plugins"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "newest (default) / oldest / updated / name / placement / views / installs / downloads / comprehensive"
+          },
+          {
+            "name": "page",
+            "in": "query",
             "schema": {
               "type": "integer"
-            }
+            },
+            "description": "Page number, default 1"
           },
           {
-            "description": "'mine' restricts to caller-owned rows",
+            "name": "page_size",
             "in": "query",
-            "name": "mode",
             "schema": {
-              "type": "string",
-              "enum": [
-                "all",
-                "mine"
-              ]
-            }
+              "type": "integer"
+            },
+            "description": "Page size, default 20, max 100"
           }
         ],
         "responses": {
@@ -1557,75 +110,306 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object"
-                      }
-                    }
-                  }
+                  "type": "object"
                 }
               }
             }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
           }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "List expert tags",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "read"
+        }
       }
     },
-    "/market/api/v1/expert_skill_uploads": {
+    "/market/api/v1/plugins/detail": {
+      "get": {
+        "operationId": "plugin.get",
+        "summary": "Get plugin detail",
+        "description": "Return the full manifest_json and plugin_json of a plugin. Skill packages are a flat attachment tree (one attachment per file).",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "plugin_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Plugin id",
+            "required": true
+          },
+          {
+            "name": "include_relations",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Include one-level relations (default true)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugins/versions": {
+      "get": {
+        "operationId": "plugin.version.list",
+        "summary": "List plugin versions",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "plugin_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Plugin id",
+            "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Page number, default 1"
+          },
+          {
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Page size, default 20, max 100"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugins/skill_md": {
+      "get": {
+        "operationId": "plugin.skillmd",
+        "summary": "Get a skill plugin SKILL.md",
+        "description": "Return the SKILL.md text of a skill plugin. For experts/expert_teams, first resolve the expert_skill relation target plugin id.",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "plugin_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Skill plugin id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugins/download": {
+      "get": {
+        "operationId": "plugin.download",
+        "summary": "Download a skill plugin package (zip)",
+        "description": "Stream the skill package as a zip, reconstructed on the fly from the attachment tree. Use --output/-o to write to a file.",
+        "x-octo-risk": "read",
+        "x-octo-binary-response": true,
+        "parameters": [
+          {
+            "name": "plugin_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Skill plugin id",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Skill package zip",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugin_categories": {
+      "get": {
+        "operationId": "plugin_category.list",
+        "summary": "List plugin categories",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "scene_code",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Marketplace scene code (use \"default\")",
+            "required": true
+          },
+          {
+            "name": "plugin_type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "skill",
+                "connector",
+                "expert",
+                "expert_team"
+              ]
+            },
+            "description": "Plugin type. Note the type mapping from the old per-type surface: mcp -> connector, squad -> expert_team.",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugin_tags": {
+      "get": {
+        "operationId": "plugin_tag.list",
+        "summary": "List plugin tags",
+        "x-octo-risk": "read",
+        "parameters": [
+          {
+            "name": "scene_code",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Marketplace scene code (use \"default\")"
+          },
+          {
+            "name": "plugin_type",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "skill",
+                "connector",
+                "expert",
+                "expert_team"
+              ]
+            },
+            "description": "Plugin type. Note the type mapping from the old per-type surface: mcp -> connector, squad -> expert_team."
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search keyword"
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Set to \"mine\" to only aggregate the caller-owned plugins"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Max tags to return"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugins/upsert": {
       "post": {
-        "description": "Presign an upload for a .zip/.skill Agent-Skill package (<=20 MiB). PUT the raw bytes to the returned presigned_url with headers, then reference upload_object_key in an expert/squad create or update.",
-        "operationId": "marketplace.expert_skill_upload.create",
+        "operationId": "plugin.upsert",
+        "summary": "Create or update a plugin",
+        "description": "Create (plugin.plugin_id empty) or update a plugin. Body: {\"plugin\":{plugin_name,plugin_type,visibility,manifest_json,plugin_json,tags,category_id,icon},\"relations\":[...]}. Pass the full document with --data. For skills prefer the upload+import flow instead.",
+        "x-octo-risk": "write",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file_name",
-                  "file_size"
-                ],
                 "properties": {
-                  "file_name": {
-                    "type": "string",
-                    "description": "Original package file name (.zip/.skill)"
+                  "plugin": {
+                    "type": "object",
+                    "description": "Plugin write document (plugin_name, plugin_type, visibility, manifest_json, plugin_json, tags, category_id, icon)"
                   },
-                  "file_size": {
-                    "type": "integer",
-                    "description": "Package size in bytes (<= 20 MiB)"
+                  "relations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "Optional relation rows"
                   }
-                }
+                },
+                "required": [
+                  "plugin"
+                ]
               }
             }
-          },
-          "description": "Skill package upload init",
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -1637,606 +421,221 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "description": "INTERNAL_ERROR"
           }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ],
-        "summary": "Initialize expert skill package upload",
-        "tags": [
-          "expert"
-        ],
-        "x-octo-risk": "write"
+        }
       }
     },
-    "/market/api/v1/bot/skills/publish": {
+    "/market/api/v1/plugins/delete": {
       "post": {
-        "description": "Parse an uploaded Skill archive synchronously through the bounded worker pool, then create a Skill owned by the bot owner.",
-        "operationId": "skill.publish",
+        "operationId": "plugin.delete",
+        "summary": "Delete a plugin",
+        "x-octo-risk": "write",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/internal_api_handler_upload.BotPublishSkillRequest"
+                "type": "object",
+                "properties": {
+                  "plugin_id": {
+                    "type": "string",
+                    "description": "Plugin id"
+                  }
+                },
+                "required": [
+                  "plugin_id"
+                ]
               }
             }
-          },
-          "description": "Bot publish request",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem"
-                }
-              }
-            },
-            "description": "Created"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "CONFLICT"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          },
-          "504": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
           }
         },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Publish Skill as bot",
-        "tags": [
-          "skill_upload"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/mcp_categories": {
-      "get": {
-        "description": "Return MCP category keys and visible record counts for the current Space.",
-        "operationId": "mcp_category.list",
-        "parameters": [
-          {
-            "description": "Scope: all or mine",
-            "in": "query",
-            "name": "mode",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "all",
-                "mine"
-              ]
-            }
-          },
-          {
-            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          }
-        ],
         "responses": {
           "200": {
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_model_CategoryFilter"
+                  "type": "object"
                 }
               }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
+            }
           }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List MCP categories",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "read"
+        }
       }
     },
-    "/market/api/v1/mcp_icon_uploads": {
+    "/market/api/v1/plugins/publish": {
       "post": {
-        "description": "Create a presigned upload target and persistent URL for an MCP icon.",
-        "operationId": "mcp_icon_upload.create",
+        "operationId": "plugin.publish",
+        "summary": "Publish a plugin version",
+        "description": "Release an immutable version and rebuild placements. Body: {plugin_id, version, changelog?, placements?}.",
+        "x-octo-risk": "write",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/internal_api_handler.MCPIconUploadRequest"
+                "type": "object",
+                "properties": {
+                  "plugin_id": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string",
+                    "description": "Semver version string (immutable once published)"
+                  },
+                  "changelog": {
+                    "type": "string"
+                  },
+                  "placements": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "description": "Placement rows; omit for the default placement"
+                  }
+                },
+                "required": [
+                  "plugin_id",
+                  "version"
+                ]
               }
             }
-          },
-          "description": "Icon metadata",
-          "required": true
+          }
         },
         "responses": {
           "200": {
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
+                  "type": "object"
                 }
               }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "413": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "PAYLOAD_TOO_LARGE"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
+            }
           }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Initialize MCP icon upload",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "write"
+        }
       }
     },
-    "/market/api/v1/mcps": {
-      "get": {
-        "description": "List MCP servers visible in the current Space using offset pagination.",
-        "operationId": "mcp.list",
-        "parameters": [
-          {
-            "description": "Search keyword",
-            "in": "query",
-            "name": "keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category key",
-            "in": "query",
-            "name": "category",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Transport filters",
-            "in": "query",
-            "name": "transport",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Visibility filters",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Source filters: system, space, mine",
-            "in": "query",
-            "name": "source",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag filters",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Sort: relevance, updated",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page number, default 1",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List MCP servers",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "read"
-      },
+    "/market/api/v1/plugins/install": {
       "post": {
-        "description": "Create an MCP server owned by the authenticated user in the current Space.",
-        "operationId": "mcp.create",
+        "operationId": "plugin.install",
+        "summary": "Install an expert / expert_team plugin into a Loop workspace",
+        "x-octo-risk": "write",
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreateRequest"
+                "type": "object",
+                "properties": {
+                  "plugin_id": {
+                    "type": "string"
+                  },
+                  "workspace_id": {
+                    "type": "string"
+                  },
+                  "runtime_id": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "plugin_id",
+                  "workspace_id",
+                  "runtime_id"
+                ]
               }
             }
-          },
-          "description": "MCP server",
-          "required": true
+          }
         },
         "responses": {
-          "201": {
+          "200": {
+            "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
+                  "type": "object"
                 }
               }
-            },
-            "description": "Created"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
+            }
+          }
+        }
+      }
+    },
+    "/market/api/v1/plugins/import": {
+      "post": {
+        "operationId": "plugin.import",
+        "summary": "Import a skill plugin from a completed parse task",
+        "description": "Finalize a skill upload: pass the parse_task_id from the upload+parse pipeline. Omit plugin_id to create, or set it to update an existing skill plugin.",
+        "x-octo-risk": "write",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "parse_task_id": {
+                    "type": "string"
+                  },
+                  "plugin_id": {
+                    "type": "string",
+                    "description": "Set to update an existing skill plugin; omit to create"
+                  },
+                  "plugin_name": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "category_id": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "public",
+                      "space",
+                      "private"
+                    ]
+                  },
+                  "icon": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "changelog": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "parse_task_id"
+                ]
               }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "DUPLICATE"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
+            }
           }
         },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
           }
-        ],
-        "summary": "Create MCP server",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "write"
+        }
       }
     },
     "/market/api/v1/mcps/_probe": {
@@ -2318,9 +717,7 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
         "summary": "Probe MCP server",
@@ -2328,695 +725,6 @@
           "mcp"
         ],
         "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/mcps/{mcp_id}": {
-      "delete": {
-        "description": "Soft-delete an MCP server owned by the caller. Repeated deletion returns not found.",
-        "operationId": "mcp.delete",
-        "parameters": [
-          {
-            "description": "MCP ID",
-            "in": "path",
-            "name": "mcp_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Delete MCP server",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "write"
-      },
-      "get": {
-        "description": "Return one MCP server visible to the caller without exposing stored secrets.",
-        "operationId": "mcp.get",
-        "parameters": [
-          {
-            "description": "MCP ID",
-            "in": "path",
-            "name": "mcp_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Get MCP server",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "read"
-      },
-      "patch": {
-        "description": "Partially update an MCP server owned by the authenticated user.",
-        "operationId": "mcp.update",
-        "parameters": [
-          {
-            "description": "MCP ID",
-            "in": "path",
-            "name": "mcp_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.PatchRequest"
-              }
-            }
-          },
-          "description": "MCP changes",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "DUPLICATE"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Update MCP server",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/mcps/mine": {
-      "get": {
-        "description": "List MCP servers owned by the authenticated user in the current Space.",
-        "operationId": "mcp.mine.list",
-        "parameters": [
-          {
-            "description": "Search keyword",
-            "in": "query",
-            "name": "keyword",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category key",
-            "in": "query",
-            "name": "category",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Transport filters",
-            "in": "query",
-            "name": "transport",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Visibility filters",
-            "in": "query",
-            "name": "visibility",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Source filters: system, space, mine",
-            "in": "query",
-            "name": "source",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Provenance filter (human, bot, import); repeatable or comma-separated",
-            "in": "query",
-            "name": "created_by_type",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Tag filters",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Sort: relevance, updated",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page number, default 1",
-            "in": "query",
-            "name": "page",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 100",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List owned MCP servers",
-        "tags": [
-          "mcp"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/skill_categories": {
-      "get": {
-        "description": "Return all Skill categories and their visible Skill counts.",
-        "operationId": "skill_category.list",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_CategoryItem"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List Skill categories",
-        "tags": [
-          "skill_category"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/skill_icon_uploads": {
-      "post": {
-        "description": "Create an upload target for a Skill icon without changing a Skill record.",
-        "operationId": "skill_icon_upload.create",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/internal_api_handler_upload.IconUploadRequest"
-              }
-            }
-          },
-          "description": "Icon metadata",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "413": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "PAYLOAD_TOO_LARGE"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Initialize Skill icon upload",
-        "tags": [
-          "skill_upload"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}": {
-      "get": {
-        "description": "Return the current parse state for one Skill archive upload.",
-        "operationId": "skill_parse_task.get",
-        "parameters": [
-          {
-            "description": "Skill parse task ID",
-            "in": "path",
-            "name": "skill_parse_task_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_PollResult"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Get Skill parse task",
-        "tags": [
-          "skill_upload"
-        ],
-        "x-octo-risk": "read"
       }
     },
     "/market/api/v1/skill_uploads": {
@@ -3108,9 +816,7 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
         "summary": "Initialize Skill upload",
@@ -3228,9 +934,7 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
         "summary": "Parse Skill upload",
@@ -3240,262 +944,15 @@
         "x-octo-risk": "write"
       }
     },
-    "/market/api/v1/skills": {
+    "/market/api/v1/skill_parse_tasks/{skill_parse_task_id}": {
       "get": {
-        "description": "List skills visible in the current Space with cursor pagination.",
-        "operationId": "skill.list",
+        "description": "Return the current parse state for one Skill archive upload.",
+        "operationId": "skill_parse_task.get",
         "parameters": [
           {
-            "description": "Search query",
-            "in": "query",
-            "name": "q",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Category ID",
-            "in": "query",
-            "name": "category_id",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Comma-separated tag names; all tags must match",
-            "in": "query",
-            "name": "tags",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Repeated tag names; all tags must match",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Sort mode: latest (default), comprehensive, downloads, views",
-            "in": "query",
-            "name": "sort",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Cursor for next page; used with default/latest sort",
-            "in": "query",
-            "name": "cursor",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 50",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List skills",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "read",
-        "x-octo-pagination": {
-          "cursorParam": "cursor",
-          "limitParam": "page_size",
-          "cursorField": "pagination.next_cursor",
-          "hasMoreField": "pagination.has_more"
-        }
-      },
-      "post": {
-        "description": "Publish a parsed Skill archive for the authenticated user and current Space.",
-        "operationId": "skill.create",
-        "x-octo-cli-hidden": true,
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/internal_api_handler_skill.CreateRequest"
-              }
-            }
-          },
-          "description": "Skill",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
-                }
-              }
-            },
-            "description": "Created"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "CONFLICT"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Create skill",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/skills/{skill_id}": {
-      "delete": {
-        "description": "Delete a Skill owned by the authenticated user.",
-        "operationId": "skill.delete",
-        "parameters": [
-          {
-            "description": "Skill ID",
+            "description": "Skill parse task ID",
             "in": "path",
-            "name": "skill_id",
+            "name": "skill_parse_task_id",
             "required": true,
             "schema": {
               "type": "string"
@@ -3507,7 +964,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp"
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_PollResult"
                 }
               }
             },
@@ -3556,324 +1013,29 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
-        "summary": "Delete skill",
+        "summary": "Get Skill parse task",
         "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "write"
-      },
-      "get": {
-        "description": "Return one skill visible to the authenticated caller.",
-        "operationId": "skill.get",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Get skill",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "read"
-      },
-      "patch": {
-        "description": "Partially update a Skill owned by the authenticated user.",
-        "operationId": "skill.update",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/internal_api_handler_skill.UpdateRequest"
-              }
-            }
-          },
-          "description": "Skill changes",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "VALIDATION_ERROR"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "409": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "CONFLICT"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Update skill",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "write"
-      }
-    },
-    "/market/api/v1/skills/{skill_id}/download": {
-      "get": {
-        "description": "Authorize access and redirect to the artifact URL, or return it when format=json.",
-        "operationId": "skill.download",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Use json to return the download URL",
-            "in": "query",
-            "name": "format",
-            "schema": {
-              "type": "string"
-            },
-            "x-octo-flag": "response-format"
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_upload_DownloadResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "302": {
-            "description": "Redirect to artifact"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Download Skill archive",
-        "tags": [
-          "skill"
+          "skill_upload"
         ],
         "x-octo-risk": "read"
       }
     },
-    "/market/api/v1/skills/{skill_id}/reuploads": {
+    "/market/api/v1/skill_icon_uploads": {
       "post": {
-        "description": "Create an upload target for a new immutable version of an owned Skill.",
-        "operationId": "skill.reupload.create",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "description": "Create an upload target for a Skill icon without changing a Skill record.",
+        "operationId": "skill_icon_upload.create",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/internal_api_handler_upload.ReuploadRequest"
+                "$ref": "#/components/schemas/internal_api_handler_upload.IconUploadRequest"
               }
             }
           },
-          "description": "Archive metadata",
+          "description": "Icon metadata",
           "required": true
         },
         "responses": {
@@ -3881,7 +1043,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_InitResult"
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
                 }
               }
             },
@@ -3950,43 +1112,51 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
-        "summary": "Initialize Skill reupload",
+        "summary": "Initialize Skill icon upload",
         "tags": [
           "skill_upload"
         ],
         "x-octo-risk": "write"
       }
     },
-    "/market/api/v1/skills/{skill_id}/skill_md": {
-      "get": {
-        "description": "Return the SKILL.md content for the current version of a visible Skill.",
-        "operationId": "skill.skillmd.get",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
+    "/market/api/v1/mcp_icon_uploads": {
+      "post": {
+        "description": "Create a presigned upload target and persistent URL for an MCP icon.",
+        "operationId": "mcp_icon_upload.create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/internal_api_handler.MCPIconUploadRequest"
+              }
             }
-          }
-        ],
+          },
+          "description": "Icon metadata",
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillMDResponse"
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_parse_IconUploadResult"
                 }
               }
             },
             "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
+                }
+              }
+            },
+            "description": "VALIDATION_ERROR"
           },
           "401": {
             "content": {
@@ -4018,7 +1188,7 @@
             },
             "description": "NOT_FOUND"
           },
-          "500": {
+          "413": {
             "content": {
               "application/json": {
                 "schema": {
@@ -4026,78 +1196,7 @@
                 }
               }
             },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "Get SKILL.md",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/skills/{skill_id}/versions": {
-      "get": {
-        "description": "List immutable release history for one visible Skill.",
-        "operationId": "skill.version.list",
-        "parameters": [
-          {
-            "description": "Skill ID",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillVersionList"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
+            "description": "PAYLOAD_TOO_LARGE"
           },
           "500": {
             "content": {
@@ -4112,394 +1211,23 @@
         },
         "security": [
           {
-            "Bearer": [
-
-            ]
+            "Bearer": []
           }
         ],
-        "summary": "List skill versions",
+        "summary": "Initialize MCP icon upload",
         "tags": [
-          "skill"
+          "mcp"
         ],
-        "x-octo-risk": "read"
-      }
-    },
-    "/market/api/v1/skills/mine": {
-      "get": {
-        "description": "List skills owned by the authenticated user in the current Space.",
-        "operationId": "skill.mine.list",
-        "parameters": [
-          {
-            "description": "Search query",
-            "in": "query",
-            "name": "q",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Comma-separated tag names; all tags must match",
-            "in": "query",
-            "name": "tags",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Repeated tag names; all tags must match",
-            "in": "query",
-            "name": "tag",
-            "schema": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          {
-            "description": "Cursor for next page",
-            "in": "query",
-            "name": "cursor",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Page size, default 20, max 50",
-            "in": "query",
-            "name": "page_size",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List owned skills",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "read",
-        "x-octo-pagination": {
-          "cursorParam": "cursor",
-          "limitParam": "page_size",
-          "cursorField": "pagination.next_cursor",
-          "hasMoreField": "pagination.has_more"
-        }
-      }
-    },
-    "/market/api/v1/skills/tags": {
-      "get": {
-        "description": "List custom Skill tags created in the current Space. Supports fuzzy search by q.",
-        "operationId": "skill.tag.list",
-        "parameters": [
-          {
-            "description": "Fuzzy tag search",
-            "in": "query",
-            "name": "q",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Limit, default 50, max 100",
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillTagList"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "401": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "AUTH_REQUIRED"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "FORBIDDEN"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "NOT_FOUND"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error"
-                }
-              }
-            },
-            "description": "INTERNAL_ERROR"
-          }
-        },
-        "security": [
-          {
-            "Bearer": [
-
-            ]
-          }
-        ],
-        "summary": "List skill tags",
-        "tags": [
-          "skill"
-        ],
-        "x-octo-risk": "read"
+        "x-octo-risk": "write"
       }
     }
   },
   "components": {
     "schemas": {
-      "SquadDependencies": {
-        "type": "object",
-        "properties": {
-          "blocking": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Hard prerequisites (runtimes, MCP servers, models)"
-          },
-          "recommended": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Recommended extras"
-          }
-        },
-        "description": "External dependency lists; the server rejects any key other than blocking/recommended"
-      },
-      "SquadMemberWrite": {
-        "type": "object",
-        "required": [
-          "name",
-          "role",
-          "instruction"
-        ],
-        "properties": {
-          "member_key": {
-            "type": "string",
-            "description": "Stable member key (letters/digits/[._-]; server default member_NN)"
-          },
-          "template_id": {
-            "type": "string",
-            "description": "Template id (server default expert-{squad_id}-NN)"
-          },
-          "name": {
-            "type": "string",
-            "description": "Member display name (required)"
-          },
-          "role": {
-            "type": "string",
-            "description": "Member role label (required)"
-          },
-          "is_leader": {
-            "type": "boolean",
-            "description": "Leader flag; exactly one leader persists (else the first member)"
-          },
-          "instruction": {
-            "type": "string",
-            "description": "Member system instruction (required; must be non-empty)"
-          },
-          "mcp_config": {
-            "type": "string",
-            "description": "Raw mcpServers config as a JSON string"
-          },
-          "skills": {
-            "type": "array",
-            "items": {
-              "type": "object"
-            },
-            "description": "Agent-Skill packages: [{name, upload_object_key?, content?, file_name?, file_size?}]"
-          }
-        },
-        "description": "One squad member on a write body"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorList-internal_api_handler_skill_SkillResponse": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/internal_api_handler_skill.SkillResponse"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "pagination": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorPagination"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.CursorPagination": {
-        "properties": {
-          "has_more": {
-            "type": "boolean"
-          },
-          "next_cursor": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_model_CategoryFilter": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CategoryFilter"
-            },
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_AdminItem": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem"
-            },
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-array_github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_CategoryItem": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.CategoryItem"
-            },
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_api_response_EmptyResp": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.EmptyResp"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_model_Detail": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Detail"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_IconResult": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.IconResult"
-          }
-        },
-        "type": "object"
-      },
       "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_ProbeResponse": {
         "properties": {
           "data": {
             "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeResponse"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_category_AdminItem": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem"
           }
         },
         "type": "object"
@@ -4528,71 +1256,12 @@
         },
         "type": "object"
       },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_SessionResponse": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler.SessionResponse"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillMDResponse": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler_skill.SkillMDResponse"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillResponse": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler_skill.SkillResponse"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillTagList": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler_skill.SkillTagList"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_skill_SkillVersionList": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler_skill.SkillVersionList"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-internal_api_handler_upload_DownloadResponse": {
-        "properties": {
-          "data": {
-            "$ref": "#/components/schemas/internal_api_handler_upload.DownloadResponse"
-          }
-        },
-        "type": "object"
-      },
       "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Data-map_string_string": {
         "properties": {
           "data": {
             "$ref": "#/components/schemas/map_string_string"
           }
         },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.EmptyResp": {
         "type": "object"
       },
       "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.Error": {
@@ -4609,548 +1278,13 @@
             "type": "string"
           },
           "details": {
-            "additionalProperties": {
-            },
+            "additionalProperties": {},
             "type": "object"
           },
           "hint": {
             "type": "string"
           },
           "message": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_model_ListItem": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.ListItem"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "pagination": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetList-github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill_SkillItem": {
-        "properties": {
-          "data": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "pagination": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_api_response.OffsetPagination": {
-        "properties": {
-          "page": {
-            "type": "integer"
-          },
-          "page_size": {
-            "type": "integer"
-          },
-          "total": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CategoryFilter": {
-        "properties": {
-          "count": {
-            "type": "integer"
-          },
-          "key": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreateRequest": {
-        "properties": {
-          "args": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "auth_type": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          },
-          "env": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "env_user_supplied": {
-            "description": "EnvUserSupplied lists env keys whose value must be filled locally by each consumer. Values are owner-visible and blanked to non-owners.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "faqs": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "headers": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "headers_user_supplied": {
-            "description": "HeadersUserSupplied has the same semantics as env_user_supplied for headers.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "icon": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "notes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "slogan": {
-            "type": "string"
-          },
-          "slug": {
-            "description": "Slug is the ASCII identifier used as the JSON key in the generated\nmcpServers snippet (mcp-v1.md §3, \"服务标识\"). Optional on the wire —\nwhen omitted or empty the server auto-slugifies Name. Must match\n^[a-z0-9-]{1,64}$ after normalization. Unique per Space among live rows.",
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "tools": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "transport": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
-          },
-          "url": {
-            "type": "string"
-          },
-          "usage_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "visibility": {
-            "type": "string",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType": {
-        "description": "Same shape + semantics as Detail (see there for rationale).",
-        "enum": [
-          "human",
-          "bot",
-          "import"
-        ],
-        "type": "string",
-        "x-enum-comments": {
-          "CreatedByImport": "reserved for Git import (#867); not written today."
-        },
-        "x-enum-varnames": [
-          "CreatedByHuman",
-          "CreatedByBot",
-          "CreatedByImport"
-        ]
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Detail": {
-        "properties": {
-          "category": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "created_by_bot_name": {
-            "type": "string"
-          },
-          "created_by_bot_uid": {
-            "type": "string"
-          },
-          "created_by_type": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType"
-          },
-          "creator_name": {
-            "type": "string"
-          },
-          "faqs": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "icon": {
-            "type": "string"
-          },
-          "mcp_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "notes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "quick_start": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.QuickStart"
-          },
-          "slogan": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "tool_count": {
-            "type": "integer"
-          },
-          "tools": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "usage_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ": {
-        "properties": {
-          "answer": {
-            "type": "string"
-          },
-          "question": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.ListItem": {
-        "properties": {
-          "category": {
-            "type": "string"
-          },
-          "created_by_bot_name": {
-            "type": "string"
-          },
-          "created_by_bot_uid": {
-            "type": "string"
-          },
-          "created_by_type": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.CreatedByType"
-          },
-          "creator_name": {
-            "type": "string"
-          },
-          "icon": {
-            "type": "string"
-          },
-          "match_reasons": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "mcp_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "relevance": {
-            "type": "integer"
-          },
-          "slogan": {
-            "type": "string"
-          },
-          "source": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "tool_count": {
-            "type": "integer"
-          },
-          "transport": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.PatchRequest": {
-        "properties": {
-          "args": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "auth_type": {
-            "type": "string"
-          },
-          "category": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          },
-          "env": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "env_user_supplied": {
-            "description": "A supplied array replaces the persisted env user-supplied key list; omission leaves it unchanged.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "faqs": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.FAQ"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "headers": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "headers_user_supplied": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "icon": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "notes": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "slogan": {
-            "type": "string"
-          },
-          "slug": {
-            "description": "Slug — same rules as CreateRequest.Slug. Nil pointer leaves the\nexisting slug untouched; a non-nil empty string is rejected as\nslug_invalid (empty is not a valid identifier).",
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "tools": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Tool"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "transport": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
-          },
-          "url": {
-            "type": "string"
-          },
-          "usage_examples": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "visibility": {
-            "type": "string",
-            "enum": [
-              "public",
-              "private"
-            ]
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.QuickStart": {
-        "properties": {
-          "args": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "auth_type": {
-            "type": "string"
-          },
-          "command": {
-            "type": "string"
-          },
-          "env": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "env_user_supplied": {
-            "description": "Environment keys each consumer must fill locally.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "headers": {
-            "additionalProperties": {
-              "type": "string"
-            },
-            "type": "object"
-          },
-          "headers_user_supplied": {
-            "description": "Header keys each consumer must fill locally.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "server_name": {
-            "type": "string"
-          },
-          "slug": {
-            "description": "Slug is the ASCII identifier used as the JSON key in the mcpServers\nsnippet. Frontend template prefers this over ServerName when generating\nthe config; always present in responses for records created after\nmigration 03.",
-            "type": "string"
-          },
-          "transport": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Transport"
-          },
-          "url": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.SkillVersion": {
-        "properties": {
-          "changed_by": {
-            "type": "string"
-          },
-          "changelog": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "skill_id": {
-            "type": "string"
-          },
-          "skill_version_id": {
-            "type": "string"
-          },
-          "storage": {
-            "description": "JSON: {\"type\":\"s3\",\"object_key\":\"...\",\"readme_key\":\"...\"}",
-            "type": "string"
-          },
-          "version": {
             "type": "string"
           }
         },
@@ -5179,32 +1313,6 @@
           "TransportStreamableHTTP",
           "TransportSSE"
         ]
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility": {
-        "enum": [
-          "public",
-          "private",
-          "system",
-          "space"
-        ],
-        "type": "string",
-        "x-enum-varnames": [
-          "VisibilityPublic",
-          "VisibilityPrivate",
-          "VisibilitySystem",
-          "VisibilitySpace"
-        ]
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_service.IconResult": {
-        "properties": {
-          "icon_url": {
-            "type": "string"
-          },
-          "version": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
       },
       "github_com_Mininglamp-OSS_octo-marketplace_internal_service.ProbeError": {
         "properties": {
@@ -5293,40 +1401,6 @@
           },
           "version": {
             "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.AdminItem": {
-        "properties": {
-          "icon_key": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "skill_category_id": {
-            "type": "string"
-          },
-          "sort_order": {
-            "type": "integer"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_category.CategoryItem": {
-        "properties": {
-          "icon_key": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "skill_category_id": {
-            "type": "string"
-          },
-          "skill_count": {
-            "type": "integer"
           }
         },
         "type": "object"
@@ -5442,89 +1516,6 @@
         },
         "type": "object"
       },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.SkillItem": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "creator_id": {
-            "type": "string"
-          },
-          "creator_name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "download_count": {
-            "type": "integer"
-          },
-          "file_name": {
-            "type": "string"
-          },
-          "file_size": {
-            "type": "integer"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "owner_name": {
-            "type": "string"
-          },
-          "readme_content": {
-            "type": "string"
-          },
-          "skill_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "view_count": {
-            "type": "integer"
-          },
-          "visibility": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.TagItem": {
-        "properties": {
-          "created_at": {
-            "type": "string"
-          },
-          "created_by": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "internal_api_handler.MCPIconUploadRequest": {
         "properties": {
           "content_type": {
@@ -5541,413 +1532,6 @@
           "file_name",
           "file_size"
         ],
-        "type": "object"
-      },
-      "internal_api_handler.SessionResponse": {
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "space_id": {
-            "type": "string"
-          },
-          "uid": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_category.AdminCategoryRequest": {
-        "properties": {
-          "icon_key": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "sort_order": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "name"
-        ],
-        "type": "object"
-      },
-      "internal_api_handler_metrics.trackRequest": {
-        "properties": {
-          "event_type": {
-            "type": "string"
-          },
-          "resource_id": {
-            "type": "string"
-          },
-          "resource_type": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.AdminCreateRequest": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "parse_task_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "version": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "parse_task_id"
-        ],
-        "type": "object"
-      },
-      "internal_api_handler_skill.AdminReuploadRequest": {
-        "properties": {
-          "changelog": {
-            "type": "string"
-          },
-          "parse_task_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "version": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "parse_task_id"
-        ],
-        "type": "object"
-      },
-      "internal_api_handler_skill.AdminUpdateRequest": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.CreateRequest": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "changelog": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "parse_task_id": {
-            "type": "string"
-          },
-          "source_skill_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "version": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string",
-            "enum": [
-              "public",
-              "private",
-              "space"
-            ]
-          }
-        },
-        "required": [
-          "parse_task_id"
-        ],
-        "type": "object"
-      },
-      "internal_api_handler_skill.SkillMDResponse": {
-        "properties": {
-          "content": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.SkillResponse": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "created_at": {
-            "type": "string"
-          },
-          "creator_id": {
-            "type": "string"
-          },
-          "creator_name": {
-            "type": "string"
-          },
-          "current_version_id": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "file_name": {
-            "type": "string"
-          },
-          "file_size": {
-            "type": "integer"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "owner_name": {
-            "type": "string"
-          },
-          "readme_content": {
-            "type": "string"
-          },
-          "skill_id": {
-            "type": "string"
-          },
-          "source_skill_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": false
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "visibility": {
-            "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.Visibility"
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.SkillTagList": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_service_skill.TagItem"
-            },
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.SkillVersionList": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/github_com_Mininglamp-OSS_octo-marketplace_internal_model.SkillVersion"
-            },
-            "type": "array",
-            "uniqueItems": false
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_skill.UpdateRequest": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "changelog": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "parse_task_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "version": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string",
-            "enum": [
-              "public",
-              "private",
-              "space"
-            ]
-          }
-        },
-        "type": "object"
-      },
-      "internal_api_handler_upload.BotPublishSkillRequest": {
-        "properties": {
-          "category_id": {
-            "type": "string"
-          },
-          "changelog": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
-          },
-          "display_name": {
-            "type": "string"
-          },
-          "icon_url": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "presigned_url": {
-            "type": "string"
-          },
-          "publish_mode": {
-            "type": "string",
-            "enum": [
-              "create"
-            ],
-            "default": "create"
-          },
-          "skill_upload_id": {
-            "type": "string"
-          },
-          "tags": {
-            "items": {
-              "maxLength": 10,
-              "type": "string"
-            },
-            "maxItems": 10,
-            "type": "array",
-            "uniqueItems": false
-          },
-          "upload_url": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "visibility": {
-            "type": "string",
-            "enum": [
-              "public",
-              "private",
-              "space"
-            ]
-          }
-        },
-        "type": "object",
-        "required": [
-          "skill_upload_id"
-        ]
-      },
-      "internal_api_handler_upload.DownloadResponse": {
-        "properties": {
-          "download_url": {
-            "type": "string"
-          },
-          "file_sha256": {
-            "type": "string"
-          }
-        },
         "type": "object"
       },
       "internal_api_handler_upload.IconUploadRequest": {
@@ -5980,33 +1564,11 @@
         ],
         "type": "object"
       },
-      "internal_api_handler_upload.ReuploadRequest": {
-        "properties": {
-          "file_name": {
-            "type": "string"
-          },
-          "file_size": {
-            "type": "integer"
-          }
-        },
-        "required": [
-          "file_name",
-          "file_size"
-        ],
-        "type": "object"
-      },
       "map_string_string": {
         "additionalProperties": {
           "type": "string"
         },
         "type": "object"
-      }
-    },
-    "securitySchemes": {
-      "Bearer": {
-        "in": "header",
-        "name": "Authorization",
-        "type": "apiKey"
       }
     }
   }

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -51,19 +51,26 @@ a normal upsert/import leaves the plugin listable without a follow-up call. Do
 not attempt to manipulate placements through the CLI.
 
 If a gateway-timeout hits a write, the outcome is UNKNOWN (the CLI surfaces
-`RESULT_UNKNOWN` rather than retrying, because create/upsert/install/delete are
-non-idempotent). Before re-running, re-check `plugin list --scene-code default
---plugin-type <type> --mode mine --q "<name>"` to confirm the plugin does or does
-not exist — that prevents duplicates.
+`RESULT_UNKNOWN` rather than retrying, because create/upsert/install/delete and
+`skill-upload parse` are non-idempotent). Before re-running, re-check `plugin
+list --scene-code default --plugin-type <type> --mode mine --q "<name>"` to
+confirm the plugin does or does not exist — that prevents duplicates. That check
+is only conclusive if you walk every page: it returns 20 rows by default and
+`--q` matches `plugin_name` substrings only, so stop at page 1 and an owner with
+many matches gets a false "not found" and creates a duplicate.
 
 ## Pagination and filtering
 
-`plugin list` is offset-paged: walk `--page` (with `--page-size`) yourself until
-a short page. There is no `--page-all`. The server-side filters are only
-`--category-id`, `--q`, `--tag` (repeatable), `--mode mine`, and `--sort`
+`plugin list` is page-paginated (`--page` / `--page-size`, default 20, max 100;
+an out-of-range `--page-size` is a 400, not a clamp): walk `--page` yourself
+until a short page. There is no `--page-all` — the unified endpoint is
+offset-based and does not advertise the cursor extension the retired per-type
+list ops used. The server-side filters are only `--category-id`, `--q`, `--tag`
+(repeatable), `--mode mine`, and `--sort`
 (`newest`/`oldest`/`updated`/`name`/`placement`/`views`/`installs`/`downloads`/
-`comprehensive`). Narrow anything else (e.g. by connector transport or
-visibility) client-side over the returned rows.
+`comprehensive`). `--q` is a substring match against `plugin_name` only — not
+the display name, description, tags or publisher. Narrow anything else (e.g. by
+connector transport or visibility) client-side over the returned rows.
 
 `plugin-category list` accepts only `--scene-code` + `--plugin-type` (no mode,
 pagination, or keyword); owned/provenance-scoped category counts from the

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -34,6 +34,11 @@ octo-cli marketplace plugin get --plugin-id <id> --include-relations
 `scene-code` is `default`. `plugin list` and `plugin-category list` require both
 `--scene-code` and `--plugin-type`. Use the immutable `plugin_id`, never a name.
 
+`plugin list` is offset-paged: walk `--page` (with `--page-size`) yourself until
+a short page. There is no `--page-all`, and the only server-side filters are
+`--category-id`, `--q`, `--tag`, `--mode`, `--sort`; narrow anything else (e.g.
+by connector transport or visibility) client-side over the returned rows.
+
 Load only the reference matching the task; each covers the type-specific detail
 (connector `mcp.json` + probe, skill file tree + upload/import, expert/team
 `AGENTS.md` + install).

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octo-marketplace
-version: 0.5.0
+version: 0.6.0
 description: Search, install, publish, and update Marketplace plugins — Skills, MCP connectors, and Experts/Squads (专家/专家团) — through the unified plugin API. Load after octo-shared.
 metadata:
   requires:
@@ -34,10 +34,44 @@ octo-cli marketplace plugin get --plugin-id <id> --include-relations
 `scene-code` is `default`. `plugin list` and `plugin-category list` require both
 `--scene-code` and `--plugin-type`. Use the immutable `plugin_id`, never a name.
 
+## Versioning and visibility — read this before any write
+
+After unification the backend has **no separate publish step**: every `plugin
+upsert` (and `plugin import`) IS a version snapshot — each save appends an
+auto-increment row to `plugin_versions`. The `plugin.version` field you pass is
+the human-readable `current_version` label (defaults to `1.0.0`); the snapshot
+label itself is server-assigned. A changelog note may be passed alongside
+`version` on **import** (which finalizes through upsert).
+
+A plugin is visible in scene-scoped lists (any `plugin list` with a non-empty
+`--scene-code`, including `--mode mine`) only while it has a visible row in
+`plugin_placements` for that scene. **Create and import attach the default
+placement automatically**; **update self-heals a missing default placement** — so
+a normal upsert/import leaves the plugin listable without a follow-up call. Do
+not attempt to manipulate placements through the CLI.
+
+If a gateway-timeout hits a write, the outcome is UNKNOWN (the CLI surfaces
+`RESULT_UNKNOWN` rather than retrying, because create/upsert/install/delete are
+non-idempotent). Before re-running, re-check `plugin list --scene-code default
+--plugin-type <type> --mode mine --q "<name>"` to confirm the plugin does or does
+not exist — that prevents duplicates.
+
+## Pagination and filtering
+
 `plugin list` is offset-paged: walk `--page` (with `--page-size`) yourself until
-a short page. There is no `--page-all`, and the only server-side filters are
-`--category-id`, `--q`, `--tag`, `--mode`, `--sort`; narrow anything else (e.g.
-by connector transport or visibility) client-side over the returned rows.
+a short page. There is no `--page-all`. The server-side filters are only
+`--category-id`, `--q`, `--tag` (repeatable), `--mode mine`, and `--sort`
+(`newest`/`oldest`/`updated`/`name`/`placement`/`views`/`installs`/`downloads`/
+`comprehensive`). Narrow anything else (e.g. by connector transport or
+visibility) client-side over the returned rows.
+
+`plugin-category list` accepts only `--scene-code` + `--plugin-type` (no mode,
+pagination, or keyword); owned/provenance-scoped category counts from the
+retired per-type surface are gone.
+
+`plugin-tag list` accepts optional `--scene-code`, `--plugin-type`, `--q`,
+`--mode mine`, and `--limit` (default 50, max 100). When `--scene-code` is
+omitted tags are aggregated over all visible plugins regardless of scene.
 
 Load only the reference matching the task; each covers the type-specific detail
 (connector `mcp.json` + probe, skill file tree + upload/import, expert/team
@@ -58,8 +92,9 @@ is flattened by the CLI output layer, exposing the item array directly at CLI
 
 ## Shared safety rule
 
-- Show the target plugin and intended mutation before install, publish, create,
+- Show the target plugin and intended mutation before install, create,
   replacement, or delete; continue only after explicit user confirmation.
+  (There is no separate "publish" step.)
 - Never print presigned URLs, tokens, headers containing secrets, or raw secret
   values. User-supplied connector secrets are written as `${VAR}` placeholders.
 - Do not change plugins outside the user-selected one.

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -1,49 +1,61 @@
 ---
 name: octo-marketplace
-version: 0.4.0
-description: Search, install, publish, and update Marketplace Skills, MCP server listings, and Experts/Squads (专家/专家团). Load after octo-shared.
+version: 0.5.0
+description: Search, install, publish, and update Marketplace plugins — Skills, MCP connectors, and Experts/Squads (专家/专家团) — through the unified plugin API. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
     skills: ["octo-shared"]
 ---
 
-# octo-marketplace — Skills and MCP servers
+# octo-marketplace — unified plugin catalog
 
-All commands use `$OCTO_API_BASE_URL/market/api/v1/*`, authenticate with the
-active bot profile, and send its Space context. Marketplace is one backend with
-several catalog domains, exposed as `marketplace skill`, `marketplace mcp`, and
-`marketplace expert` / `marketplace squad`.
+The marketplace is one backend with a single catalog surface: every asset is a
+**plugin** with a `plugin_type`. All commands use
+`$OCTO_API_BASE_URL/market/api/v1/plugins*`, authenticate with the active bot
+profile, and send its Space context.
 
-Load only the reference matching the task:
+The four plugin types (the old per-type surface maps onto them):
 
-| Task | Read |
-|---|---|
-| Search, install, publish, or update a Skill ZIP | [`skills.md`](skills.md) |
-| Search, install, create, probe, or update an MCP listing | [`mcp.md`](mcp.md) |
-| Search, create, update, or publish an Expert (专家) or Squad (专家团) | [`expert.md`](expert.md) |
+| plugin_type | was | read via |
+|---|---|---|
+| `skill` | Skill ZIP | [`skills.md`](skills.md) |
+| `connector` | MCP listing | [`mcp.md`](mcp.md) |
+| `expert` | Expert (专家) | [`expert.md`](expert.md) |
+| `expert_team` | Squad (专家团) | [`expert.md`](expert.md) |
+
+One command family drives every type — pass `--plugin-type`:
+
+```bash
+octo-cli marketplace plugin list --scene-code default --plugin-type skill --q "<kw>"
+octo-cli marketplace plugin get --plugin-id <id> --include-relations
+```
+
+`scene-code` is `default`. `plugin list` and `plugin-category list` require both
+`--scene-code` and `--plugin-type`. Use the immutable `plugin_id`, never a name.
+
+Load only the reference matching the task; each covers the type-specific detail
+(connector `mcp.json` + probe, skill file tree + upload/import, expert/team
+`AGENTS.md` + install).
 
 ## Shared output rule
 
-For a non-paginated command, normalize the backend payload before reading its
-fields because CLI versions may either unwrap the backend envelope or retain it:
+For a non-paginated command, normalize the payload before reading fields because
+CLI versions may unwrap the backend envelope or retain it:
 
 ```bash
-payload=$(octo-cli marketplace ... | jq -c '.data.data // .data')
+payload=$(octo-cli marketplace plugin get --plugin-id <id> | jq -c '.data.data // .data')
 ```
 
-Do not apply that expression to any command whose backend response is
-`{data:[...], pagination:{...}}` — the CLI output layer flattens that shape,
-exposing the result array directly as CLI `.data` and pagination as
-`._pagination`. This covers the paginated `skill list` / `mcp list` search
-commands **and** the offset-paginated `expert list` / `squad list` (and their
-`mine` variants), regardless of whether the command supports `--page-all`.
+Do not apply that to a `{data:[...], pagination:{...}}` response: `plugin list`
+is flattened by the CLI output layer, exposing the item array directly at CLI
+`.data` and pagination at `._pagination`.
 
 ## Shared safety rule
 
-- Show the target object and intended mutation before install, publish, create,
-  replacement, or update; continue only after explicit user confirmation.
+- Show the target plugin and intended mutation before install, publish, create,
+  replacement, or delete; continue only after explicit user confirmation.
 - Never print presigned URLs, tokens, headers containing secrets, or raw secret
-  values.
-- Do not change records outside the user-selected Skill, MCP, Expert, or Squad.
+  values. User-supplied connector secrets are written as `${VAR}` placeholders.
+- Do not change plugins outside the user-selected one.
 - On failure, preserve the previously installed runtime configuration.

--- a/skills/octo-marketplace/SKILL.md
+++ b/skills/octo-marketplace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-marketplace
-version: 0.6.0
-description: Search, install, publish, and update Marketplace plugins — Skills, MCP connectors, and Experts/Squads (专家/专家团) — through the unified plugin API. Load after octo-shared.
+version: 0.7.0
+description: Search, install, publish, review, and update Marketplace plugins — Skills, MCP connectors, and Experts/Squads (专家/专家团) — through the unified plugin API. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
@@ -11,11 +11,11 @@ metadata:
 # octo-marketplace — unified plugin catalog
 
 The marketplace is one backend with a single catalog surface: every asset is a
-**plugin** with a `plugin_type`. All commands use
-`$OCTO_API_BASE_URL/market/api/v1/plugins*`, authenticate with the active bot
-profile, and send its Space context.
-
-The four plugin types (the old per-type surface maps onto them):
+**plugin** with a `plugin_type`. All commands authenticate with the active
+credential and send its Space context; a `bf_*` User Bot is resolved to its owner
+and authoritative Bot Space by the backend. Unified catalog operations use
+`/market/api/v1/plugins*`; helper operations such as categories, uploads, probes,
+and icon presigns use other routes under `/market/api/v1/*`.
 
 | plugin_type | was | read via |
 |---|---|---|
@@ -24,85 +24,126 @@ The four plugin types (the old per-type surface maps onto them):
 | `expert` | Expert (专家) | [`expert.md`](expert.md) |
 | `expert_team` | Squad (专家团) | [`expert.md`](expert.md) |
 
-One command family drives every type — pass `--plugin-type`:
-
 ```bash
 octo-cli marketplace plugin list --scene-code default --plugin-type skill --q "<kw>"
 octo-cli marketplace plugin get --plugin-id <id> --include-relations
 ```
 
-`scene-code` is `default`. `plugin list` and `plugin-category list` require both
-`--scene-code` and `--plugin-type`. Use the immutable `plugin_id`, never a name.
+`scene-code` is `default`. Catalog listing requires `--scene-code` and
+`--plugin-type`; the owned all-types view is the exception:
 
-## Versioning and visibility — read this before any write
+```bash
+octo-cli marketplace plugin list --scene-code default --mode mine
+```
 
-After unification the backend has **no separate publish step**: every `plugin
-upsert` (and `plugin import`) IS a version snapshot — each save appends an
-auto-increment row to `plugin_versions`. The `plugin.version` field you pass is
-the human-readable `current_version` label (defaults to `1.0.0`); the snapshot
-label itself is server-assigned. A changelog note may be passed alongside
-`version` on **import** (which finalizes through upsert).
+Use immutable `plugin_id` and `review_id` values, never names.
 
-A plugin is visible in scene-scoped lists (any `plugin list` with a non-empty
-`--scene-code`, including `--mode mine`) only while it has a visible row in
-`plugin_placements` for that scene. **Create and import attach the default
-placement automatically**; **update self-heals a missing default placement** — so
-a normal upsert/import leaves the plugin listable without a follow-up call. Do
-not attempt to manipulate placements through the CLI.
+## Save, publish, and review lifecycle
 
-If a gateway-timeout hits a write, the outcome is UNKNOWN (the CLI surfaces
-`RESULT_UNKNOWN` rather than retrying, because create/upsert/install/delete and
-`skill-upload parse` are non-idempotent). Before re-running, re-check `plugin
-list --scene-code default --plugin-type <type> --mode mine --q "<name>"` to
-confirm the plugin does or does not exist — that prevents duplicates. That check
-is only conclusive if you walk every page: it returns 20 rows by default and
-`--q` matches `plugin_name` substrings only, so stop at page 1 and an owner with
-many matches gets a false "not found" and creates a duplicate.
+Creating with `plugin upsert` or skill `plugin import` saves a **draft** and a
+version snapshot; it does not expose the plugin to the Space catalog. Updates
+preserve the current listing state: draft/delisted content remains editable,
+published private content remains owner-only, and published Space content
+rejects direct edits and must use review. Version labels use
+`MAJOR.MINOR.PATCH` (each numeric component is 1–9 digits) and may not move
+backward.
+
+After verifying a saved draft, publish it explicitly:
+
+```bash
+octo-cli marketplace plugin publish --plugin-id <plugin-id> \
+  --version 1.2.0 --changelog "What changed"
+```
+
+- A `private` plugin's listing state becomes published immediately, but it stays
+  owner-only and is not exposed in the Space catalog.
+- A `space` plugin opens a review request and remains a draft until a Space
+  owner/admin approves it. Save the returned `review_id`.
+- Read `display_status` as the user-facing state: `draft`, `pending_review`,
+  `published`, `rejected`, or `delisted`. `listing_state` is the lower-level
+  listing axis.
+
+Applicants can inspect or cancel their requests:
+
+```bash
+octo-cli marketplace plugin review-request list --mode mine --status pending
+octo-cli marketplace plugin review-request get <review-id>
+octo-cli marketplace plugin review-request cancel <review-id>
+```
+
+Space owners/admins review the frozen submission, not mutable live draft data:
+
+```bash
+octo-cli marketplace plugin review-request list --mode space --status pending
+octo-cli marketplace plugin review-request get <review-id>
+octo-cli marketplace plugin review-request approve <review-id>
+octo-cli marketplace plugin review-request reject <review-id> --reason "Explain the required correction"
+```
+
+A Space owner/admin can take published Space content down; this leaves the
+plugin editable and eligible for a later publish:
+
+```bash
+octo-cli marketplace plugin delist --plugin-id <plugin-id> --reason "Policy or maintenance reason"
+```
+
+An already-published Space plugin cannot be edited through `upsert` or skill
+`import`; the backend rejects that bypass. Submit the full frozen upgrade with
+`review-request create`: a listed upgrade must carry either `parse_task_id` for
+a freshly parsed skill archive or both `manifest_json` + `plugin_json` for
+declared documents. Only an unlisted Space-intent first submission may omit
+content and snapshot its live draft. A present `relations` array replaces the
+frozen graph; omitting it inherits the live graph.
+
+## Retry and recovery
+
+Marketplace mutations are not transport-retried. A gateway failure may mean the
+server committed the operation, so `RESULT_UNKNOWN` must be resolved by reading
+state before retrying:
+
+- create: walk `plugin list --scene-code default --mode mine --q "<name>"`
+  through every page;
+- update/import of an existing id: `plugin get --plugin-id <id>` and compare the
+  intended version, hashes, and content; use `plugin version list` where useful;
+- publish: `plugin get --plugin-id <id>` and inspect `display_status` /
+  `review_id`, then list owned review requests;
+- review decisions: re-read the review request;
+- delist/delete: re-read the plugin.
+
+`--q` matches `plugin_name` substrings only and a page defaults to 20 rows. Stop
+only after an exact match or a short page.
 
 ## Pagination and filtering
 
-`plugin list` is page-paginated (`--page` / `--page-size`, default 20, max 100;
-an out-of-range `--page-size` is a 400, not a clamp): walk `--page` yourself
-until a short page. There is no `--page-all` — the unified endpoint is
-offset-based and does not advertise the cursor extension the retired per-type
-list ops used. The server-side filters are only `--category-id`, `--q`, `--tag`
-(repeatable), `--mode mine`, and `--sort`
-(`newest`/`oldest`/`updated`/`name`/`placement`/`views`/`installs`/`downloads`/
-`comprehensive`). `--q` is a substring match against `plugin_name` only — not
-the display name, description, tags or publisher. Narrow anything else (e.g. by
-connector transport or visibility) client-side over the returned rows.
+`plugin list` uses `--page` / `--page-size` (default 20, max 100); there is no
+`--page-all`. Filters are `--category-id`, `--q`, repeatable `--tag`, `--mode
+mine`, and `--sort` (`newest`, `oldest`, `updated`, `name`, `placement`, `views`,
+`installs`, `downloads`, `comprehensive`).
 
-`plugin-category list` accepts only `--scene-code` + `--plugin-type` (no mode,
-pagination, or keyword); owned/provenance-scoped category counts from the
-retired per-type surface are gone.
-
+`plugin-category list` requires `--scene-code` and `--plugin-type`.
 `plugin-tag list` accepts optional `--scene-code`, `--plugin-type`, `--q`,
-`--mode mine`, and `--limit` (default 50, max 100). When `--scene-code` is
-omitted tags are aggregated over all visible plugins regardless of scene.
+`--mode mine`, and `--limit` (default 50, max 100).
 
-Load only the reference matching the task; each covers the type-specific detail
-(connector `mcp.json` + probe, skill file tree + upload/import, expert/team
-`AGENTS.md` + install).
+Load only the reference matching the task: connector `mcp.json` + probe,
+skill attachment tree + upload/import, or expert/team `AGENTS.md` + relations.
 
 ## Shared output rule
 
-For a non-paginated command, normalize the payload before reading fields because
-CLI versions may unwrap the backend envelope or retain it:
+For a non-paginated command, normalize before reading fields:
 
 ```bash
 payload=$(octo-cli marketplace plugin get --plugin-id <id> | jq -c '.data.data // .data')
 ```
 
-Do not apply that to a `{data:[...], pagination:{...}}` response: `plugin list`
-is flattened by the CLI output layer, exposing the item array directly at CLI
+Do not apply that to `{data:[...], pagination:{...}}`; the CLI exposes items at
 `.data` and pagination at `._pagination`.
 
 ## Shared safety rule
 
-- Show the target plugin and intended mutation before install, create,
-  replacement, or delete; continue only after explicit user confirmation.
-  (There is no separate "publish" step.)
-- Never print presigned URLs, tokens, headers containing secrets, or raw secret
-  values. User-supplied connector secrets are written as `${VAR}` placeholders.
-- Do not change plugins outside the user-selected one.
-- On failure, preserve the previously installed runtime configuration.
+- Show the target and intended mutation before create, update, publish, review
+  decision, delist, install, or delete; continue only after explicit user
+  confirmation.
+- Never print presigned URLs, tokens, secret-bearing headers, or raw secret
+  values. Connector secrets use `${VAR}` placeholders.
+- Do not modify a plugin or review request outside the user-selected target.
+- Preserve the prior runtime configuration if installation fails.

--- a/skills/octo-marketplace/expert.md
+++ b/skills/octo-marketplace/expert.md
@@ -1,164 +1,89 @@
-# octo-marketplace — Expert workflows
+# octo-marketplace — Expert and Squad workflows
 
 Read `SKILL.md` first for authentication, payload normalization, and the shared
-safety rule. This file covers the **专家市场**: two symmetric entities —
-`expert` (专家, a single agent) and `squad` (专家团, an expert team). Every verb,
-flag, and envelope below is identical between them; only the payload shape and
-the id argument name (`<expert-id>` / `<squad-id>`) differ.
+safety rule. This file covers the **专家市场**: `expert` (专家, a single agent,
+`plugin_type=expert`) and `squad` (专家团, an expert team,
+`plugin_type=expert_team`). Both are plugins; only the type and package shape
+differ.
 
-## Pagination is offset-based (not cursor)
-
-Unlike the cursor-based `skill list` / `skill mine list`, the expert lists page
-by number, so `--page-all` does **not** apply (the same offset scheme as
-`mcp list`). Walk pages with `--page` (one-based) and `--page-size` (max 100):
-
-```bash
-octo-cli marketplace expert list --page 1 --page-size 20
-```
-
-The backend returns `{data:[...], pagination:{total,page,page_size}}`, and the
-CLI output layer flattens that shape onto the envelope: list **items are at
-`.data`** (already an array) and pagination metadata is at `._pagination`. Do
-NOT apply the `.data.data // .data` normalization here — `.data` is the array,
-so indexing it errors.
-
-```bash
-items=$(octo-cli marketplace expert list --keyword "架构" | jq -c '.data')
-total=$(octo-cli marketplace expert list --keyword "架构" | jq '._pagination.total')
-```
-
-Single-record and non-paginated reads (`expert get`, `expert-category list`,
-`expert-tag list`) return no `pagination` key, so they are NOT flattened —
-apply the shared `.data.data // .data` rule from `SKILL.md` to those instead.
+An expert's instruction lives in the package's root `AGENTS.md`; an
+expert_team is a single `AGENTS.md` describing collaboration/dispatch, and its
+members and their skills/connectors are expressed as **relations** (fetch with
+`--include-relations`).
 
 ## Search
 
 ```bash
-octo-cli marketplace expert-category list --kind agent      # kind: agent | squad
-octo-cli marketplace expert-tag list --kind agent --q "<tag>"
-octo-cli marketplace expert list \
-  --keyword "<kw>" --category <category_id> --tag "<tag>" \
-  --visibility public --created-by-type human --sort updated --page 1
-octo-cli marketplace expert get <expert-id>
+octo-cli marketplace plugin-category list --scene-code default --plugin-type expert
+octo-cli marketplace plugin-tag list --plugin-type expert --q "<tag>"
+octo-cli marketplace plugin list --scene-code default --plugin-type expert \
+  --q "<kw>" --category-id <id> --tag "<tag>" --sort updated --page 1 --page-size 20
+octo-cli marketplace plugin get --plugin-id <plugin-id> --include-relations
 ```
 
-- `--category` / `--tag` / `--visibility` / `--created-by-type` are repeatable
-  (repeat the flag to combine). `category` is a `category_id`; `all` disables
-  the filter. Resolve ids and live tag names from `expert-category list` and
-  `expert-tag list` for the current Space.
-- `--sort updated` surfaces recently edited records first; anything else
-  (including omitting the flag) sorts newest-first. There is no relevance mode.
-- Use the immutable `expert_id` / `squad_id`, never a name.
+Squads are identical with `--plugin-type expert_team`. `plugin list` is
+page-paginated (CLI `.data` + `._pagination`); add `--mode mine` for owned
+records of any visibility. Use the immutable `plugin_id`, never a name.
 
-The `squad` family is identical: `squad list`, `squad get <squad-id>`,
-`squad mine list`, and `--kind squad` on the taxonomy commands.
+## Read member skills
 
-## View owned records
+`plugin get --include-relations` returns the relations. For an expert_team, each
+member is an `expert_team_expert` relation; a member/expert's skills are
+`expert_skill` relations whose target is a skill plugin. Read a skill's document
+by its own plugin id:
 
 ```bash
-octo-cli marketplace expert mine list --page 1     # own records, any visibility
-octo-cli marketplace squad  mine list --page 1
+octo-cli marketplace plugin skillmd --plugin-id <skill-plugin-id>
+octo-cli marketplace plugin download --plugin-id <skill-plugin-id> -o <tmp>/skill.zip
 ```
 
 ## Create / update
 
-Bodies are nested (an expert carries `instruction` / `mcp_config` / `skills`; a
-squad carries `members[]`), so submit them as JSON via `--data`. Show the target
-and the intended change, then continue only after explicit confirmation.
+Create or edit through the unified write path. Show the target and intended
+change, then continue only after explicit confirmation:
 
 ```bash
-# Create a standalone expert (name/summary/category/instruction required;
-# new records publish public)
-octo-cli marketplace expert create --data '{
-  "name": "后端架构师",
-  "summary": "评审服务边界、数据模型和可靠性方案。",
-  "category": "研发工具",
-  "tags": ["架构评审", "可靠性"],
-  "instruction": "你是资深后端架构师……",
-  "mcp_config": "{\"mcpServers\":{}}",
-  "skills": [{"name": "架构评审清单"}]
-}'
-
-# Partial update — owner only; send only mutable fields
-octo-cli marketplace expert update <expert-id> --data '{"summary":"新的一句话简介"}'
+octo-cli marketplace plugin upsert --data @plugin.json
 ```
 
-- `category` is the category **NAME** (e.g. `研发工具`), resolved from
-  `expert-category list`; an empty or unknown name is rejected.
-- `mcp_config` is the raw `mcpServers` config as a JSON **string**; validated as
-  well-formed JSON and size-capped, stored verbatim. Use the
-  `__OCTO_SECRET_PLACEHOLDER__` sentinel instead of real tokens.
-- A `visibility` field is ignored on write (records stay their current
-  visibility; `system` is rejected).
+The `--data` body is `{"plugin":{plugin_name, plugin_type, visibility,
+category_id, tags, manifest_json, plugin_json}, "relations":[...]}`:
 
-For a **squad**, the body adds `leader` / `strategies` / `dependencies` /
-`permission` / `members`. `category` and `members` (≥ 1) are required on
-create; each member is `{member_key?, template_id?, name, role, is_leader?,
-instruction, mcp_config?, skills?}` (`?` marks the optional fields). `leader`
-is a display label (free text) — which member actually leads is chosen by
-`is_leader` (else the first member). `dependencies` accepts only
-`{blocking: [..], recommended: [..]}` string lists; any other key is
-rejected. On update, sending `members` **replaces the whole array** — always
-submit the complete member list.
+- **expert**: `plugin_json` carries a root `AGENTS.md` (the instruction) and,
+  when it uses connectors, a root `mcp.json` with `${VAR}` placeholders for
+  consumer secrets.
+- **expert_team**: `plugin_json` is a single `AGENTS.md` rendering the
+  collaboration/dispatch, leader, strategies, dependencies, and permissions.
+  Members and their skills are `relations` entries
+  (`expert_team_expert` / `expert_skill` / `expert_connector`); the leader is
+  the member relation with `is_leader`.
+
+Set `plugin.plugin_id` to update; sending `relations` replaces the relation set,
+so submit the complete list. Publish an immutable version separately:
+
+```bash
+octo-cli marketplace plugin publish --plugin-id <id> --version 1.1.0 --changelog "…"
+```
+
+## Install into a Loop workspace
+
+Provision an expert or expert_team into a Loop workspace/runtime (creates the
+agent or squad, acting as the caller against octo-fleet, with rollback):
+
+```bash
+octo-cli marketplace plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>
+```
+
+The response carries `agent_id` (expert) or `squad_id` (expert_team).
 
 ## Delete (owner only, confirmed)
 
-Soft delete; the name frees up for reuse:
+Soft delete; the name frees for reuse:
 
 ```bash
-octo-cli marketplace expert delete <expert-id>
-octo-cli marketplace squad  delete <squad-id>
+octo-cli marketplace plugin delete --plugin-id <id>
 ```
 
-## Skills are whole Agent-Skill packages
-
-A skill on an expert/squad is a `.zip`/`.skill` package containing `SKILL.md`.
-Publishing one is a three-step client-side flow — never send raw bytes through
-`--data`:
-
-1. **Presign** an upload (`.zip`/`.skill`, ≤ 20 MiB):
-
-   ```bash
-   octo-cli marketplace expert-skill-upload create \
-     --file-name "架构评审清单.zip" --file-size <bytes>
-   ```
-
-   Returns `{upload_object_key, presigned_url, method, headers, expires_in}`.
-2. **PUT** the raw package bytes to `presigned_url` using the returned HTTP
-   `method` and `headers`. Never print the presigned URL or its headers.
-3. **Reference** the key in a create/update `skills[]` entry — the server
-   extracts `SKILL.md`, derives the authoritative skill `name`, stores the
-   package, and records the file manifest:
-
-   ```json
-   { "skills": [ { "name": "架构评审清单",
-                   "upload_object_key": "expert-uploads/…",
-                   "file_name": "架构评审清单.zip", "file_size": 12345 } ] }
-   ```
-
-   A name-only skill is `{ "name": "…" }`; inline `SKILL.md` text is
-   `{ "name": "…", "content": "…" }`. Sending only a name on update preserves
-   the existing stored package.
-
-### Read / download a stored skill package
-
-On read, each `skills[]` item carries `has_content` / `can_download` /
-`file_name` / `file_size` / `files`. Fetch by index `i`:
-
-```bash
-octo-cli marketplace expert skillmd get <expert-id> --index <i>        # SKILL.md text
-octo-cli marketplace expert skill-download <expert-id> --index <i>     # {download_url}
-```
-
-For a squad member, `--member <member_key>` is required (`--index` still
-defaults to 0):
-
-```bash
-octo-cli marketplace squad skillmd get <squad-id> --member <member_key> --index <i>
-octo-cli marketplace squad skill-download <squad-id> --member <member_key> --index <i>
-```
-
-`skill-download` returns a short-lived presigned GET `download_url`; download
-into a fresh temp dir and never infer or log the URL. Apply the same archive
-safety checks as Skill install (`skills.md`): reject absolute paths, `..`
-traversal, links, and devices before extraction.
+Skill packages attached to an expert/team are themselves `skill` plugins — to
+publish or update one, follow the upload → parse → import flow in `skills.md`,
+then wire it with an `expert_skill` relation in `plugin upsert`.

--- a/skills/octo-marketplace/expert.md
+++ b/skills/octo-marketplace/expert.md
@@ -66,11 +66,48 @@ every write:
 
 Set `plugin.plugin_id` to update; omit to create. Inspect history with `plugin version list --plugin-id <id>` after a release.
 
+> **`manifest_json` must agree with the outer `plugin` fields.** The backend
+> rejects the write unless all three hold:
+> `manifest_json.plugin_name == plugin.plugin_name`,
+> `manifest_json.plugin_type == plugin.plugin_type`, and
+> `manifest_json.labels == plugin.tags` **in the same order** (they are compared
+> as canonical JSON arrays, not as sets, so reordering, a duplicate or an
+> untrimmed label fails). Every violation returns the same opaque
+> `400 VALIDATION_ERROR` with `details {"field":"body","reason":"invalid"}` and
+> no hint as to which field disagreed — check all three before retrying.
+>
+> ```jsonc
+> {
+>   "plugin": {
+>     "plugin_name": "deep-miner",
+>     "plugin_type": "expert",
+>     "visibility": "space",
+>     "tags": ["research", "analysis"],
+>     "manifest_json": {
+>       "plugin_name": "deep-miner",        // == plugin.plugin_name
+>       "plugin_type": "expert",            // == plugin.plugin_type
+>       "labels": ["research", "analysis"]  // == plugin.tags, same order
+>     },
+>     "plugin_json": { "attachments": [] }
+>   },
+>   "relations": []
+> }
+> ```
+
+> **Upsert replaces the row; it does not patch it.** The backend rebuilds the
+> whole plugin from your document, preserving only `created_at`, the version
+> history and the creator identity. An omitted `category_id`, `publisher` or
+> `icon` is accepted as empty and **clears the stored value**. Read-modify-write
+> with `plugin get` and resubmit the complete document on every edit. (`plugin
+> import` is the opposite — it falls back to the existing row — so do not carry
+> habits between the two paths.)
+
 > **Every upsert replaces the relation set.** Always resubmit the complete list
 > — including on metadata-only edits. Omitting the `relations` key is identical
 > to submitting `[]` and soft-deletes every live relation (team members,
-> attached skills, attached connectors) on save. Echo `relation_id` for rows
-> you want to keep verbatim.
+> attached skills, attached connectors) on save. Nothing validates this locally,
+> so the destruction is silent. Echo `relation_id` for rows you want to keep
+> verbatim.
 
 Bumping `plugin.version` (and adding a changelog via the import flow for
 skill-bearing experts) is how a new release is recorded; there is no separate

--- a/skills/octo-marketplace/expert.md
+++ b/skills/octo-marketplace/expert.md
@@ -1,10 +1,10 @@
 # octo-marketplace — Expert and Squad workflows
 
-Read `SKILL.md` first for authentication, payload normalization, and the shared
-safety rule. This file covers the **专家市场**: `expert` (专家, a single agent,
-`plugin_type=expert`) and `squad` (专家团, an expert team,
-`plugin_type=expert_team`). Both are plugins; only the type and package shape
-differ.
+Read `SKILL.md` first for authentication, payload normalization, versioning, the
+no-separate-publish rule, and the shared safety rule. This file covers the
+**专家市场**: `expert` (专家, a single agent, `plugin_type=expert`) and `squad`
+(专家团, an expert team, `plugin_type=expert_team`). Both are plugins; only the
+type and package shape differ.
 
 An expert's instruction lives in the package's root `AGENTS.md`; an
 expert_team is a single `AGENTS.md` describing collaboration/dispatch, and its
@@ -39,31 +39,42 @@ octo-cli marketplace plugin download --plugin-id <skill-plugin-id> -o <tmp>/skil
 
 ## Create / update
 
-Create or edit through the unified write path. Show the target and intended
-change, then continue only after explicit confirmation:
+Create or edit through the unified write path. Every save is a version snapshot
+and attaches/self-heals the default market placement, so a created expert or
+team is listable immediately — there is no separate publish step. Show the
+target and intended change, then continue only after explicit confirmation:
 
 ```bash
 octo-cli marketplace plugin upsert --data @plugin.json
 ```
 
 The `--data` body is `{"plugin":{plugin_name, plugin_type, visibility,
-category_id, tags, manifest_json, plugin_json}, "relations":[...]}`:
+category_id, tags, icon, version?, manifest_json, plugin_json},
+"relations":[...]}`. Both `manifest_json` and `plugin_json` are required on
+every write:
 
 - **expert**: `plugin_json` carries a root `AGENTS.md` (the instruction) and,
   when it uses connectors, a root `mcp.json` with `${VAR}` placeholders for
   consumer secrets.
 - **expert_team**: `plugin_json` is a single `AGENTS.md` rendering the
   collaboration/dispatch, leader, strategies, dependencies, and permissions.
-  Members and their skills are `relations` entries
-  (`expert_team_expert` / `expert_skill` / `expert_connector`); the leader is
-  the member relation with `is_leader`.
+  Members and their skills are `relations` entries; valid `relation_type`
+  values are `expert_team_expert` (team → member expert), `expert_skill`
+  (expert → skill), and `expert_connector` (expert → connector). The team
+  leader is the member relation whose `data.is_leader` is true; every
+  relation requires `target_plugin_id` and `relation_type`.
 
-Set `plugin.plugin_id` to update; sending `relations` replaces the relation set,
-so submit the complete list. Publish an immutable version separately:
+Set `plugin.plugin_id` to update; omit to create. Inspect history with `plugin version list --plugin-id <id>` after a release.
 
-```bash
-octo-cli marketplace plugin publish --plugin-id <id> --version 1.1.0 --changelog "…"
-```
+> **Every upsert replaces the relation set.** Always resubmit the complete list
+> — including on metadata-only edits. Omitting the `relations` key is identical
+> to submitting `[]` and soft-deletes every live relation (team members,
+> attached skills, attached connectors) on save. Echo `relation_id` for rows
+> you want to keep verbatim.
+
+Bumping `plugin.version` (and adding a changelog via the import flow for
+skill-bearing experts) is how a new release is recorded; there is no separate
+publish command.
 
 ## Install into a Loop workspace
 
@@ -74,7 +85,8 @@ agent or squad, acting as the caller against octo-fleet, with rollback):
 octo-cli marketplace plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>
 ```
 
-The response carries `agent_id` (expert) or `squad_id` (expert_team).
+The response carries exactly one of `agent_id` (expert) or `squad_id`
+(expert_team), depending on the plugin's type.
 
 ## Delete (owner only, confirmed)
 
@@ -85,5 +97,7 @@ octo-cli marketplace plugin delete --plugin-id <id>
 ```
 
 Skill packages attached to an expert/team are themselves `skill` plugins — to
-publish or update one, follow the upload → parse → import flow in `skills.md`,
-then wire it with an `expert_skill` relation in `plugin upsert`.
+release a new version of one, re-run the upload → parse → import flow in
+[`skills.md`](skills.md) with the existing `--plugin-id`; wire or re-wire it
+with an `expert_skill` relation in a subsequent `plugin upsert` that resubmits
+the full relation list.

--- a/skills/octo-marketplace/expert.md
+++ b/skills/octo-marketplace/expert.md
@@ -1,7 +1,7 @@
 # octo-marketplace — Expert and Squad workflows
 
-Read `SKILL.md` first for authentication, payload normalization, versioning, the
-no-separate-publish rule, and the shared safety rule. This file covers the
+Read `SKILL.md` first for authentication, payload normalization, the
+save→publish/review lifecycle, and the shared safety rule. This file covers the
 **专家市场**: `expert` (专家, a single agent, `plugin_type=expert`) and `squad`
 (专家团, an expert team, `plugin_type=expert_team`). Both are plugins; only the
 type and package shape differ.
@@ -39,9 +39,11 @@ octo-cli marketplace plugin download --plugin-id <skill-plugin-id> -o <tmp>/skil
 
 ## Create / update
 
-Create or edit through the unified write path. Every save is a version snapshot
-and attaches/self-heals the default market placement, so a created expert or
-team is listable immediately — there is no separate publish step. Show the
+Create or edit an **unpublished** draft through the unified write path. Every
+save records a version snapshot but does not publish the expert or team. An
+already-published Space expert/team cannot be changed with upsert; submit its
+new manifest/package/relations through `plugin review-request create --data
+@submission.json` so approval atomically applies the frozen upgrade. Show the
 target and intended change, then continue only after explicit confirmation:
 
 ```bash
@@ -58,11 +60,11 @@ every write:
   consumer secrets.
 - **expert_team**: `plugin_json` is a single `AGENTS.md` rendering the
   collaboration/dispatch, leader, strategies, dependencies, and permissions.
-  Members and their skills are `relations` entries; valid `relation_type`
-  values are `expert_team_expert` (team → member expert), `expert_skill`
-  (expert → skill), and `expert_connector` (expert → connector). The team
-  leader is the member relation whose `data.is_leader` is true; every
-  relation requires `target_plugin_id` and `relation_type`.
+  A team's own `relations` array may contain only `expert_team_expert` entries
+  (team → member expert). The leader is the member relation whose
+  `data.is_leader` is true. `expert_skill` and `expert_connector` belong on each
+  member expert's own upsert/review document, never directly on the team source.
+  Every relation requires `target_plugin_id` and `relation_type`.
 
 Set `plugin.plugin_id` to update; omit to create. Inspect history with `plugin version list --plugin-id <id>` after a release.
 
@@ -84,11 +86,23 @@ Set `plugin.plugin_id` to update; omit to create. Inspect history with `plugin v
 >     "visibility": "space",
 >     "tags": ["research", "analysis"],
 >     "manifest_json": {
->       "plugin_name": "deep-miner",        // == plugin.plugin_name
->       "plugin_type": "expert",            // == plugin.plugin_type
->       "labels": ["research", "analysis"]  // == plugin.tags, same order
+>       "$schema": "cowork-plugin-manifest-2.0.json",
+>       "plugin_name": "deep-miner",
+>       "plugin_type": "expert",
+>       "name": "deep-miner",
+>       "description": "Research and analysis expert",
+>       "labels": ["research", "analysis"],
+>       "examples": []
 >     },
->     "plugin_json": { "attachments": [] }
+>     "plugin_json": {
+>       "$schema": "cowork-plugin-package-2.0.json",
+>       "attachments": [{
+>         "path": "AGENTS.md",
+>         "content_type": "raw",
+>         "mime_type": "text/markdown",
+>         "raw_content": "# Deep Miner\n\nResearch the question and cite evidence."
+>       }]
+>     }
 >   },
 >   "relations": []
 > }
@@ -109,9 +123,11 @@ Set `plugin.plugin_id` to update; omit to create. Inspect history with `plugin v
 > so the destruction is silent. Echo `relation_id` for rows you want to keep
 > verbatim.
 
-Bumping `plugin.version` (and adding a changelog via the import flow for
-skill-bearing experts) is how a new release is recorded; there is no separate
-publish command.
+After saving, publish with `plugin publish --plugin-id <id> --version <x.y.z>
+--changelog "…"`. A Space-visible expert/team enters review; follow the
+applicant or reviewer flow in `SKILL.md`. `plugin import` is skill-only and must
+never be used to release an expert or expert_team. To review changed declared
+content directly, use `plugin review-request create --data @submission.json`.
 
 ## Install into a Loop workspace
 

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -1,109 +1,76 @@
-# octo-marketplace — MCP workflows
+# octo-marketplace — MCP connector workflows
 
-Read `SKILL.md` first for authentication, payload normalization, and confirmation
-rules. MCP listings have no downloadable archive or release version.
+Read `SKILL.md` first for authentication, payload normalization, and the shared
+safety rule. MCP listings are `plugin_type=connector`: no downloadable archive
+or release version. The connection lives in the package's root `mcp.json`
+(standard `{"mcpServers":…}`); user-supplied secret values appear as `${VAR}`
+placeholders, never real secrets.
 
 ## Search and inspect
 
 ```bash
-octo-cli marketplace mcp-category list --mode all
-octo-cli marketplace mcp list --keyword "<keywords>" --sort relevance --page 1 --page-size 20
-octo-cli marketplace mcp mine list --page 1 --page-size 20
-octo-cli marketplace mcp get <mcp-id>
+octo-cli marketplace plugin-category list --scene-code default --plugin-type connector
+octo-cli marketplace plugin list --scene-code default --plugin-type connector \
+  --q "<keywords>" --sort comprehensive --page 1 --page-size 20
+octo-cli marketplace plugin list --scene-code default --plugin-type connector --mode mine
+octo-cli marketplace plugin get --plugin-id <plugin-id>
 ```
 
-Search is paginated: read results from CLI `.data[]`.
-The category command is non-paginated; normalize it and use a returned `key` as
-the MCP `category` value or list filter. MCP tags are free-form strings; there
-is no tag dictionary endpoint.
-
-Search filters include repeatable/comma-separated `transport`, `visibility`,
-`source`, `created-by-type`, and `tag`. `mcp-category list --mode mine` returns
-counts for owned records; `--created-by-type` narrows provenance.
-
-`key: "all"` is the list-filter sentinel and `key: ""` means uncategorized;
-do not store either as a new listing's category. Category keys are derived from
-visible MCP records rather than managed as a separate administrator dictionary.
+`plugin list` is page-paginated (CLI `.data` + `._pagination`). Filter with
+repeatable `--tag` and `--category-id`. `plugin get` returns the connector
+descriptor (`plugin_json.connector`) plus the root `mcp.json`.
 
 ## Install into an Agent Runtime
 
-Installation means adding the detail response's `quick_start` connection to the
-runtime's MCP configuration.
-
-Before writing configuration, show:
-
-- MCP name and transport;
-- target runtime and config file;
-- command or URL;
-- required environment-variable and header names, without secret values.
+Installation adds the connector's `mcp.json` server entry to the runtime's MCP
+configuration. Before writing config, show the connector name and transport, the
+target runtime and config file, the command or URL, and the required
+environment-variable / header names (never secret values).
 
 After confirmation, preserve existing entries unless replacement was approved.
-Use `quick_start.slug` as the `mcpServers` key. Map stdio to
-`command`/`args`/`env`, and HTTP/SSE to `url`/`headers`. Treat keys listed in
-`quick_start.env_user_supplied` and `quick_start.headers_user_supplied` as
-consumer-provided secrets: ask for them locally, never invent or echo them, and
-persist them only through the runtime's approved secret mechanism. Reload the
+Copy the `mcpServers` entry from `mcp.json`. Any value written as `${VAR}` is a
+consumer-supplied secret: ask for it locally, never invent or echo it, and
+persist it only through the runtime's approved secret mechanism. Reload the
 runtime and verify the server connects.
 
 ## Validate a connection
 
-For `streamable-http` and `sse`, probe without persisting:
+For `streamable-http` and `sse`, probe without persisting (retained endpoint):
 
 ```bash
 octo-cli marketplace mcp probe --data @connection.json
 ```
 
-Build `connection.json` with only the probe fields: `transport`, `url`,
-`command`, `args`, `env`, and `headers`. The probe endpoint rejects catalog
-fields and `env_user_supplied` / `headers_user_supplied` as unknown fields.
-Use empty values for consumer-supplied secrets; do not send real secrets just
-to validate a public connection.
+`connection.json` carries only probe fields: `transport`, `url`, `command`,
+`args`, `env`, `headers`. Use empty values for consumer-supplied secrets; do not
+send real secrets just to validate. Continue only when the normalized response
+has `is_ok=true`.
 
-Normalize the response and continue only when `is_ok=true`.
+Do not probe `stdio`: the server does not spawn user commands. The runtime must
+start the command locally, complete MCP `initialize` and `tools/list`, then stop.
 
-Do not call the Marketplace probe endpoint for `stdio`: the server deliberately
-does not spawn user commands. The Agent Runtime must start the proposed command
-locally, complete MCP `initialize` and `tools/list`, then stop the test process.
+## Create / update
 
-## Create
-
-Create only after the applicable remote or local validation succeeds and the
-user reviews tools and visibility:
+Create or edit a connector plugin through the unified write path. Show the
+target and intended change, then continue only after confirmation:
 
 ```bash
-octo-cli marketplace mcp create --data @mcp.json
+octo-cli marketplace plugin upsert --data @plugin.json
 ```
 
-The body is flat: catalog metadata plus `transport`, and either
-`command`/`args`/`env` for stdio or `url`/`headers` for HTTP/SSE. Put every key
-that each consumer must fill locally in `env_user_supplied` or
-`headers_user_supplied`; submit an empty value for those keys instead of a real
-secret. The owner can round-trip submitted values, while non-owner detail reads
-blank them. `category` must be a key returned by `mcp-category list`; `tags` is
-a free-form string array.
+The `--data` body is `{"plugin":{plugin_name, plugin_type:"connector",
+visibility, category_id, tags, manifest_json, plugin_json}}`. The `plugin_json`
+must follow the connector contract: a top-level `connector:{type,source}`
+descriptor plus a root `mcp.json`, with every consumer-filled value written as a
+`${VAR}` placeholder (never a real secret). Set `plugin.plugin_id` to update.
+Validate changed connection fields with `mcp probe` first.
 
-## Update
-
-Updates are partial and do not create versions. Validate changed connection
-fields first, then update only after confirmation:
+Re-read with `plugin get --plugin-id <id>` and verify the `${VAR}` placeholders
+round-trip. Delete only after showing the owned record and confirming:
 
 ```bash
-# HTTP/SSE validation when connection fields changed
-octo-cli marketplace mcp probe --data @connection.json
-
-octo-cli marketplace mcp update <mcp-id> --data @changes.json
+octo-cli marketplace plugin delete --plugin-id <id>
 ```
 
-Category and tag changes use the same `category` key and free-form `tags`
-string array as create.
-
-For stdio connection changes, use the local handshake instead of backend probe.
-When changing `env` or `headers`, update the matching `*_user_supplied` list in
-the same request. Re-read with `marketplace mcp get <mcp-id>` and verify those
-lists round-trip and `quick_start` contains no `version` field. Do not print
-owner-visible secret values.
-
-Use `marketplace mcp delete <mcp-id>` only after showing the selected owned
-record and obtaining explicit confirmation. MCP icon uploads use the presigned
-target from `marketplace mcp-icon-upload create`; after uploading, pass the
-returned persistent icon URL through `mcp create` or `mcp update`.
+Icon upload uses the presigned target from `marketplace mcp-icon-upload create`;
+pass the returned persistent icon URL through `plugin upsert`.

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -1,9 +1,10 @@
 # octo-marketplace — MCP connector workflows
 
-Read `SKILL.md` first for authentication, payload normalization, and the shared
-safety rule. MCP listings are `plugin_type=connector`: no downloadable archive
-or release version. The connection lives in the package's root `mcp.json`
-(standard `{"mcpServers":…}`); user-supplied secret values appear as `${VAR}`
+Read `SKILL.md` first for authentication, payload normalization, versioning, the
+no-separate-publish rule, and the shared safety rule. MCP listings are
+`plugin_type=connector`: no downloadable archive or release version. The
+connection lives in the package's root `mcp.json` (standard
+`{"mcpServers":…}`); user-supplied secret values appear as `${VAR}`
 placeholders, never real secrets.
 
 ## Search and inspect
@@ -17,8 +18,9 @@ octo-cli marketplace plugin get --plugin-id <plugin-id>
 ```
 
 `plugin list` is page-paginated (CLI `.data` + `._pagination`). Filter with
-repeatable `--tag` and `--category-id`. `plugin get` returns the connector
-descriptor (`plugin_json.connector`) plus the root `mcp.json`.
+repeatable `--tag`; `--category-id` is scalar (not repeatable). `plugin get`
+returns the connector descriptor (`plugin_json.connector`) plus the root
+`mcp.json`.
 
 ## Install into an Agent Runtime
 
@@ -41,6 +43,10 @@ For `streamable-http` and `sse`, probe without persisting (retained endpoint):
 octo-cli marketplace mcp probe --data @connection.json
 ```
 
+A newer connector-namespaced alias is also available server-side at
+`POST /api/v1/connectors/_probe`; the `marketplace mcp probe` command targets
+`/mcps/_probe` which the backend retains.
+
 `connection.json` carries only probe fields: `transport`, `url`, `command`,
 `args`, `env`, `headers`. Use empty values for consumer-supplied secrets; do not
 send real secrets just to validate. Continue only when the normalized response
@@ -51,7 +57,9 @@ start the command locally, complete MCP `initialize` and `tools/list`, then stop
 
 ## Create / update
 
-Create or edit a connector plugin through the unified write path. Show the
+Create or edit a connector plugin through the unified write path. Every save is
+a version snapshot and attaches/self-heals the default market placement, so a
+created connector is listable immediately — no follow-up publish step. Show the
 target and intended change, then continue only after confirmation:
 
 ```bash
@@ -59,11 +67,13 @@ octo-cli marketplace plugin upsert --data @plugin.json
 ```
 
 The `--data` body is `{"plugin":{plugin_name, plugin_type:"connector",
-visibility, category_id, tags, manifest_json, plugin_json}}`. The `plugin_json`
-must follow the connector contract: a top-level `connector:{type,source}`
-descriptor plus a root `mcp.json`, with every consumer-filled value written as a
-`${VAR}` placeholder (never a real secret). Set `plugin.plugin_id` to update.
-Validate changed connection fields with `mcp probe` first.
+visibility, category_id, tags, icon, version?, manifest_json, plugin_json}}`.
+Both `manifest_json` and `plugin_json` are required on every write. The
+`plugin_json` must follow the connector contract: a top-level
+`connector:{type,source}` descriptor plus a root `mcp.json`, with every
+consumer-filled value written as a `${VAR}` placeholder (never a real secret).
+Set `plugin.plugin_id` to update; omit to create. Validate changed connection
+fields with `mcp probe` first.
 
 Re-read with `plugin get --plugin-id <id>` and verify the `${VAR}` placeholders
 round-trip. Delete only after showing the owned record and confirming:
@@ -73,4 +83,4 @@ octo-cli marketplace plugin delete --plugin-id <id>
 ```
 
 Icon upload uses the presigned target from `marketplace mcp-icon-upload create`;
-pass the returned persistent icon URL through `plugin upsert`.
+pass the returned persistent icon URL through `plugin upsert`'s `plugin.icon`.

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -1,8 +1,10 @@
 # octo-marketplace — MCP connector workflows
 
-Read `SKILL.md` first for authentication, payload normalization, versioning, the
-no-separate-publish rule, and the shared safety rule. MCP listings are
-`plugin_type=connector`: no downloadable archive or release version. The
+Read `SKILL.md` first for authentication, payload normalization, the
+save→publish/review lifecycle, and the shared safety rule. MCP listings are
+`plugin_type=connector`: there is no downloadable archive. Connectors still
+carry a `current_version`; a missing initial label defaults to `1.0.0`, and
+Space publication/review uses a version label. The
 connection lives in the package's root `mcp.json` (standard
 `{"mcpServers":…}`); user-supplied secret values appear as `${VAR}`
 placeholders, never real secrets.
@@ -57,14 +59,20 @@ start the command locally, complete MCP `initialize` and `tools/list`, then stop
 
 ## Create / update
 
-Create or edit a connector plugin through the unified write path. Every save is
-a version snapshot and attaches/self-heals the default market placement, so a
-created connector is listable immediately — no follow-up publish step. Show the
-target and intended change, then continue only after confirmation:
+Create or edit an **unpublished** connector draft through the unified write
+path. Saving creates a version snapshot but does not publish the draft. An
+already-published Space connector cannot be changed with upsert; submit its new
+manifest/package through `plugin review-request create --data @review.json`
+instead so the live version remains unchanged until approval. Show the target
+and intended change, then continue only after confirmation:
 
 ```bash
 octo-cli marketplace plugin upsert --data @plugin.json
 ```
+
+This workflow covers an MCP connector (`connector.type="mcp"`). The backend also
+supports `openconnector`, `cli`, and `skill-only`, whose descriptors and required
+attachments differ; do not reuse the MCP package shape for those subtypes.
 
 The `--data` body is `{"plugin":{plugin_name, plugin_type:"connector",
 visibility, category_id, tags, icon, version?, manifest_json, plugin_json}}`.
@@ -91,13 +99,23 @@ fields with `mcp probe` first.
 >     "visibility": "space",
 >     "tags": ["vcs", "github"],
 >     "manifest_json": {
->       "plugin_name": "github-mcp",   // == plugin.plugin_name
->       "plugin_type": "connector",    // == plugin.plugin_type
->       "labels": ["vcs", "github"]    // == plugin.tags, same order
+>       "$schema": "cowork-plugin-manifest-2.0.json",
+>       "plugin_name": "github-mcp",
+>       "plugin_type": "connector",
+>       "name": "github-mcp",
+>       "description": "GitHub tools over MCP",
+>       "labels": ["vcs", "github"],
+>       "examples": []
 >     },
 >     "plugin_json": {
->       "connector": { "type": "stdio" },
->       "mcpServers": { "github": { "env": { "TOKEN": "${GITHUB_TOKEN}" } } }
+>       "$schema": "cowork-plugin-package-2.0.json",
+>       "connector": { "type": "mcp", "source": "connector.github-mcp" },
+>       "attachments": [{
+>         "path": "mcp.json",
+>         "content_type": "raw",
+>         "mime_type": "application/json",
+>         "raw_content": "{\"mcpServers\":{\"github\":{\"command\":\"github-mcp-server\",\"env\":{\"TOKEN\":\"${GITHUB_TOKEN}\"}}}}"
+>       }]
 >     }
 >   }
 > }
@@ -111,7 +129,10 @@ fields with `mcp probe` first.
 > Read-modify-write with `plugin get` and resubmit the complete document.
 
 Re-read with `plugin get --plugin-id <id>` and verify the `${VAR}` placeholders
-round-trip. Delete only after showing the owned record and confirming:
+round-trip. Then run `plugin publish --plugin-id <id> --version <x.y.z>`; a
+Space-visible connector enters review, while a private connector lists
+immediately. Follow the review commands in `SKILL.md`. Delete only after showing
+the owned record and confirming:
 
 ```bash
 octo-cli marketplace plugin delete --plugin-id <id>

--- a/skills/octo-marketplace/mcp.md
+++ b/skills/octo-marketplace/mcp.md
@@ -75,6 +75,41 @@ consumer-filled value written as a `${VAR}` placeholder (never a real secret).
 Set `plugin.plugin_id` to update; omit to create. Validate changed connection
 fields with `mcp probe` first.
 
+> **`manifest_json` must agree with the outer `plugin` fields.** The backend
+> rejects the write unless `manifest_json.plugin_name == plugin.plugin_name`,
+> `manifest_json.plugin_type == plugin.plugin_type` (`"connector"`), and
+> `manifest_json.labels == plugin.tags` **in the same order** — compared as
+> canonical JSON arrays, not as sets. Every violation returns the same opaque
+> `400 VALIDATION_ERROR` with `details {"field":"body","reason":"invalid"}`, so
+> check all three before retrying.
+>
+> ```jsonc
+> {
+>   "plugin": {
+>     "plugin_name": "github-mcp",
+>     "plugin_type": "connector",
+>     "visibility": "space",
+>     "tags": ["vcs", "github"],
+>     "manifest_json": {
+>       "plugin_name": "github-mcp",   // == plugin.plugin_name
+>       "plugin_type": "connector",    // == plugin.plugin_type
+>       "labels": ["vcs", "github"]    // == plugin.tags, same order
+>     },
+>     "plugin_json": {
+>       "connector": { "type": "stdio" },
+>       "mcpServers": { "github": { "env": { "TOKEN": "${GITHUB_TOKEN}" } } }
+>     }
+>   }
+> }
+> ```
+
+> **Upsert replaces the row; it does not patch it.** The backend rebuilds the
+> whole plugin from your document, preserving only `created_at`, the version
+> history and the creator identity. An omitted `category_id`, `publisher` or
+> `icon` is accepted as empty and **clears the stored value** — so a
+> "metadata-only" edit that sends just the changed field wipes the others.
+> Read-modify-write with `plugin get` and resubmit the complete document.
+
 Re-read with `plugin get --plugin-id <id>` and verify the `${VAR}` placeholders
 round-trip. Delete only after showing the owned record and confirming:
 

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -1,149 +1,107 @@
 # octo-marketplace — Skill workflows
 
-Read `SKILL.md` first for authentication, payload normalization, and confirmation
-rules.
+Read `SKILL.md` first for authentication, payload normalization, and the shared
+safety rule. Skills are `plugin_type=skill`. A skill package is a **flat
+attachment tree**: `plugin_json.attachments` is the file list, one attachment
+per file (text inline as `raw`, binary as `storage`), always including a root
+`SKILL.md`.
 
 ## Search
 
 ```bash
-octo-cli marketplace skill-category list
-octo-cli marketplace skill tag list --q "<tag>"
-octo-cli marketplace skill list --q "<keywords>" --sort latest --page-size 20
-octo-cli marketplace skill get <skill-id>
+octo-cli marketplace plugin-category list --scene-code default --plugin-type skill
+octo-cli marketplace plugin-tag list --plugin-type skill --q "<tag>"
+octo-cli marketplace plugin list --scene-code default --plugin-type skill \
+  --q "<keywords>" --sort newest --page 1 --page-size 20
+octo-cli marketplace plugin get --plugin-id <plugin-id>
 ```
 
-Search uses cursor pagination: read results from CLI `.data[]` and use
-`--page-all` when all matches are required. Use the immutable `skill_id`, not a
-name. Sort may be `latest`, `comprehensive`, `downloads`, or `views`.
-The category command is non-paginated; normalize it and use each returned
-`skill_category_id` for create, update, or search filters.
+`plugin list` is page-paginated (`{data:[...],pagination}` → CLI `.data` +
+`._pagination`). Add `--mode mine` to list only owned skills. Sort may be
+`newest`/`oldest`/`updated`/`name`/`downloads`/`views`/`comprehensive`. A skill
+has at most 10 tags, each at most 10 characters.
 
-Skill tags are strings normally parsed from `SKILL.md` frontmatter. Use
-`skill tag list` for current-Space and global suggestions; new valid tag values
-may still be submitted when publishing or updating. A Skill may have at most
-10 tags, and each tag may contain at most 10 characters.
+## Read content without downloading
+
+```bash
+octo-cli marketplace plugin skillmd --plugin-id <plugin-id>   # SKILL.md text
+octo-cli marketplace plugin get --plugin-id <plugin-id>       # full attachment tree
+```
+
+`plugin get` returns `plugin_json.attachments`; each entry has `path`,
+`content_type` (`raw`/`storage`), and for text files an inline `raw_content`.
 
 ## Install
 
-Before downloading or modifying the runtime, show the Skill name and version,
-destination Skills root, and whether an existing installation will be replaced.
+Before touching the runtime, show the skill name/version, the destination Skills
+root, and whether an existing install is replaced. After confirmation:
 
-After confirmation:
-
-1. Run `marketplace skill get <skill-id>` and verify name, version, file name,
-   and file size.
-2. Run `marketplace skill download <skill-id> --response-format json`.
-   `--response-format json` is mandatory for this workflow; without it the
-   backend returns an artifact redirect that octo-cli intentionally does not follow.
-3. Normalize the result, then read `download_url` and `file_sha256`. Never infer
-   an artifact URL from metadata or log the short-lived URL.
-4. Download into a new temporary directory and require an exact SHA-256 match.
-5. Reject absolute paths, `..` traversal, links, devices, and entries escaping
-   the extraction directory. The extracted root must contain `SKILL.md`; one
-   wrapping ZIP directory is allowed.
-6. Atomically move the verified directory to `<skills-root>/<skill-name>`.
-7. After successful activation, remove staging and backup directories. On
-   failure, restore the backup before returning the error.
-8. Read the installed `SKILL.md` and follow the runtime's normal reload flow.
+1. `plugin get --plugin-id <id>` — verify name, version, and the attachment list.
+2. `plugin download --plugin-id <id> -o <tmp>/skill.zip` — the backend streams a
+   zip reconstructed from the attachment tree (authenticated; no presigned URL).
+3. Extract into a fresh temp dir. Reject absolute paths, `..` traversal, links,
+   devices, and entries escaping the dir. The root must contain `SKILL.md`; one
+   wrapping directory is allowed.
+4. Atomically move the verified dir to `<skills-root>/<skill-name>`; remove
+   staging on success, restore the backup on failure.
+5. Read the installed `SKILL.md` and follow the runtime's reload flow.
 
 Never execute archive scripts during installation.
 
-## Publish as a Bot
+## Publish as a Bot (upload → parse → import)
 
-The user must first provide a `.zip` / `.skill` package, or an accessible Skill
-directory. Do not search the machine, guess a path, explain Skill loading,
-repeat the prompt, or narrate checks step by step.
+The user must provide a `.zip`/`.skill` package or an accessible skill directory.
+Do not search the machine or guess a path.
 
-1. For a directory, copy it into a fresh `mktemp -d` staging directory and
-   package the copy. Never modify the source directory or use a fixed temporary
-   path. Exclude `.git`, `.github`, caches, dependencies, and build output; keep
-   `SKILL.md`, referenced files, README, and LICENSE. If `version` is absent,
-   use `1.0.0` and write it only to the staged `SKILL.md`.
-2. Inspect the package without executing it. Read the root `SKILL.md` and obtain
-   its `name`, `version`, optional `id`, byte size, and SHA-256. Reject an unsafe
-   archive using the same path, link, and size checks required for installation.
-3. Run `marketplace skill mine list --q <name> --page-all`, then compare exact
-   names. This owned-Space lookup is authoritative for the backend uniqueness
-   scope; do not use the public search result for duplicate detection.
-4. Choose exactly one flow:
-   - No exact owned name: continue with the create flow below. An existing
-     package `id` represents its source and the server will publish a new Skill
-     with a new ID and `forked_from` metadata.
-   - Exact owned name and package `id` equals that Skill's `skill_id`: stop the
-     create flow and follow **Update ZIP version** below.
-   - Exact owned name but the package has no `id`, or its `id` differs: report a
-     name conflict and ask the user to rename the package or stop. Never guess
-     that this is an update and never overwrite the existing Skill.
-5. Run `marketplace skill-category list`, resolve the intended category, then
-   show one final plan containing the package path, name, version, size,
-   SHA-256, create/update decision, visibility, and category. Ask for one final
-   confirmation; do not initialize or upload before it.
-6. Initialize with `marketplace skill-upload create --file-name <file>
-   --file-size <bytes>`, then upload to its `presigned_url` using the returned
-   HTTP `method` and `headers`.
-7. Publish once with `marketplace skill publish --skill-upload-id <id>
-   --visibility <visibility>` plus reviewed optional metadata. This endpoint
-   synchronously parses and creates the Skill; do not call `skill-upload parse`,
-   poll `skill-parse-task`, or call `skill create` in the normal Bot flow.
-8. Read the returned `skill_id`, then run `marketplace skill get <skill-id>` to
-   verify the name, version, creator, visibility, and current version.
-
-Optional metadata may override parsed values, including `category_id` and a
-JSON string array `tags`, but do not silently replace a package version. Only
-default a missing version to `1.0.0`.
-
-`skill create` is intentionally hidden from octo-cli because it records a human
-publisher and is reserved for the Web workflow. `skill-upload parse` and
-`skill-parse-task get` remain available for diagnosis, but they are not an
-alternative Agent workflow. Bots must publish with `skill publish`.
-If parsing returns `RATE_LIMITED`, wait and retry within the user's timeout. If
-Bot publish returns a gateway timeout, query `skill mine list` before retrying
-so an already-created Skill is never duplicated.
-
-## Update metadata
-
-Metadata-only changes do not create a release:
-
-```bash
-octo-cli marketplace skill update <skill-id> --data \
-  '{"display_name":"New title","description":"New description","category_id":"<id>","tags":["automation","cli"]}'
-```
-
-Resolve `category_id` through `skill-category list`. Tags remain free-form
-strings and need no dictionary lookup.
-
-## Update ZIP version
-
-Only enter this flow after exact-name lookup identifies an owned Skill and the
-package `id` equals its `skill_id`. A missing or different package ID is not
-enough evidence to update an existing record.
-
-1. Require the parsed package version to differ from the current version.
-2. Initialize with `marketplace skill reupload create <skill-id>` plus the new
-   ZIP's `file_name` and `file_size`.
-3. Upload to the returned presigned target.
-4. Trigger and poll parsing with `skill-upload parse` and
-   `skill-parse-task get`.
-5. Show the new version, changelog, file size, and SHA-256 and request
+1. For a directory, copy into a fresh `mktemp -d` and package the copy (exclude
+   `.git`, caches, build output; keep `SKILL.md`, referenced files, README,
+   LICENSE). Default a missing `version` to `1.0.0` in the staged `SKILL.md`.
+2. Inspect without executing; read `name`/`version` from the root `SKILL.md`.
+3. Check ownership: `plugin list --scene-code default --plugin-type skill
+   --mode mine --q <name>`, compare exact names. Decide create vs. update.
+4. Show the final plan (path, name, version, visibility, category) and get one
    confirmation.
-6. Apply the release with `marketplace skill update <skill-id>` using
-   `parse_task_id`, `version`, and `changelog`.
-7. Run `marketplace skill version list <skill-id>`, normalize the response, and
-   read releases from `payload.items`.
+5. Presign + upload + parse + import:
 
-If create returns `DUPLICATE_NAME` after exact owned-name lookup found no live
-record, report that a soft-deleted Skill may still reserve the name. Do not
-retry, auto-rename, or switch to update without user direction.
+   ```bash
+   octo-cli marketplace skill-upload create --file-name "<file>.zip" --file-size <bytes>
+   # PUT the bytes to the returned presigned_url with its method/headers
+   octo-cli marketplace skill-upload parse <skill_upload_id>
+   octo-cli marketplace skill-parse-task get <parse_task_id>   # poll until success
+   octo-cli marketplace plugin import --parse-task-id <parse_task_id> \
+     --name "<name>" --visibility space --version 1.0.0
+   ```
 
-## Manage owned Skills
+   `plugin import` builds the attachment tree server-side. Omit `--plugin-id` to
+   create; set it to update an existing owned skill. Optional `--category-id`,
+   `--tags`, `--icon`, `--changelog`.
+6. Read the returned `plugin_id`, then `plugin get --plugin-id <id>` to verify.
 
-Use `marketplace skill mine list` to resolve owned records before update or
-delete. Deletion is a confirmed destructive action:
+If parse returns `RATE_LIMITED`, wait and retry within the user's timeout. If
+import returns a gateway timeout, re-check `plugin list --mode mine` before
+retrying so a created skill is never duplicated.
+
+## Release a new version
+
+A published skill version is immutable:
 
 ```bash
-octo-cli marketplace skill delete <skill-id>
+octo-cli marketplace plugin publish --plugin-id <id> --version 1.1.0 --changelog "…"
+octo-cli marketplace plugin version list --plugin-id <id>
 ```
 
-Use `marketplace skill skillmd get <skill-id>` when the current raw `SKILL.md`
-is needed without downloading the full package. Skill icon upload is a
-presigned flow initialized by `marketplace skill-icon-upload create`.
+To ship new content in that version, first re-run the upload/parse pipeline for
+the new package and `plugin import --plugin-id <id> --parse-task-id <id>
+--version 1.1.0`, then confirm.
+
+## Update metadata / manage owned skills
+
+Metadata-only edits reuse `plugin import` with the existing `--plugin-id` and no
+version bump, or `plugin upsert` for advanced edits. Deletion is destructive and
+confirmed:
+
+```bash
+octo-cli marketplace plugin delete --plugin-id <id>
+```
+
+Skill icon upload is a presigned flow: `marketplace skill-icon-upload create`.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -1,7 +1,7 @@
 # octo-marketplace — Skill workflows
 
-Read `SKILL.md` first for authentication, payload normalization, versioning, the
-no-separate-publish rule, and the shared safety rule. Skills are
+Read `SKILL.md` first for authentication, payload normalization, the
+save→publish/review lifecycle, and the shared safety rule. Skills are
 `plugin_type=skill`. A skill package is a **flat attachment tree**:
 `plugin_json.attachments` is the file list, one attachment per file (text inline
 as `raw`, binary as `storage`), always including a root `SKILL.md`.
@@ -19,8 +19,8 @@ octo-cli marketplace plugin get --plugin-id <plugin-id>
 `plugin list` is page-paginated (`{data:[...],pagination}` → CLI `.data` +
 `._pagination`). Add `--mode mine` to list only owned skills. Sort may be
 `newest`/`oldest`/`updated`/`name`/`placement`/`downloads`/`views`/
-`installs`/`comprehensive`. A skill has at most 10 tags, each at most 10
-characters.
+`installs`/`comprehensive`. A plugin has at most 100 tags; each tag is non-empty
+UTF-8 and at most 128 bytes.
 
 ## Read content without downloading
 
@@ -78,28 +78,58 @@ Do not search the machine or guess a path.
      --name "<name>" --visibility space --version 1.0.0
    ```
 
-   `plugin import` finalizes through the unified write path: it builds the
-   attachment tree server-side, snapshots a new version, and attaches the
-   default market placement so the skill is immediately listable. Omit
+   `plugin import` builds the attachment tree and saves a draft version. Omit
    `--plugin-id` to create; set it to update an existing owned skill. Optional
    `--category-id`, `--tags`, `--icon`, `--changelog`.
-6. Read the returned `plugin_id`, then `plugin get --plugin-id <id>` to verify.
+6. Read the returned `plugin_id`, then `plugin get --plugin-id <plugin-id>` to
+   verify the draft.
+7. Publish explicitly:
+
+   ```bash
+   octo-cli marketplace plugin publish --plugin-id <plugin-id> \
+     --version 1.0.0 --changelog "Initial release"
+   ```
+
+   A Space-visible skill returns `pending_review` plus a `review_id`; it becomes
+   catalog-visible only after a Space owner/admin approves that request.
 
 If parse returns `RATE_LIMITED`, wait and retry within the user's timeout. Parse
 itself is not idempotent: re-triggering an already-parsed upload returns `409
 CONFLICT` rather than the original task, so poll `skill-parse-task get` instead
-of re-posting. If import returns a gateway timeout or RESULT_UNKNOWN, re-check
-`plugin list --scene-code default --plugin-type skill --mode mine --q <name>`,
-walking `--page` until a short page as in step 3, before retrying so a created
-skill is never duplicated.
+of re-posting. If a create import returns a gateway timeout or RESULT_UNKNOWN,
+re-check `plugin list --scene-code default --plugin-type skill --mode mine --q
+<name>`, walking every page before retrying so the skill is never duplicated. If
+an existing-id import is ambiguous, use `plugin get`, version history, hashes,
+and content comparison instead—the row existed before the request, so finding it
+does not prove the update committed.
 
 ## Release a new version
 
-Every save is a version snapshot. To ship new content, re-run the upload / parse
-pipeline for the new package and `plugin import --plugin-id <id>
---parse-task-id <id> --version <new-version> --changelog "…"` — that is what
-creates the new snapshot and bumps `current_version`. There is no separate
-"publish" step.
+First inspect `display_status` with `plugin get`:
+
+- For an unpublished draft, re-run upload/parse and update it with `plugin
+  import --plugin-id <plugin-id> --parse-task-id <parse-task-id> ...`, then run
+  `plugin publish` as in the initial flow.
+- For an already-published Space skill, **do not call import or upsert**: direct
+  edits are rejected so live content cannot bypass review. Upload and parse the
+  new archive, then submit that fresh parse task as the frozen upgrade:
+
+```bash
+cat >review.json <<'JSON'
+{
+  "plugin_id": "<plugin-id>",
+  "version": "<new-version>",
+  "changelog": "What changed",
+  "parse_task_id": "<parse-task-id>"
+}
+JSON
+octo-cli marketplace plugin review-request create --data @review.json
+```
+
+Keep `<plugin-id>` and `<parse-task-id>` distinct. The published version remains
+live until a Space owner/admin approves the request. Version labels must be
+forward-moving `MAJOR.MINOR.PATCH` values; if review is rejected, correct the
+content and submit another review request.
 
 ```bash
 octo-cli marketplace plugin version list --plugin-id <id>
@@ -107,8 +137,11 @@ octo-cli marketplace plugin version list --plugin-id <id>
 
 ## Update metadata / manage owned skills
 
-Metadata-only edits (name, category, tags, icon, visibility, version label) go
-through `plugin upsert` with the existing `plugin.plugin_id` in the document.
+Metadata edits on a draft, delisted plugin, or published-private plugin go
+through `plugin upsert` with the existing `plugin.plugin_id`. A published Space
+plugin rejects direct metadata edits. Because review snapshots content rather
+than arbitrary market metadata, a Space owner/admin must delist it first; then
+the owner may edit and publish it for review again.
 `plugin import` is **not** a metadata-only path: its `--parse-task-id` is
 required, so reusing it always means a fresh upload+parse cycle to ship new
 package content.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -1,10 +1,10 @@
 # octo-marketplace — Skill workflows
 
-Read `SKILL.md` first for authentication, payload normalization, and the shared
-safety rule. Skills are `plugin_type=skill`. A skill package is a **flat
-attachment tree**: `plugin_json.attachments` is the file list, one attachment
-per file (text inline as `raw`, binary as `storage`), always including a root
-`SKILL.md`.
+Read `SKILL.md` first for authentication, payload normalization, versioning, the
+no-separate-publish rule, and the shared safety rule. Skills are
+`plugin_type=skill`. A skill package is a **flat attachment tree**:
+`plugin_json.attachments` is the file list, one attachment per file (text inline
+as `raw`, binary as `storage`), always including a root `SKILL.md`.
 
 ## Search
 
@@ -18,8 +18,9 @@ octo-cli marketplace plugin get --plugin-id <plugin-id>
 
 `plugin list` is page-paginated (`{data:[...],pagination}` → CLI `.data` +
 `._pagination`). Add `--mode mine` to list only owned skills. Sort may be
-`newest`/`oldest`/`updated`/`name`/`downloads`/`views`/`comprehensive`. A skill
-has at most 10 tags, each at most 10 characters.
+`newest`/`oldest`/`updated`/`name`/`placement`/`downloads`/`views`/
+`installs`/`comprehensive`. A skill has at most 10 tags, each at most 10
+characters.
 
 ## Read content without downloading
 
@@ -57,8 +58,7 @@ Do not search the machine or guess a path.
    `.git`, caches, build output; keep `SKILL.md`, referenced files, README,
    LICENSE). Default a missing `version` to `1.0.0` in the staged `SKILL.md`.
 2. Inspect without executing; read `name`/`version` from the root `SKILL.md`.
-3. Check ownership: `plugin list --scene-code default --plugin-type skill
-   --mode mine --q <name>`, compare exact names. Decide create vs. update.
+3. Check ownership: `plugin list --scene-code default --plugin-type skill --mode mine --q <name>`, compare exact names. Decide create vs. update.
 4. Show the final plan (path, name, version, visibility, category) and get one
    confirmation.
 5. Presign + upload + parse + import:
@@ -72,39 +72,48 @@ Do not search the machine or guess a path.
      --name "<name>" --visibility space --version 1.0.0
    ```
 
-   `plugin import` builds the attachment tree server-side. Omit `--plugin-id` to
-   create; set it to update an existing owned skill. Optional `--category-id`,
-   `--tags`, `--icon`, `--changelog`.
+   `plugin import` finalizes through the unified write path: it builds the
+   attachment tree server-side, snapshots a new version, and attaches the
+   default market placement so the skill is immediately listable. Omit
+   `--plugin-id` to create; set it to update an existing owned skill. Optional
+   `--category-id`, `--tags`, `--icon`, `--changelog`.
 6. Read the returned `plugin_id`, then `plugin get --plugin-id <id>` to verify.
 
 If parse returns `RATE_LIMITED`, wait and retry within the user's timeout. If
-import returns a gateway timeout, re-check `plugin list --mode mine` before
+import returns a gateway timeout or RESULT_UNKNOWN, re-check `plugin list --scene-code default --plugin-type skill --mode mine --q <name>` before
 retrying so a created skill is never duplicated.
 
 ## Release a new version
 
-A published skill version is immutable:
+Every save is a version snapshot. To ship new content, re-run the upload / parse
+pipeline for the new package and `plugin import --plugin-id <id>
+--parse-task-id <id> --version <new-version> --changelog "…"` — that is what
+creates the new snapshot and bumps `current_version`. There is no separate
+"publish" step.
 
 ```bash
-octo-cli marketplace plugin publish --plugin-id <id> --version 1.1.0 --changelog "…"
 octo-cli marketplace plugin version list --plugin-id <id>
 ```
 
-To ship new content in that version, first re-run the upload/parse pipeline for
-the new package and `plugin import --plugin-id <id> --parse-task-id <id>
---version 1.1.0`, then confirm.
-
 ## Update metadata / manage owned skills
 
-Metadata-only edits (name, category, tags, icon, visibility) go through `plugin
-upsert` with the existing `plugin_id` in the document — pass the full plugin
-write document with `--data`. `plugin import` is **not** a metadata-only path:
-its `--parse-task-id` is required, so reusing it always means a fresh
-upload+parse cycle to ship new package content. Deletion is destructive and
-confirmed:
+Metadata-only edits (name, category, tags, icon, visibility, version label) go
+through `plugin upsert` with the existing `plugin.plugin_id` in the document —
+pass the full plugin write document with `--data`, including the existing
+`manifest_json` and `plugin_json` (the backend rejects an upsert that omits
+either). `plugin import` is **not** a metadata-only path: its `--parse-task-id`
+is required, so reusing it always means a fresh upload+parse cycle to ship new
+package content.
+
+Deletion is destructive and confirmed:
 
 ```bash
 octo-cli marketplace plugin delete --plugin-id <id>
 ```
+
+> **Relations and expert/team edits:** every upsert replaces the relation set.
+> When updating an `expert` or `expert_team` that carries relations, always
+> resubmit the complete list — omitting the `relations` key soft-deletes all
+> relations on save.
 
 Skill icon upload is a presigned flow: `marketplace skill-icon-upload create`.

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -58,7 +58,13 @@ Do not search the machine or guess a path.
    `.git`, caches, build output; keep `SKILL.md`, referenced files, README,
    LICENSE). Default a missing `version` to `1.0.0` in the staged `SKILL.md`.
 2. Inspect without executing; read `name`/`version` from the root `SKILL.md`.
-3. Check ownership: `plugin list --scene-code default --plugin-type skill --mode mine --q <name>`, compare exact names. Decide create vs. update.
+3. Check ownership exhaustively: `plugin list --scene-code default --plugin-type
+   skill --mode mine --q <name> --page 1`, then walk `--page` until a short page
+   (there is no `--page-all`, and the default page size is 20). `--q` is a
+   substring match against `plugin_name` only — not the display name set by
+   `--name` — so search the registry name and compare exact names across every
+   page. Checking only page 1 when the owner has more than 20 keyword matches
+   reports a false "no match" and creates a duplicate. Decide create vs. update.
 4. Show the final plan (path, name, version, visibility, category) and get one
    confirmation.
 5. Presign + upload + parse + import:
@@ -79,9 +85,13 @@ Do not search the machine or guess a path.
    `--category-id`, `--tags`, `--icon`, `--changelog`.
 6. Read the returned `plugin_id`, then `plugin get --plugin-id <id>` to verify.
 
-If parse returns `RATE_LIMITED`, wait and retry within the user's timeout. If
-import returns a gateway timeout or RESULT_UNKNOWN, re-check `plugin list --scene-code default --plugin-type skill --mode mine --q <name>` before
-retrying so a created skill is never duplicated.
+If parse returns `RATE_LIMITED`, wait and retry within the user's timeout. Parse
+itself is not idempotent: re-triggering an already-parsed upload returns `409
+CONFLICT` rather than the original task, so poll `skill-parse-task get` instead
+of re-posting. If import returns a gateway timeout or RESULT_UNKNOWN, re-check
+`plugin list --scene-code default --plugin-type skill --mode mine --q <name>`,
+walking `--page` until a short page as in step 3, before retrying so a created
+skill is never duplicated.
 
 ## Release a new version
 
@@ -98,12 +108,24 @@ octo-cli marketplace plugin version list --plugin-id <id>
 ## Update metadata / manage owned skills
 
 Metadata-only edits (name, category, tags, icon, visibility, version label) go
-through `plugin upsert` with the existing `plugin.plugin_id` in the document —
-pass the full plugin write document with `--data`, including the existing
-`manifest_json` and `plugin_json` (the backend rejects an upsert that omits
-either). `plugin import` is **not** a metadata-only path: its `--parse-task-id`
-is required, so reusing it always means a fresh upload+parse cycle to ship new
+through `plugin upsert` with the existing `plugin.plugin_id` in the document.
+`plugin import` is **not** a metadata-only path: its `--parse-task-id` is
+required, so reusing it always means a fresh upload+parse cycle to ship new
 package content.
+
+> **`plugin upsert` replaces the row; it does not patch it.** There is no
+> metadata-only PATCH on this API. The backend rebuilds the whole plugin from
+> your document, keeping only `created_at`, the version history and the creator
+> identity. An omitted `category_id`, `publisher` or `icon` is accepted as empty
+> and **clears the stored value** — editing one field by sending only that field
+> silently wipes the rest. Always read-modify-write: `plugin get --plugin-id
+> <id>` first, rebuild the full write document from what it returns (the read
+> shape is flat; the write shape is `{"plugin":{...},"relations":[...]}`), change
+> the one field, and send the whole document via `--data @plugin.json`.
+> `manifest_json` and `plugin_json` are required on every write, and
+> `manifest_json` must agree with the outer fields (see the invariant in
+> `expert.md`). Note `plugin import` behaves the *opposite* way — omitted fields
+> there fall back to the existing row — so do not carry habits between the two.
 
 Deletion is destructive and confirmed:
 

--- a/skills/octo-marketplace/skills.md
+++ b/skills/octo-marketplace/skills.md
@@ -96,8 +96,11 @@ the new package and `plugin import --plugin-id <id> --parse-task-id <id>
 
 ## Update metadata / manage owned skills
 
-Metadata-only edits reuse `plugin import` with the existing `--plugin-id` and no
-version bump, or `plugin upsert` for advanced edits. Deletion is destructive and
+Metadata-only edits (name, category, tags, icon, visibility) go through `plugin
+upsert` with the existing `plugin_id` in the document — pass the full plugin
+write document with `--data`. `plugin import` is **not** a metadata-only path:
+its `--parse-task-id` is required, so reusing it always means a fresh
+upload+parse cycle to ship new package content. Deletion is destructive and
 confirmed:
 
 ```bash

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -168,34 +168,26 @@ func TestOctoMarketplaceExpertReferenceDocumentsFlow(t *testing.T) {
 	}
 	content := string(b)
 	for _, want := range []string{
-		"marketplace expert list",
-		"marketplace expert get <expert-id>",
-		"marketplace expert create",
-		"marketplace expert update <expert-id>",
-		"marketplace expert delete <expert-id>",
-		"marketplace squad",
-		"marketplace expert-category list",
-		"marketplace expert-tag list",
-		"marketplace expert-skill-upload create",
-		"marketplace expert skill-download <expert-id> --index",
-		"marketplace squad skill-download <squad-id> --member",
-		"upload_object_key",
-		"--page-all` does **not** apply", // offset pagination, distinct from skill/mcp
-		// List responses are flattened by the output layer: items at .data,
-		// pagination at ._pagination. The docs must NOT tell readers to use
-		// `.data.data // .data` on a list (that indexes an array and errors).
-		// Match on the claim, not on where the paragraph happens to wrap.
-		"items are at",
-		"pagination metadata is at `._pagination`",
-		"NOT apply the `.data.data // .data` normalization here",
+		"--plugin-type expert",
+		"--plugin-type expert_team",
+		"plugin get --plugin-id <plugin-id> --include-relations",
+		"plugin upsert",
+		"plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>",
+		"plugin delete --plugin-id <id>",
+		"plugin publish --plugin-id",
+		"AGENTS.md",                    // expert instruction / team collaboration doc
+		"expert_skill",                 // member skills are relations
+		"CLI `.data` + `._pagination`", // list flattening, not .data.data
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("expert workflow must document %q", want)
 		}
 	}
-	// The package upload must presign before it is referenced in create/update.
-	if strings.Index(content, "expert-skill-upload create") > strings.Index(content, `"upload_object_key": "expert-uploads`) {
-		t.Error("presign step must precede referencing upload_object_key in a create/update body")
+	// The legacy per-type surface must be gone from the doc.
+	for _, gone := range []string{"marketplace expert list", "expert-skill-upload", "skill-download", "upload_object_key"} {
+		if strings.Contains(content, gone) {
+			t.Errorf("expert workflow must not reference the retired %q surface", gone)
+		}
 	}
 }
 
@@ -259,24 +251,28 @@ func TestOctoMarketplacePublishFlowChecksOwnedNameBeforeMutation(t *testing.T) {
 	}
 	content := string(b)
 	for _, want := range []string{
-		"or an accessible Skill",
+		"or an accessible skill directory",
 		"mktemp -d",
-		"Never modify the source directory",
-		"skill mine list --q <name> --page-all",
-		"package `id` equals that Skill's `skill_id`",
-		"name conflict",
-		"soft-deleted Skill may still reserve the name",
-		"do not initialize or upload before it",
+		"--mode mine --q <name>", // owned-name lookup on the unified list
+		"skill-upload create --file-name",
+		"skill-upload parse <skill_upload_id>",
+		"skill-parse-task get <parse_task_id>",
+		"plugin import --parse-task-id",
+		"never duplicated",
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("publish workflow must contain %q", want)
 		}
 	}
-	if strings.Index(content, "skill mine list --q <name> --page-all") > strings.Index(content, "skill-upload create --file-name") {
+	// The owned-name ownership check must precede upload initialization.
+	if strings.Index(content, "--mode mine --q <name>") > strings.Index(content, "skill-upload create --file-name") {
 		t.Error("owned-name lookup must happen before upload initialization")
 	}
-	if strings.Index(content, "skill-category list") > strings.Index(content, "one final plan") {
-		t.Error("category lookup must happen before the final confirmation plan")
+	// The retired synchronous publish path must be gone.
+	for _, gone := range []string{"skill publish --skill-upload-id", "skill mine list", "download_url"} {
+		if strings.Contains(content, gone) {
+			t.Errorf("skills workflow must not reference the retired %q surface", gone)
+		}
 	}
 }
 

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -174,7 +174,7 @@ func TestOctoMarketplaceExpertReferenceDocumentsFlow(t *testing.T) {
 		"plugin upsert",
 		"plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>",
 		"plugin delete --plugin-id <id>",
-		"plugin publish --plugin-id",
+		"plugin version list",         // version snapshots live behind version list
 		"AGENTS.md",                    // expert instruction / team collaboration doc
 		"expert_skill",                 // member skills are relations
 		"CLI `.data` + `._pagination`", // list flattening, not .data.data
@@ -268,8 +268,10 @@ func TestOctoMarketplacePublishFlowChecksOwnedNameBeforeMutation(t *testing.T) {
 	if strings.Index(content, "--mode mine --q <name>") > strings.Index(content, "skill-upload create --file-name") {
 		t.Error("owned-name lookup must happen before upload initialization")
 	}
-	// The retired synchronous publish path must be gone.
-	for _, gone := range []string{"skill publish --skill-upload-id", "skill mine list", "download_url"} {
+	// The retired synchronous publish path and the unified plugin.publish op
+	// (removed from the backend in refactor "drop formal publish; every save is
+	// a version snapshot") must both be gone from the workflow docs.
+	for _, gone := range []string{"skill publish --skill-upload-id", "skill mine list", "download_url", "plugin publish --plugin-id"} {
 		if strings.Contains(content, gone) {
 			t.Errorf("skills workflow must not reference the retired %q surface", gone)
 		}

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -174,7 +174,7 @@ func TestOctoMarketplaceExpertReferenceDocumentsFlow(t *testing.T) {
 		"plugin upsert",
 		"plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>",
 		"plugin delete --plugin-id <id>",
-		"plugin version list",         // version snapshots live behind version list
+		"plugin version list",          // version snapshots live behind version list
 		"AGENTS.md",                    // expert instruction / team collaboration doc
 		"expert_skill",                 // member skills are relations
 		"CLI `.data` + `._pagination`", // list flattening, not .data.data

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -175,6 +175,8 @@ func TestOctoMarketplaceExpertReferenceDocumentsFlow(t *testing.T) {
 		"plugin install --plugin-id <id> --workspace-id <ws> --runtime-id <rt>",
 		"plugin delete --plugin-id <id>",
 		"plugin version list",          // version snapshots live behind version list
+		"plugin publish --plugin-id",   // saving a draft does not publish it
+		"plugin review-request create", // declared-content upgrade review
 		"AGENTS.md",                    // expert instruction / team collaboration doc
 		"expert_skill",                 // member skills are relations
 		"CLI `.data` + `._pagination`", // list flattening, not .data.data
@@ -258,6 +260,9 @@ func TestOctoMarketplacePublishFlowChecksOwnedNameBeforeMutation(t *testing.T) {
 		"skill-upload parse <skill_upload_id>",
 		"skill-parse-task get <parse_task_id>",
 		"plugin import --parse-task-id",
+		"plugin publish --plugin-id <plugin-id>",
+		"--parse-task-id <parse-task-id>",
+		"plugin review-request create --data @review.json",
 		"never duplicated",
 	} {
 		if !strings.Contains(content, want) {
@@ -268,10 +273,9 @@ func TestOctoMarketplacePublishFlowChecksOwnedNameBeforeMutation(t *testing.T) {
 	if strings.Index(content, "--mode mine --q <name>") > strings.Index(content, "skill-upload create --file-name") {
 		t.Error("owned-name lookup must happen before upload initialization")
 	}
-	// The retired synchronous publish path and the unified plugin.publish op
-	// (removed from the backend in refactor "drop formal publish; every save is
-	// a version snapshot") must both be gone from the workflow docs.
-	for _, gone := range []string{"skill publish --skill-upload-id", "skill mine list", "download_url", "plugin publish --plugin-id"} {
+	// Retired per-type commands and presigned-download wording must stay gone;
+	// publication now uses the unified plugin.publish operation above.
+	for _, gone := range []string{"skill publish --skill-upload-id", "skill mine list", "download_url"} {
 		if strings.Contains(content, gone) {
 			t.Errorf("skills workflow must not reference the retired %q surface", gone)
 		}


### PR DESCRIPTION
## Summary

Migrate the Marketplace CLI from the retired per-type endpoints to the unified `/plugins/*` API, then align it with the latest review-aware publishing lifecycle from `octo-marketplace` `upstream/main@50a1be3`.

The command surface now has 25 Marketplace operations, including explicit publish/delist and the complete review-request workflow. The metadata-driven engine also supports the backend's conditional `plugin_type` requirement and opt-in strict request-schema validation.

## Linked Spec

N/A — this repository has no matching `.octospec/tasks/*/brief.md` or linked GitHub issue. The implementation contract is the pinned `octo-marketplace` backend API at `upstream/main@50a1be3`; PR #142 is the change-tracking context.

## Changes

- Replace the legacy Skill/MCP/Expert/Squad command families with the unified `marketplace plugin` surface.
- Add `plugin publish`, `plugin delist`, and `plugin review-request create|list|get|approve|reject|cancel`.
- Let `plugin list --mode mine` omit `--plugin-type`, while catalog listings continue to require it.
- Add `x-octo-required-unless-query` and `x-octo-strict-request-schema` support to the generic registry/validation path.
- Enforce fixed-shape Marketplace write documents, nested enums, Unicode length limits, and relation count limits without narrowing intentionally opaque JSON payloads or tolerant review decoders.
- Document draft, private publication, Space review, delist, published-upgrade, retry-recovery, and relation ownership semantics.
- Update operation counts, command-tree tests, route/body/query assertions, enum provenance, and skill documentation contracts.

## How verified

- `go test ./... -count=1`
- `go vet ./...`
- `go build ./...`
- `python3 -m json.tool internal/registry/specs/marketplace.json`
- `git diff --check`
- Compared all 25 CLI method/path pairs against `octo-marketplace` `upstream/main@50a1be3`; no missing upstream route.
- Adversarially reviewed the generic validation engine, Marketplace OpenAPI metadata, and all four Marketplace skill documents.

## COMPREHENSION

### 1. What does this change actually do to the load-bearing path?

Before this change, the embedded Marketplace spec exposed only the earlier unified save/import surface and modeled `plugin_type` as unconditionally required. The backend now separates saving from publication: private publication lists immediately, Space publication freezes a review request, published Space upgrades must submit frozen content directly for review, and owners/admins have distinct delist/review actions.

After this change, the embedded spec generates that lifecycle directly. The generic engine can express a query parameter that is required unless another query has a specific value, and Marketplace opts into deeper fixed-schema validation. Existing services retain their historical validation behavior unless they explicitly opt in.

### 2. What could break because of it?

The shared registry loader and request validator serve every generated command. An overly broad strictness change could reject requests accepted by legacy services; malformed conditional metadata could silently remove a required-field guard; and closing opaque Marketplace documents could block forward-compatible payloads. The implementation therefore makes strict validation opt-in, validates conditional metadata at registry load, limits conditional peers to strings, leaves manifest/package/relation data open, and does not locally enforce state-dependent version patterns.

The Marketplace-specific risks are lifecycle mistakes: directly editing a published Space plugin, treating private publication as Space visibility, or retrying a mutation with an unknown outcome. The spec tests and agent docs pin the correct branches and recovery reads.

### 3. How do you know it works?

Tests execute the real embedded registry and generated Cobra tree against HTTP stubs. They pin all 25 method/path pairs, command generation, conditional requiredness in both directions (including an explicitly empty dependent flag), request bodies, enum vocabularies, strict unknown-field rejection where supported, grandfathered version forwarding, and publication/review requests. Malformed conditional extension forms are rejected directly in loader tests. The full Go test, vet, build, JSON parse, and diff-whitespace checks pass, and every route was cross-checked against the pinned backend checkout.

## Checklist

- [x] Conventional commits used
- [x] Code, comments, and documentation are in English
- [x] Agent-facing docs and `CLAUDE.md` command inventory are updated
- [x] New behavior has tests
- [x] No unrelated changes or credentials included
