### PR TITLE
fix(api): forward workspace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli api --workspace-id`** — generic passthrough requests can now send
+  explicit workspace context through the `X-Workspace-ID` header.
 - **`octo-cli docs search`** — permission-scoped full-text search across online
   documents, sheets, boards, and mounted HTML documents registered in docs-backend
   via `POST /v1/bot/docs/search`. Supports repeatable `--doc-type` filters, manual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ octo-cli html      list | get | publish | versions | rm     (octo-doc HTML docs;
 
 octo-cli auth      login | status | logout | list
 octo-cli schema [--list [domain] | <operation-id>]
-octo-cli api <METHOD> <PATH> [--params ...] [--data ...] [--service ...]
+octo-cli api <METHOD> <PATH> [--params ...] [--data ...] [--service ...] [--workspace-id <uuid>]
 octo-cli config show
 octo-cli completion bash|zsh|fish|powershell
 octo-cli version

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ octo-cli config show                # resolved config (token masked)
 # Generic passthrough for ops that aren't auto-registered.
 octo-cli api GET  /v1/messages --params '{"chat_id":"chat-1"}'
 octo-cli api POST /v1/messages --data @body.json
+octo-cli api GET  /fleet/api/v1/custom --workspace-id <workspace-uuid>
 ```
 
 ## Authentication

