### PR TITLE
feat(docs): support Space-qualified members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--role` flags front the `shareScope` / `shareRole` wire keys.
 
 ### Changed
+- **`octo-cli docs members remove` now requires `--principal-space-id`** — Bot
+  membership deletion is an exact Space-qualified mutation. Requiring the
+  principal Space prevents an ambiguous uid from deleting the wrong row when
+  the same uid has memberships in multiple Spaces.
 - **`octo-cli html` adopts canonical create and document references** — create
   omits `slug`; the CLI generates `idempotency_key` once per invocation and
   reuses it across transport retries (an explicit key remains supported). It returns `data.doc_id` plus

--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ octo-cli docs export doc-123 --export-format pdf -o ./notes.pdf
 octo-cli docs scene export board-7 --image-format excalidraw -o ./board.excalidraw
 octo-cli docs comments add board-7 --body "Review this" --point 120,240
 # For --element-id anchors, dry-run still reads the live board scene to resolve geometry.
-octo-cli docs members set doc-123 --data '{"uid":"u-1","role":"writer"}'
+octo-cli docs members set doc-123 --uid u-1 --role writer
+# Member mutations are Space-qualified. Set defaults to the authenticated Bot
+# Space when omitted; removal always requires the exact principal Space.
+octo-cli docs members set doc-123 --uid u-1 --role writer --principal-space-id space-2
+octo-cli docs members remove doc-123 u-1 --principal-space-id space-2
 
 # Fleet/Loop uses the same gateway under /fleet/api/v1.
 octo-cli loop task list --workspace-id <workspace-id>

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -122,6 +122,86 @@ func TestDocs_RegistryShape(t *testing.T) {
 			t.Errorf("%s: first segment must be the service; got %q", id, segs[0])
 		}
 	}
+
+	list, ok := reg.GetOperation("docs.members.list")
+	if !ok || list.ResponseSchema == nil {
+		t.Fatal("docs.members.list response schema missing")
+	}
+	items, ok := list.ResponseSchema.Properties["items"]
+	if !ok || items.Items == nil {
+		t.Fatalf("docs.members.list items schema = %#v, want array item schema", items)
+	}
+	principalSpaceID, ok := items.Items.Properties["principalSpaceId"]
+	if !ok || principalSpaceID.Type != "string" {
+		t.Fatalf("docs.members.list item principalSpaceId = %#v, want string", principalSpaceID)
+	}
+}
+
+func TestDocsMembersSet_PrincipalSpaceIDIsOptionalBodyField(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantSpace string
+	}{
+		{name: "defaults to authenticated Bot Space", args: []string{"docs", "members", "set", "doc-1", "--uid", "user-1", "--role", "writer"}},
+		{name: "sends explicit principal Space", args: []string{"docs", "members", "set", "doc-1", "--uid", "user-1", "--role", "writer", "--principal-space-id", "space-2"}, wantSpace: "space-2"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var body map[string]any
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatalf("decode body: %v", err)
+				}
+				_, _ = w.Write([]byte(`{"ok":true}`))
+			})
+			root.SetArgs(tc.args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			got, present := body["principalSpaceId"]
+			if tc.wantSpace == "" {
+				if present {
+					t.Fatalf("omitted --principal-space-id must leave Bot Space resolution to the backend: %v", body)
+				}
+				return
+			}
+			if got != tc.wantSpace {
+				t.Fatalf("principalSpaceId = %v, want %q", got, tc.wantSpace)
+			}
+		})
+	}
+}
+
+func TestDocsMembersRemove_RequiresAndSendsPrincipalSpaceID(t *testing.T) {
+	t.Run("requires principal Space", func(t *testing.T) {
+		requests := 0
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			requests++
+		})
+		root.SetArgs([]string{"docs", "members", "remove", "doc-1", "user-1"})
+		if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "required flag") {
+			t.Fatalf("missing --principal-space-id error = %v, want required flag error", err)
+		}
+		if requests != 0 {
+			t.Fatalf("missing required flag sent %d requests, want 0", requests)
+		}
+	})
+
+	t.Run("sends exact principal Space", func(t *testing.T) {
+		var gotQuery url.Values
+		root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+			gotQuery = r.URL.Query()
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		})
+		root.SetArgs([]string{"docs", "members", "remove", "doc-1", "user-1", "--principal-space-id", "space-2"})
+		if err := root.Execute(); err != nil {
+			t.Fatalf("execute: %v", err)
+		}
+		if got := gotQuery.Get("principalSpaceId"); got != "space-2" {
+			t.Fatalf("principalSpaceId query = %q, want space-2", got)
+		}
+	})
 }
 
 // TestDocsSceneExport_ImageFormatFlagNoGlobalShadow pins the fix for the
@@ -543,18 +623,22 @@ func TestDocsMembersSet_PutUpsertBody(t *testing.T) {
 
 // TestDocsMembersRemove_TwoPathArgs checks both positional args land in the path.
 func TestDocsMembersRemove_TwoPathArgs(t *testing.T) {
-	var gotMethod, gotPath string
+	var gotMethod, gotPath, gotSpace string
 	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath = r.Method, r.URL.Path
+		gotSpace = r.URL.Query().Get("principalSpaceId")
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	})
-	root.SetArgs([]string{"docs", "members", "remove", "d1", "u9"})
+	root.SetArgs([]string{"docs", "members", "remove", "d1", "u9", "--principal-space-id", "s1"})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	if gotMethod != "DELETE" || gotPath != "/v1/bot/docs/d1/members/u9" {
 		t.Errorf("got %s %s, want DELETE /v1/bot/docs/d1/members/u9", gotMethod, gotPath)
+	}
+	if gotSpace != "s1" {
+		t.Errorf("principalSpaceId = %q, want s1", gotSpace)
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -668,6 +668,7 @@
                         "type": "object",
                         "properties": {
                           "uid": { "type": "string" },
+                          "principalSpaceId": { "type": "string", "description": "principal Space id that qualifies this membership" },
                           "role": { "type": "string" },
                           "source": { "type": "string" },
                           "grantedBy": { "type": "string" }
@@ -684,7 +685,7 @@
       "put": {
         "operationId": "docs.members.set",
         "summary": "Add or change a member's role by uid (upsert; needs admin)",
-        "description": "PUT-upsert: adds the member if absent or changes the role if present. The target uid must be a real Octo user or the backend returns 404 user_not_found.",
+        "description": "Space-qualified PUT mutation for Bot callers. When principalSpaceId is omitted, the backend uses the authenticated Bot Space. That Space may also be supplied explicitly and supports add or role update. A foreign principalSpaceId performs no directory lookup and can only update an existing exact (docId, uid, principalSpaceId) membership; a missing exact row returns 404.",
         "x-octo-risk": "write",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } }
@@ -697,7 +698,8 @@
                 "type": "object",
                 "required": ["uid", "role"],
                 "properties": {
-                  "uid": { "type": "string", "description": "target user uid" },
+                  "uid": { "type": "string", "description": "uid in the Space-qualified membership key" },
+                  "principalSpaceId": { "type": "string", "x-octo-flag": "principal-space-id", "description": "principal Space id; for Bot calls, omission defaults to the authenticated Bot Space, an explicit matching value supports add/upsert, and a foreign value can only update an existing exact membership without a directory lookup" },
                   "role": { "type": "string", "enum": ["reader", "commenter", "writer", "admin"], "description": "role to grant. Matches octo-docs-backend isMemberRole (src/permission/role.ts); commenter is a stored role ranked between reader and writer, so omitting it made the local enum gate reject a call the backend accepts" }
                 }
               }
@@ -710,11 +712,13 @@
     "/v1/bot/docs/{docId}/members/{uid}": {
       "delete": {
         "operationId": "docs.members.remove",
-        "summary": "Remove a member (needs admin; the owner cannot be removed)",
+        "summary": "Remove a Space-qualified member (needs admin; the owner cannot be removed)",
+        "description": "Bot exact-delete mutation for the membership identified by (docId, uid, principalSpaceId). principalSpaceId is required because one uid can have distinct memberships in multiple Spaces.",
         "x-octo-risk": "write",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "uid", "in": "path", "required": true, "schema": { "type": "string" } }
+          { "name": "uid", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "name": "principalSpaceId", "in": "query", "required": true, "x-octo-flag": "principal-space-id", "schema": { "type": "string" }, "description": "principal Space id of the membership to remove; required to disambiguate the same uid across Spaces" }
         ],
         "responses": { "200": { "description": "Removed" } }
       }

--- a/skills/octo-docs/common.md
+++ b/skills/octo-docs/common.md
@@ -110,9 +110,10 @@ Schema: `octo-cli schema docs.versions.restore`.
 ## Members & sharing
 
 ```bash
