### PR TITLE
fix(loop): clarify workspace UUID contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `--role` flags front the `shareScope` / `shareRole` wire keys.
 
 ### Changed
+- **Loop workspace flag terminology** — generated `--workspace-id` help and the
+  bundled Loop skill now state that the value is a workspace UUID, not a slug
+  or generic selector. The architecture guide records the separate Web slug,
+  Public API UUID, and credential-bound task conventions.
 - **Generated service commands now reject incomplete JSON bodies locally** —
   request-schema `required` fields and nested `minItems` constraints are
   validated after merging `--data` with promoted body flags, before any HTTP

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -291,6 +291,21 @@ func TestLoopWorkspaceIDFlagIsRequired(t *testing.T) {
 	}
 }
 
+func TestLoopWorkspaceIDFlagDocumentsUUID(t *testing.T) {
+	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {})
+	taskList := findCmd(findCmd(findCmd(root, "loop"), "task"), "list")
+	if taskList == nil {
+		t.Fatal("loop task list command not registered")
+	}
+	flag := taskList.Flags().Lookup("workspace-id")
+	if flag == nil {
+		t.Fatal("loop task list --workspace-id flag not registered")
+	}
+	if flag.Usage != "Workspace UUID for workspace-scoped Loop requests." {
+		t.Errorf("--workspace-id usage = %q", flag.Usage)
+	}
+}
+
 func TestLoopWorkspaceCreateIsNotRegistered(t *testing.T) {
 	root, _, _ := rootWithService(t, func(http.ResponseWriter, *http.Request) {
 		t.Fatal("hidden workspace create command must not send a request")

--- a/docs/architecture-design.md
+++ b/docs/architecture-design.md
@@ -190,6 +190,31 @@ Service commands resolve URLs as `OCTO_API_BASE_URL + operation path`.
 Module namespaces such as `/market/api`, `/docs-html`, and `/fleet/api` live
 in the embedded OpenAPI paths.
 
+### 3.3 Workspace Context Convention
+
+Fleet accepts more than one workspace selector at its Web compatibility
+boundary, but authorization and business logic always operate on the resolved
+workspace UUID. Each client surface must use one explicit convention:
+
+| Caller | Workspace input | Rationale |
+|--------|-----------------|-----------|
+| Octo Web human session | `X-Workspace-Slug: <slug>` | Matches the selected workspace and human-readable deep links; Fleet resolves it to a UUID. |
+| CLI and Public API automation | `X-Workspace-ID: <uuid>` | Stable, unambiguous OpenAPI contract that matches resource IDs and credential bindings. |
+| `/v1/workspaces/{id}` resources | UUID path parameter | The resource path is the authoritative workspace selector. |
+| Credential-bound task execution | Server-verified binding | Fleet replaces or ignores client workspace selection so a task cannot widen its scope. |
+
+The `--workspace-id` flag on `octo-cli` commands therefore accepts a workspace
+UUID only. It must never place a slug or display name in `X-Workspace-ID`.
+Callers obtain the UUID from `octo-cli loop workspace list` and pass it
+explicitly; there is no environment fallback.
+
+Clients should not send both `X-Workspace-Slug` and `X-Workspace-ID`. Fleet's
+Web resolver gives slug precedence, so mismatched values are ambiguous and can
+select or reject a different workspace than the caller intended. If slug
+support is added to the CLI later, it must be a separately named
+`--workspace-slug` flag, mutually exclusive with `--workspace-id`, and first be
+declared as part of the Public API specification.
+
 ---
 
 ## 4. Output Protocol

--- a/internal/registry/specs/loop.json
+++ b/internal/registry/specs/loop.json
@@ -6523,7 +6523,7 @@
         "name": "X-Workspace-ID",
         "in": "header",
         "required": true,
-        "description": "Workspace selector for workspace-scoped Loop requests.",
+        "description": "Workspace UUID for workspace-scoped Loop requests.",
         "x-octo-flag": "workspace-id",
         "schema": {
           "type": "string",

--- a/skills/octo-loop/SKILL.md
+++ b/skills/octo-loop/SKILL.md
@@ -43,15 +43,16 @@ All Loop commands use the same gateway as every other domain. The embedded
 paths include the Fleet module namespace, so requests resolve under
 `$OCTO_API_BASE_URL/fleet/api/v1/*`.
 
-## Workspace selector
+## Workspace UUID
 
-Workspace-scoped Loop commands require the `--workspace-id <id>` flag (sent as
-the `X-Workspace-ID` header). There is no environment fallback for it — pass it
-explicitly. Discover available workspaces first:
+Workspace-scoped Loop commands require the `--workspace-id <workspace-uuid>`
+flag, sent as the `X-Workspace-ID` header. The value must be the UUID returned
+by `workspace list`, not a workspace slug or name. There is no environment
+fallback — pass it explicitly. Discover available workspaces first:
 
 ```bash
 octo-cli loop workspace list
-octo-cli loop workspace member list --workspace-id <workspace-id>
+octo-cli loop workspace member list --workspace-id <workspace-uuid>
 ```
 
 ## Discover and execute operations
@@ -60,11 +61,11 @@ Output is JSON by default (`--format json`); parse JSON rather than scraping
 tables.
 
 ```bash
-octo-cli loop task list --workspace-id <ws>
-octo-cli loop task get <task-id> --workspace-id <ws>
-octo-cli loop expert list --workspace-id <ws>
-octo-cli loop expert-team list --workspace-id <ws>
-octo-cli loop execution message list <execution-id> --workspace-id <ws>
+octo-cli loop task list --workspace-id <workspace-uuid>
+octo-cli loop task get <task-id> --workspace-id <workspace-uuid>
+octo-cli loop expert list --workspace-id <workspace-uuid>
+octo-cli loop expert-team list --workspace-id <workspace-uuid>
+octo-cli loop execution message list <execution-id> --workspace-id <workspace-uuid>
 ```
 
 Inspect the current contract before constructing a write:
@@ -84,10 +85,10 @@ runtime paths are intentionally not part of this CLI surface.
 Read before you write.
 
 ```bash
-octo-cli loop task get <task-id> --workspace-id <ws>
-octo-cli loop task comment list <task-id> --workspace-id <ws>
-octo-cli loop task metadata list <task-id> --workspace-id <ws>
-octo-cli loop task children-by-parent <task-id> --workspace-id <ws>
+octo-cli loop task get <task-id> --workspace-id <workspace-uuid>
+octo-cli loop task comment list <task-id> --workspace-id <workspace-uuid>
+octo-cli loop task metadata list <task-id> --workspace-id <workspace-uuid>
+octo-cli loop task children-by-parent <task-id> --workspace-id <workspace-uuid>
 ```
 
 Comment history is paginated with `--page` / `--page-size`.
@@ -119,7 +120,7 @@ trap 'rm -rf "$body_dir"' EXIT
 # ...write the comment body to "$body_dir/reply.md", preserving real newlines...
 printf '{"content": %s}' "$(jq -Rs . < "$body_dir/reply.md")" > "$body_dir/body.json"
 
-octo-cli loop task comment create <task-id> --workspace-id <ws> --data @body.json
+octo-cli loop task comment create <task-id> --workspace-id <workspace-uuid> --data @body.json
 ```
 
 Use `mktemp -d`, never a fixed path like `./reply.md` (it can clobber a user
@@ -133,7 +134,7 @@ flag with the same shell hazards, so prefer a JSON body from a file:
 printf '{"title": %s, "description": %s}' \
   "$(jq -Rs . <<< 'Fix login redirect')" \
   "$(jq -Rs . < "$body_dir/description.md")" > "$body_dir/task.json"
-octo-cli loop task create --workspace-id <ws> --data @task.json
+octo-cli loop task create --workspace-id <workspace-uuid> --data @task.json
 ```
 
 ### Metadata
@@ -145,7 +146,7 @@ is keyed by a metadata id:
 
 ```bash
 octo-cli schema task.metadata.set
-octo-cli loop task metadata list <task-id> --workspace-id <ws>
+octo-cli loop task metadata list <task-id> --workspace-id <workspace-uuid>
 ```
 
 ## Status and assignment side effects
@@ -153,8 +154,8 @@ octo-cli loop task metadata list <task-id> --workspace-id <ws>
 Status and assignment are done through `task update`, not a dedicated command:
 
 ```bash
-octo-cli loop task update <task-id> --workspace-id <ws> --status <status>
-octo-cli loop task update <task-id> --workspace-id <ws> \
+octo-cli loop task update <task-id> --workspace-id <workspace-uuid> --status <status>
+octo-cli loop task update <task-id> --workspace-id <workspace-uuid> \
   --assignee-id <uuid> --assignee-type expert   # or expert_team, member
 ```
 
@@ -172,7 +173,7 @@ To create a task and dispatch it to an expert or expert-team in one call, use
 `quick-create` with a `prompt` and an assignee id:
 
 ```bash
-octo-cli loop task quick-create --workspace-id <ws> \
+octo-cli loop task quick-create --workspace-id <workspace-uuid> \
   --prompt "Investigate the login redirect bug" --expert-id <uuid>
 # or --expert-team-id <uuid>
 ```
@@ -181,9 +182,9 @@ Each dispatch produces an execution. Read run state and stop a runaway run
 rather than guessing:
 
 ```bash
-octo-cli loop task execution list <task-id> --workspace-id <ws>
-octo-cli loop task execution cancel <task-id> <execution-id> --workspace-id <ws>
-octo-cli loop task rerun <task-id> --workspace-id <ws> --execution-id <execution-id>
+octo-cli loop task execution list <task-id> --workspace-id <workspace-uuid>
+octo-cli loop task execution cancel <task-id> <execution-id> --workspace-id <workspace-uuid>
+octo-cli loop task rerun <task-id> --workspace-id <workspace-uuid> --execution-id <execution-id>
 ```
 
 Cancelling and rerunning are writes with side effects — confirm before running
@@ -197,9 +198,9 @@ mentioning a person is a notification only. Look up real ids before composing a
 mention:
 
 ```bash
-octo-cli loop expert list --workspace-id <ws>
-octo-cli loop expert-team list --workspace-id <ws>
-octo-cli loop workspace member list --workspace-id <ws>
+octo-cli loop expert list --workspace-id <workspace-uuid>
+octo-cli loop expert-team list --workspace-id <workspace-uuid>
+octo-cli loop workspace member list --workspace-id <workspace-uuid>
 ```
 
 Do not mention an expert or expert-team just to say thanks, confirm, or wrap up


### PR DESCRIPTION
## What

Generated Loop commands describe `--workspace-id` as a generic workspace
"selector", even though the Public API schema and Fleet contract require a
workspace UUID. This can lead callers to pass a slug or display name in
`X-Workspace-ID`, which Fleet rejects as `invalid workspace_id`.

## How

- **internal/registry/specs/loop.json** — describe the shared workspace header
  parameter explicitly as a UUID, updating generated help for every affected
  Loop operation.
- **skills/octo-loop/SKILL.md** — require the UUID returned by `workspace list`
  and use `<workspace-uuid>` consistently in command examples.
- **docs/architecture-design.md** — define the workspace context convention:
  Web human sessions use `X-Workspace-Slug`, CLI/Public API automation uses
  `X-Workspace-ID`, workspace resource paths use UUIDs, and credential-bound
  tasks cannot override their server-verified scope.
- **cmd/service/service_test.go** — pin the generated help text to the UUID
  contract.

The design intentionally does not overload `--workspace-id` with slug support.
Any future CLI slug capability must use a separate, mutually exclusive flag
and first be declared in the Public API specification.

## Tests

- `go test -race -count=1 ./...`
- `go test ./... -count=1` on the latest `dev/v0.14.1`
- `make fmt`
- `go vet ./...`
- `go build -o /private/tmp/octo-cli-workspace-id-verify ./cmd/octo-cli`
- `git diff --check`

Related: #156
