### PR TITLE
docs: guide agents to ingest external document images

### DIFF
--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -25,7 +25,7 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 | Read/edit a rich-text **document body** (`doc_type: doc`): incremental block ops | **`doc.md`** |
 | Read/edit a **whiteboard** (`doc_type: board`): scene elements/files, image export | **`board.md`** |
 | Continue from a searchable **HTML document** (`doc_type: html`): resolve its document reference, then use immutable versions/drafts/assets/comments | **`../octo-html/SKILL.md`** |
-| Cross-cutting features — **comments** (doc range or sheet cell), **versions** (snapshot/restore), **members & sharing**, **attachments** (presign/upload) | **`common.md`** |
+| Cross-cutting features — **comments** (doc range or sheet cell), **versions** (snapshot/restore), **members & sharing**, **attachments** (presign/upload and external-image ingest) | **`common.md`** |
 
 > The first four split by `doc_type` (what kind of document you're handling);
 > `common.md` holds the features that apply across kinds. Read a reference with

--- a/skills/octo-docs/common.md
+++ b/skills/octo-docs/common.md
@@ -6,7 +6,7 @@ you need:
 - [Comments](#comments) — add/list/reply/resolve, on a doc text range or a sheet cell
 - [Versions](#versions) — snapshot / preview / rename / delete / restore
 - [Members & sharing](#members--sharing) — roles, forward-grant
-- [Attachments](#attachments) — presign + upload file/image bytes
+- [Attachments](#attachments) — presign/upload local bytes and ingest external images
 
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`. Auth & space rules are in
 `SKILL.md`.
@@ -182,3 +182,46 @@ Once uploaded, reference the `attachId` from a document body's image node (see
 `doc.md`) or a whiteboard file ref (see `board.md`). NOTE: a spreadsheet's floating
 images do NOT use this attachment flow — they inline the base64 bytes in the
 drawing's `source` field (see `sheet.md`). Schema: `octo-cli schema docs.attachments.presign`.
+
+### External image URLs (including SVG)
+
+Never persist an arbitrary external URL as an image node's only `src`. Current
+Octo clients render images only from trusted storage hosts, so a node such as
+`{"type":"image","attrs":{"src":"https://third-party.example/image.svg"}}`
+can be stored but renders as **Image unavailable**.
+
+Re-host a public HTTP(S) image under the target document first. The ingest
+endpoint is not yet a generated `docs attachments` subcommand, so call it
+through the generic API passthrough:
+
+```bash
+octo-cli api POST /v1/bot/docs/<docId>/attachments/ingest \
+  --data '{"urls":["https://source.example/diagram.svg"]}'
+```
+
+Read the new document-scoped `attachId` from `data.mappings`; treat an entry in
+`data.notIngested` as a failed image import and keep it as a normal hyperlink or
+text instead of writing a broken image node. The backend fetches the source with
+SSRF protections, validates that the bytes are an allowed image, and stores the
+successful result in Octo object storage.
+
+After either upload or ingest succeeds, write the image node using its durable
+`attachId`. Omit `src` (or set it to `null`): the client resolves a fresh signed
+display URL from the attachment. Also provide a positive pixel `width`; current
+clients can collapse an agent-created image with `width: null` to `0x0`. Use the
+known display width when available, otherwise `300` is a safe compatibility
+default:
+
+```json
+{
+  "type": "image",
+  "attrs": {
+    "attachId": "att_xxx",
+    "width": 300,
+    "alt": "Diagram"
+  }
+}
+```
+
+The `attachId` must belong to the same target document; a foreign or unknown
+attachment is rejected with `422 attachment_not_found`.

--- a/skills/octo-docs/doc.md
+++ b/skills/octo-docs/doc.md
@@ -64,8 +64,35 @@ board/whiteboard/sheet), `413 too_many_ops` / `413 op_content_too_large` /
 attachment that is not this doc's (`attachment_not_found`), or content the
 schema rejects (`schema_incompatible`).
 
-Inserting an image into the body references an uploaded attachment — see
-`common.md` (Attachments) for the presign → upload → reference flow.
+## Image nodes
+
+Do not write a third-party image URL as the image node's only `src`: the Octo
+client rejects off-whitelist asset hosts and displays **Image unavailable**.
+First upload local bytes or ingest a public HTTP(S) URL into the target document
+as described in `common.md` (Attachments), then use the returned document-scoped
+`attachId` in the body edit:
+
+```json
+{
+  "type": "insert",
+  "at": { "path": [], "position": "inside_end" },
+  "content": [
+    {
+      "type": "image",
+      "attrs": {
+        "attachId": "att_xxx",
+        "width": 300,
+        "alt": "Diagram"
+      }
+    }
+  ]
+}
+```
+
+The durable reference is `attachId`; omit `src` (or set it to `null`) so the
+client resolves a fresh signed display URL. Supply the real positive pixel width
+when known; otherwise use `300` as a compatibility default because current
+clients can lay out an agent-created image with `width: null` as `0x0`.
 
 ## Schema lookup
 

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -43,14 +43,17 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 	if !strings.Contains(strings.ToLower(content), "whiteboard") {
 		t.Error("SKILL.md must mention the whiteboard/board surface")
 	}
+	if !strings.Contains(content, "external-image ingest") {
+		t.Error("SKILL.md must route external-image ingest guidance to common.md")
+	}
 
 	// The reference files are embedded (ride the */*.md glob) and each leads with
 	// its surface's read/edit commands.
 	refChecks := map[string][]string{
-		"octo-docs/doc.md":    {"docs content get", "docs content edit"},
+		"octo-docs/doc.md":    {"docs content get", "docs content edit", `"attachId": "att_xxx"`, `"width": 300`},
 		"octo-docs/sheet.md":  {"docs sheet get", "docs sheet edit"},
 		"octo-docs/board.md":  {"docs scene get", "docs scene edit"},
-		"octo-docs/common.md": {"docs comments add", "docs versions restore", "docs members set", "docs attachments presign"},
+		"octo-docs/common.md": {"docs comments add", "docs versions restore", "docs members set", "docs attachments presign", "/attachments/ingest", `"attachId": "att_xxx"`, `"width": 300`},
 	}
 	for path, needles := range refChecks {
 		rb, err := FS.ReadFile(path)


### PR DESCRIPTION
## Summary

Document the safe Agent workflow for inserting external images, including SVG, into rich-text Octo documents.

## Changes

- Route attachment URL-ingest tasks from the top-level octo-docs skill to common.md.
- Require external image URLs to be re-hosted through `/attachments/ingest` before writing an image node.
- Show the durable `attachId` image-node shape with a positive `width` compatibility default.
- Tell agents to degrade failed ingests to links instead of persisting broken external image nodes.
- Extend embedded-skill tests to lock the new guidance.

## Motivation

An Agent can use `docs content edit` to persist an image containing only an external `src`. Off-whitelist hosts then render as **Image unavailable**. Separately, the current client can lay out an attachment-backed image with `width: null` as `0x0`. The skill should teach the complete ingest → attachId → image-node flow instead of leaving these constraints implicit.

This is documentation and regression coverage for Agent guidance; it does not change the frontend layout implementation or add a generated `docs attachments ingest` command.

## Linked Spec

No separate issue. The guidance follows the existing docs attachment-ingest and image-node contracts.

## Testing

- [x] `go vet ./...` passes
- [x] `go test -race -count=1 ./...` passes
- [x] `go build ./...` passes

## Checklist

- [x] Code and documentation are in English
- [x] N/A — no new command was added to the README command table
- [x] N/A — no command list changed in CLAUDE.md
- [x] New guidance includes embedded-skill regression checks
- [x] No unrelated changes included

## COMPREHENSION

The load-bearing rule is that `src` is not a durable substitute for an Octo attachment: external HTTP(S) images must first be ingested into the target document and referenced by that document-scoped `attachId`. Current clients also need a positive image `width` for predictable rendering; the skill uses the known width when available and `300` as a compatibility default. This depends on the existing backend ingest endpoint and frontend attachment resolver. It was verified against a real test document, where an external SVG produced **Image unavailable**, the ingested SVG resolved from Octo COS, and adding `width` changed its rendered box from `0x0` to `150x150`.