-octo-cli docs members list   <docId>                             # admin
-octo-cli docs members set    <docId> --uid <uid> --role writer   # add/upsert; role: reader|writer|admin
-octo-cli docs members remove <docId> <uid>                       # admin; owner cannot be removed
+octo-cli docs members list   <docId>                             # admin; items include principalSpaceId
+octo-cli docs members set    <docId> --uid <uid> --role writer   # authenticated Bot Space; role: reader|commenter|writer|admin
+octo-cli docs members set    <docId> --uid <uid> --role writer --principal-space-id <spaceId>
+octo-cli docs members remove <docId> <uid> --principal-space-id <spaceId> # required; owner cannot be removed
 
 # Grant-only forward access (never downgrades). Only reader|writer are grantable.
 octo-cli docs forward-grant  <docId> --uid <uid> --role reader
@@ -124,9 +125,15 @@ octo-cli docs share set <docId> --scope anyone_in_space --role read   # admin; e
 octo-cli docs share set <docId> --scope anyone_in_space --role edit   # admin; every space member gets edit
 ```
 
-`docs members set` is a PUT-upsert: it adds the member if absent or changes the
-role if already present. The target uid must be a real Octo user — a miss returns
-`404 user_not_found` and writes no ghost member. Schema: `octo-cli schema docs.members.set`.
+`docs members set` is a Space-qualified Bot mutation. Omit
+`--principal-space-id` to use the authenticated Bot Space, or pass that same
+Space explicitly; either form can add a member or update an existing role. A
+foreign Space is never queried through the directory and can only update an
+existing exact `(docId, uid, principalSpaceId)` row; if that row is absent, the
+backend returns `404`. A uid can have distinct member rows in multiple Spaces,
+so `docs members remove` always requires `--principal-space-id` and deletes the
+exact qualified row. Schemas:
+`octo-cli schema docs.members.set` and `octo-cli schema docs.members.remove`.
 
 `docs share set` changes the space-level share scope. Two scopes: `restricted`
 (only the owner and explicit members reach the doc — the default) and


### PR DESCRIPTION
## Summary

- make Docs member mutations explicitly Space-qualified in the embedded OpenAPI contract and CLI documentation
- for Bot `docs members set`, omit `--principal-space-id` to use the authenticated Bot Space; explicitly selecting that same Space supports add/upsert, while a foreign Space can only update an existing exact membership and never performs a directory lookup
- require and send `--principal-space-id` for `docs members remove`, making deletion target the exact `(docId, uid, principalSpaceId)` row
- include `principalSpaceId` in the `docs members list` response schema and document the complete member-role vocabulary, including `commenter`
- use isolated command roots in set/remove tests so Cobra persistent flag state cannot leak between cases; leave document-Space-bound forward-grant behavior unchanged

## Linked Issue

Fixes #149

## How verified

- `go generate ./...` (no generated changes)
- `make fmt`
- `make vet`
- `golangci-lint v2.12.2 run`
- focused Docs member tests
- `make test` (`go test -race -count=1 ./...`)
- `make build`
- `git diff --check`
- built-CLI dry runs: set omitted / set qualified / remove omitted / remove qualified
- schema/help inspection: member-list items expose `principalSpaceId`; set help describes authenticated-Bot-Space default and foreign-Space exact-update behavior

## COMPREHENSION

1. **What invariant is load-bearing?** A Docs membership is identified by `(docId, uid, principalSpaceId)`, not by uid alone. Set and remove must preserve that qualified identity on the wire.
2. **What is the Bot set contract?** Omitting `principalSpaceId` delegates to the authenticated Bot Space. Supplying that same Space explicitly permits add/upsert. Supplying a foreign Space performs no directory lookup and can only update an already-existing exact row; an absent row returns `404`.
3. **Why is remove stricter?** A uid may have memberships in multiple Spaces, so Bot deletion must require `principalSpaceId` and delete only the exact qualified row. The CLI now fails locally before HTTP when the flag is absent.
4. **What failure would indicate a regression?** Emitting the optional set field when omitted, treating a foreign Space as directory-addable, allowing unqualified removal, sending the remove selector outside the query, or omitting `principalSpaceId` from list schema would violate the backend contract. Shape and wire tests pin these boundaries with fresh command roots.

## Compatibility / rollout

- `docs members set` remains source-compatible for callers that omit `--principal-space-id`; its server-side default is the authenticated Bot Space.
- `docs members remove` is intentionally breaking for unqualified calls: callers must add `--principal-space-id` to avoid ambiguous deletion.
- This CLI change depends on the matching Docs Backend contract in MR !110 and Server principal lookup behavior in PR #819; deploy those backend changes before relying on cross-Space exact updates.