--- a/cmd/api.go
+++ b/cmd/api.go
@@ -15,14 +15,14 @@ import (
 
 // newAPICmd implements the generic passthrough:
 //
-//	octo-cli api <METHOD> <PATH> [--params '{...}'] [--data '{...}']
+//	octo-cli api <METHOD> <PATH> [--params '{...}'] [--data '{...}'] [--workspace-id <id>]
 //
 // Auth, service URL routing, retry, envelope, and universal flags are reused
 // verbatim. No spec consultation, no flag auto-generation, no pagination
 // helper — this is the escape hatch when an endpoint isn't in the registry
 // yet or when a caller needs to exercise something bespoke.
 func newAPICmd(f *cmdutil.Factory) *cobra.Command {
-	var paramsSpec, dataSpec, service string
+	var paramsSpec, dataSpec, service, workspaceID string
 
 	cmd := &cobra.Command{
 		Use:   "api <METHOD> <PATH>",
@@ -33,6 +33,7 @@ Examples:
   octo-cli api GET /api/v1/matters --params '{"status":"open"}'
   octo-cli api POST /api/v1/matters --data '{"title":"test"}'
   octo-cli api GET /v1/bot/events --service dmworkim
+  octo-cli api GET /fleet/api/v1/custom --workspace-id 00000000-0000-0000-0000-000000000000
   octo-cli api POST /api/v1/matters --data @body.json
   octo-cli api POST /api/v1/matters --data @-       # read from stdin
 
@@ -74,12 +75,17 @@ flags are not auto-generated and --page-all is not available.`,
 				_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
 				return err
 			}
+			var headers map[string]string
+			if workspaceID != "" {
+				headers = map[string]string{"X-Workspace-ID": workspaceID}
+			}
 			respBody, err := cli.Do(cobraCmd.Context(), &client.Request{
 				Service: service,
 				Method:  method,
 				Path:    path,
 				Query:   q,
 				Body:    body,
+				Headers: headers,
 			})
 			if err != nil {
 				_ = f.EmitError(err) //nolint:errcheck // best-effort emit before returning err
@@ -92,6 +98,7 @@ flags are not auto-generated and --page-all is not available.`,
 	cmd.Flags().StringVar(&paramsSpec, "params", "", "query parameters as JSON object (e.g. '{\"status\":\"open\"}')")
 	cmd.Flags().StringVar(&dataSpec, "data", "", "request body: inline JSON, @filepath, or @- for stdin")
 	cmd.Flags().StringVar(&service, "service", "", "service key override (matters | dmworkim). Default: OCTO_API_BASE_URL")
+	cmd.Flags().StringVar(&workspaceID, "workspace-id", "", "workspace UUID sent as X-Workspace-ID")
 	return cmd
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -235,6 +235,57 @@ func TestCmd_API_POSTBody(t *testing.T) {
 	}
 }
 
+func TestCmd_API_WorkspaceIDHeader(t *testing.T) {
+	const workspaceID = "00000000-0000-0000-0000-000000000001"
+	var gotWorkspaceID string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotWorkspaceID = r.Header.Get("X-Workspace-ID")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	f := newTestFactoryWithReg()
+	cfg := &config.Config{APIBaseURL: srv.URL, BotToken: "app_test", Format: "json"}
+	cred := &credential.BotCredential{Token: "app_test"}
+	f.SetConfig(cfg)
+	f.SetCredential(cred)
+	f.SetClient(client.New(cfg, cred, client.Options{}))
+
+	_, _, err := execRoot(t, f, "api", "GET", "/fleet/api/v1/custom", "--workspace-id", workspaceID)
+	if err != nil {
+		t.Fatalf("api GET with workspace context: %v\n%s", err, f.ErrOut.String())
+	}
+	if gotWorkspaceID != workspaceID {
+		t.Errorf("X-Workspace-ID = %q, want %q", gotWorkspaceID, workspaceID)
+	}
+}
+
+func TestCmd_API_OmitsWorkspaceHeaderByDefault(t *testing.T) {
+	var gotWorkspaceHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, gotWorkspaceHeader = r.Header[http.CanonicalHeaderKey("X-Workspace-ID")]
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	f := newTestFactoryWithReg()
+	cfg := &config.Config{APIBaseURL: srv.URL, BotToken: "app_test", Format: "json"}
+	cred := &credential.BotCredential{Token: "app_test"}
+	f.SetConfig(cfg)
+	f.SetCredential(cred)
+	f.SetClient(client.New(cfg, cred, client.Options{}))
+
+	_, _, err := execRoot(t, f, "api", "GET", "/test")
+	if err != nil {
+		t.Fatalf("api GET without workspace context: %v\n%s", err, f.ErrOut.String())
+	}
+	if gotWorkspaceHeader {
+		t.Error("X-Workspace-ID header is present by default")
+	}
+}
+
 func TestCmd_API_PathMustStartWithSlash(t *testing.T) {
 	f := newTestFactoryWithReg()
 	_, errOut, err := execRoot(t, f, "api", "GET", "no-slash")

--- a/docs/architecture-design.md
+++ b/docs/architecture-design.md
@@ -446,8 +446,11 @@ Discovered from backend code, relevant to CLI alias design and Skill documentati
 Passthrough for API calls not in specs:
 ```bash
 octo-cli api GET /api/v1/matters --params '{"status":"open"}'
+octo-cli api GET /fleet/api/v1/custom --workspace-id <workspace-uuid>
 ```
-Uses credential provider, outputs envelope, supports universal flags. No spec consultation, no flag auto-gen, no --page-all.
+Uses credential provider, outputs envelope, supports universal flags, and can
+explicitly send workspace context as `X-Workspace-ID` with `--workspace-id`.
+No spec consultation, no flag auto-gen, no --page-all.
 
 ---
 

--- a/skills/octo-shared/SKILL.md
+++ b/skills/octo-shared/SKILL.md
@@ -208,7 +208,11 @@ When an operation isn't auto-registered yet or you need low-level control:
 ```bash
 octo-cli api GET  /api/v1/messages --params '{"chat_id":"chat-1"}'
 octo-cli api POST /api/v1/messages --data @body.json
+octo-cli api GET  /fleet/api/v1/custom --workspace-id <workspace-uuid>
 ```
+
+For a workspace-scoped passthrough endpoint, pass `--workspace-id` explicitly;
+the CLI sends it as `X-Workspace-ID` and does not infer a workspace.
 
 ## 8. Domain skills
 


### PR DESCRIPTION
## What

`octo-cli api` is the escape hatch for endpoints that are not represented in
the embedded registry, but it could not send workspace context. Calls to
workspace-scoped custom or legacy endpoints therefore could not provide the
required `X-Workspace-ID` header.

## How

- **cmd/api.go** — add an optional `--workspace-id` flag and forward its value
  as `X-Workspace-ID`. Omitted flags leave the header absent, preserving all
  existing passthrough behavior.
- **cmd/cmd_test.go** — cover both explicit header forwarding and default
  omission at the HTTP transport boundary.
- **README.md, CLAUDE.md, docs/architecture-design.md, skills/octo-shared/SKILL.md,
  CHANGELOG.md** — document the new command shape and workspace-scoped usage.

This change does not alter daemon task-mode command policy; task processes
remain restricted to the generated Loop command surface.

## Tests

- `go test -race -count=1 ./...`
- `make fmt`
- `go vet ./...`
- `go build -o /private/tmp/octo-cli-pr-verify ./cmd/octo-cli`
- `git diff --check`
