### PR TITLE
fix(loop): rename expert team evaluation

### DIFF
--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -167,6 +167,50 @@ func TestLoopCommandUsesUnifiedGatewayAndModulePath(t *testing.T) {
 	}
 }
 
+func TestLoopExpertTeamEvaluateCommandShape(t *testing.T) {
+	var gotMethod, gotPath, gotWorkspace string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotWorkspace = r.Header.Get("X-Workspace-ID")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"evaluation-1"}`))
+	})
+	loop := findCmd(root, "loop")
+	expertTeam := findCmd(loop, "expert-team")
+	if expertTeam == nil || findCmd(expertTeam, "evaluate") == nil {
+		t.Fatal("loop expert-team evaluate command not registered")
+	}
+	task := findCmd(loop, "task")
+	if task != nil && findCmd(task, "team-evaluation") != nil {
+		t.Fatal("legacy loop task team-evaluation hierarchy must not be generated")
+	}
+
+	root.SetArgs([]string{
+		"loop", "expert-team", "evaluate", "task-1",
+		"--workspace-id", "workspace-1",
+		"--outcome", "no_action",
+		"--reason", "nothing to dispatch",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("loop expert-team evaluate: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/fleet/api/v1/tasks/task-1/expert_team_evaluations" {
+		t.Fatalf("request = %s %s", gotMethod, gotPath)
+	}
+	if gotWorkspace != "workspace-1" {
+		t.Fatalf("X-Workspace-ID = %q", gotWorkspace)
+	}
+	if gotBody["outcome"] != "no_action" || gotBody["reason"] != "nothing to dispatch" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+}
+
 func TestLoopTaskWorkspaceHeaderFlag(t *testing.T) {
 	var gotPath, gotWorkspace string
 	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -160,7 +161,7 @@ func TestLoopExtendedBusinessContract(t *testing.T) {
 		"loop.skill.list",
 		"runtime.update_request.get",
 		"autopilot.delivery.replay",
-		"task.team_evaluation.record",
+		"expert_team.evaluate",
 	} {
 		op, ok := r.GetOperation(id)
 		if !ok {
@@ -170,6 +171,24 @@ func TestLoopExtendedBusinessContract(t *testing.T) {
 		if op.Service != "loop" || !strings.HasPrefix(op.Path, "/fleet/api/v1/") {
 			t.Errorf("%s: got service=%q path=%q", id, op.Service, op.Path)
 		}
+	}
+
+	evaluation, ok := r.GetOperation("expert_team.evaluate")
+	if !ok {
+		t.Fatal("expert_team.evaluate: not found")
+	}
+	if evaluation.Path != "/fleet/api/v1/tasks/{task_id}/expert_team_evaluations" {
+		t.Fatalf("expert_team.evaluate path = %q", evaluation.Path)
+	}
+	if evaluation.RequestBody == nil {
+		t.Fatal("expert_team.evaluate request body missing")
+	}
+	outcome, ok := evaluation.RequestBody.Properties["outcome"]
+	if !ok || !slices.Equal(outcome.Enum, []any{"action", "no_action", "failed"}) {
+		t.Fatalf("expert_team.evaluate outcome schema = %+v", outcome)
+	}
+	if _, ok := evaluation.RequestBody.Properties["reason"]; !ok {
+		t.Fatalf("expert_team.evaluate reason schema missing: %+v", evaluation.RequestBody.Properties)
 	}
 
 	op, ok := r.GetOperation("label.list")

--- a/internal/registry/specs/loop.json
+++ b/internal/registry/specs/loop.json
@@ -6338,14 +6338,14 @@
         }
       }
     },
-    "/fleet/api/v1/tasks/{task_id}/expert_team_evaluation": {
+    "/fleet/api/v1/tasks/{task_id}/expert_team_evaluations": {
       "post": {
-        "summary": "Record expert team evaluation",
-        "description": "Record expert team evaluation in the authenticated workspace.",
+        "summary": "Evaluate a task as expert team leader",
+        "description": "Record the authenticated Expert Team Leader's evaluation outcome for the current Task execution.",
         "tags": [
           "tasks"
         ],
-        "operationId": "task.team_evaluation.record",
+        "operationId": "expert_team.evaluate",
         "parameters": [
           {
             "name": "task_id",
@@ -6362,7 +6362,24 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/FlexibleRequest"
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "outcome"
+                ],
+                "properties": {
+                  "outcome": {
+                    "type": "string",
+                    "enum": [
+                      "action",
+                      "no_action",
+                      "failed"
+                    ]
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
## What

The Loop registry generated `task team-evaluation record` from a singular, weakly typed endpoint contract.

## How

- Rename the operation to `expert_team.evaluate` and use the plural `/tasks/{task_id}/expert_team_evaluations` resource.
- Type `outcome` as `action | no_action | failed` and expose `reason` as a normal generated flag.
- Verify the generated `loop expert-team evaluate` command, request path, workspace header, and JSON body.

## Tests

- `GOCACHE=/private/tmp/octo-go-build-cache go test ./cmd ./internal/...`
- `GOCACHE=/private/tmp/octo-go-build-cache go run ./cmd/octo-cli loop expert-team evaluate --help`
- `git diff --check`

## Dependency

This is a stacked PR targeting `test/autopilot-public-contract-integration`, which contains the pending Loop Public API contract required by this operation.
