### PR TITLE
fix(loop): enforce public API media type

### DIFF
--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -129,11 +129,12 @@ func TestRegisterServiceCommands_TreeShape(t *testing.T) {
 }
 
 func TestLoopCommandUsesUnifiedGatewayAndModulePath(t *testing.T) {
-	var gotPath, gotAuth, gotSpace string
+	var gotPath, gotAuth, gotSpace, gotAccept string
 	gateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotPath = r.URL.Path
 		gotAuth = r.Header.Get("Authorization")
 		gotSpace = r.Header.Get("X-Space-Id")
+		gotAccept = r.Header.Get("Accept")
 		_, _ = w.Write([]byte(`{"data":{"task_id":"task-1"}}`))
 	}))
 	defer gateway.Close()
@@ -164,6 +165,9 @@ func TestLoopCommandUsesUnifiedGatewayAndModulePath(t *testing.T) {
 	}
 	if gotSpace != "" {
 		t.Fatalf("Loop public API must not receive X-Space-Id, got %q", gotSpace)
+	}
+	if gotAccept != "application/vnd.octo+json" {
+		t.Fatalf("Accept = %q, want application/vnd.octo+json", gotAccept)
 	}
 }
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -160,8 +160,8 @@ func (c *Client) Do(ctx context.Context, req *Request) ([]byte, error) {
 	}
 
 	headers := cloneHeaders(req.Headers)
-	if req.Service == "loop" && headerValue(headers, "Accept") == "" {
-		headers["Accept"] = publicAPIMediaType
+	if req.Service == "loop" {
+		setHeader(headers, "Accept", publicAPIMediaType)
 	}
 
 	if c.options.DryRun {
@@ -179,13 +179,13 @@ func cloneHeaders(headers map[string]string) map[string]string {
 	return cloned
 }
 
-func headerValue(headers map[string]string, name string) string {
-	for key, value := range headers {
+func setHeader(headers map[string]string, name, value string) {
+	for key := range headers {
 		if strings.EqualFold(key, name) {
-			return value
+			delete(headers, key)
 		}
 	}
-	return ""
+	headers[name] = value
 }
 
 // doWithRetry runs the HTTP request, retrying transient errors with backoff.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -69,12 +69,12 @@ func TestDo_LoopSelectsPublicAPIContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	if gotAccept != publicAPIMediaType {
-		t.Fatalf("Accept = %q, want %q", gotAccept, publicAPIMediaType)
+	if gotAccept != "application/vnd.octo+json" {
+		t.Fatalf("Accept = %q, want application/vnd.octo+json", gotAccept)
 	}
 }
 
-func TestDo_LoopPreservesExplicitAccept(t *testing.T) {
+func TestDo_LoopOverridesGenericJSONAccept(t *testing.T) {
 	t.Parallel()
 
 	var gotAccept string
@@ -89,13 +89,13 @@ func TestDo_LoopPreservesExplicitAccept(t *testing.T) {
 		Service: "loop",
 		Method:  http.MethodGet,
 		Path:    "/fleet/api/v1/workspaces",
-		Headers: map[string]string{"Accept": "application/json"},
+		Headers: map[string]string{"accept": "application/json"},
 	})
 	if err != nil {
 		t.Fatalf("Do: %v", err)
 	}
-	if gotAccept != "application/json" {
-		t.Fatalf("Accept = %q, want application/json", gotAccept)
+	if gotAccept != "application/vnd.octo+json" {
+		t.Fatalf("Accept = %q, want application/vnd.octo+json", gotAccept)
 	}
 }
 


### PR DESCRIPTION
## What

Fleet selects its stable Public API only when Loop requests send
`Accept: application/vnd.octo+json`. Generic JSON enters the legacy `/api`
routing path and makes Public API routes return `404`.

The `dev/v0.14.1` client already uses the vendor media type by default, but an
explicit or generated `Accept: application/json` header could still override
that contract.

## How

- **internal/client/client.go** — normalize the `Accept` header after cloning
  request headers and enforce the Fleet Public API media type for every Loop
  request, including case-variant recipe headers.
- **internal/client/client_test.go** — assert the wire-level media type as a
  literal and cover generic JSON header override behavior.
- **cmd/service/service_test.go** — verify the generated Loop command sends the
  vendor media type through the full command-to-transport path.

## Tests

- `GOCACHE=/private/tmp/octo-cli-accept-gocache go test ./internal/client ./cmd/service -run '^(TestDo_Loop|TestLoopCommandUsesUnifiedGatewayAndModulePath)' -count=1`
- `make fmt`
- `go vet ./...`
- `golangci-lint run` with CI version `v2.12.2` (`0 issues`)
- `GOCACHE=/private/tmp/octo-cli-accept-gocache make test build`
- `git diff --check`
