### PR TITLE
feat(docs): document spreadsheet P0 bot controls

### DIFF
--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -1110,6 +1111,161 @@ func TestDocsSheetEdit_SendsCellsBatchAndIfMatch(t *testing.T) {
 	// The base version travels in the header, not the JSON body.
 	if _, present := gotBody["baseVersion"]; present {
 		t.Errorf("baseVersion must not be duplicated into the JSON body; got %v", gotBody["baseVersion"])
+	}
+}
+
+// TestDocsSheetEdit_SendsP0ResourcesAndIfMatch pins the generic --data transport:
+// freeze, filter and single/multi dropdown payloads reach one PATCH with the
+// optimistic-concurrency header. Schema key presence is tested by the registry
+// loader test; this request schema intentionally remains an open object.
+func TestDocsSheetEdit_SendsP0ResourcesAndIfMatch(t *testing.T) {
+	var gotMethod, gotPath, gotIfMatch string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotIfMatch = r.Header.Get("If-Match")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode request: %v", err)
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"docId":"d1","bytes":512,"baseVersion":"BV_NEXT==","newDocVersionSeq":5}`))
+	})
+	payload := `{
+		"freeze":{
+			"default":{"startRow":1,"startColumn":1,"xSplit":1,"ySplit":1},
+			"rowOnly":{"startRow":1,"startColumn":-1,"xSplit":0,"ySplit":1},
+			"columnOnly":{"startRow":-1,"startColumn":1,"xSplit":1,"ySplit":0}
+		},
+		"filters":{"default":{"ref":{"startRow":0,"startColumn":0,"endRow":20,"endColumn":1},"filterColumns":[{"colId":1,"filters":{"filters":["待处理"]}}]}},
+		"dataValidations":{"default":[
+			{"uid":"single","type":"list","formula1":"[\"待处理\",\"已完成\"]","formula2":"#E4F4FE,#EFFBD0","showDropDown":true,"renderMode":2,"ranges":[{"startRow":1,"startColumn":0,"endRow":20,"endColumn":0}]},
+			{"uid":"multiple","type":"listMultiple","formula1":"[\"待处理\",\"已完成\"]","formula2":"#E4F4FE,#EFFBD0","showDropDown":true,"renderMode":2,"ranges":[{"startRow":1,"startColumn":1,"endRow":20,"endColumn":1}]}
+		]}
+	}`
+	root.SetArgs([]string{"docs", "sheet", "edit", "d1", "--base-version", "BV_P0==", "--data", payload})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPatch || gotPath != "/v1/bot/docs/d1/sheet" {
+		t.Fatalf("got %s %s, want PATCH /v1/bot/docs/d1/sheet", gotMethod, gotPath)
+	}
+	if gotIfMatch != "BV_P0==" {
+		t.Fatalf("If-Match = %q, want BV_P0==", gotIfMatch)
+	}
+	freeze, ok := gotBody["freeze"].(map[string]any)
+	if !ok {
+		t.Fatalf("freeze = %#v, want object", gotBody["freeze"])
+	}
+	wantFreeze := map[string]map[string]float64{
+		"default":    {"startRow": 1, "startColumn": 1, "xSplit": 1, "ySplit": 1},
+		"rowOnly":    {"startRow": 1, "startColumn": -1, "xSplit": 0, "ySplit": 1},
+		"columnOnly": {"startRow": -1, "startColumn": 1, "xSplit": 1, "ySplit": 0},
+	}
+	for logicalID, wantFields := range wantFreeze {
+		gotConfig, ok := freeze[logicalID].(map[string]any)
+		if !ok {
+			t.Errorf("freeze.%s = %#v, want object", logicalID, freeze[logicalID])
+			continue
+		}
+		for field, want := range wantFields {
+			if got := gotConfig[field]; got != want {
+				t.Errorf("freeze.%s.%s = %#v, want %v", logicalID, field, got, want)
+			}
+		}
+	}
+	filters, ok := gotBody["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("filters = %#v, want default filter", gotBody["filters"])
+	}
+	filterDefault, ok := filters["default"].(map[string]any)
+	if !ok {
+		t.Fatalf("filters.default = %#v, want object", filters["default"])
+	}
+	filterRef, ok := filterDefault["ref"].(map[string]any)
+	if !ok {
+		t.Fatalf("filters.default.ref = %#v, want object", filterDefault["ref"])
+	}
+	for field, want := range map[string]float64{
+		"startRow": 0, "startColumn": 0, "endRow": 20, "endColumn": 1,
+	} {
+		if got := filterRef[field]; got != want {
+			t.Errorf("filters.default.ref.%s = %#v, want %v", field, got, want)
+		}
+	}
+	filterColumns, ok := filterDefault["filterColumns"].([]any)
+	if !ok || len(filterColumns) != 1 {
+		t.Fatalf("filters.default.filterColumns = %#v, want one-element array", filterDefault["filterColumns"])
+	}
+	filterColumn, ok := filterColumns[0].(map[string]any)
+	if !ok {
+		t.Fatalf("filters.default.filterColumns[0] = %#v, want object", filterColumns[0])
+	}
+	if got := filterColumn["colId"]; got != float64(1) {
+		t.Errorf("filters.default.filterColumns[0].colId = %#v, want 1", got)
+	}
+	filterCriteria, ok := filterColumn["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("filters.default.filterColumns[0].filters = %#v, want object", filterColumn["filters"])
+	}
+	if got, want := filterCriteria["filters"], []any{"待处理"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("filters.default.filterColumns[0].filters.filters = %#v, want %#v", got, want)
+	}
+	validations, ok := gotBody["dataValidations"].(map[string]any)
+	if !ok {
+		t.Fatalf("dataValidations = %#v, want object", gotBody["dataValidations"])
+	}
+	rules, ok := validations["default"].([]any)
+	if !ok || len(rules) != 2 {
+		t.Fatalf("dataValidations.default = %#v, want two rules", validations["default"])
+	}
+	wantRules := []struct {
+		uid         string
+		typeName    string
+		startColumn float64
+	}{
+		{uid: "single", typeName: "list", startColumn: 0},
+		{uid: "multiple", typeName: "listMultiple", startColumn: 1},
+	}
+	for i, wantRule := range wantRules {
+		rule, ok := rules[i].(map[string]any)
+		if !ok {
+			t.Errorf("dataValidations.default[%d] = %#v, want object", i, rules[i])
+			continue
+		}
+		for field, want := range map[string]any{
+			"uid":          wantRule.uid,
+			"type":         wantRule.typeName,
+			"formula1":     `["待处理","已完成"]`,
+			"formula2":     "#E4F4FE,#EFFBD0",
+			"showDropDown": true,
+			"renderMode":   float64(2),
+		} {
+			if got := rule[field]; !reflect.DeepEqual(got, want) {
+				t.Errorf("dataValidations.default[%d].%s = %#v, want %#v", i, field, got, want)
+			}
+		}
+		ranges, ok := rule["ranges"].([]any)
+		if !ok || len(ranges) != 1 {
+			t.Errorf("dataValidations.default[%d].ranges = %#v, want one-element array", i, rule["ranges"])
+			continue
+		}
+		gotRange, ok := ranges[0].(map[string]any)
+		if !ok {
+			t.Errorf("dataValidations.default[%d].ranges[0] = %#v, want object", i, ranges[0])
+			continue
+		}
+		wantRange := map[string]any{
+			"startRow": float64(1), "startColumn": wantRule.startColumn,
+			"endRow": float64(20), "endColumn": wantRule.startColumn,
+		}
+		if !reflect.DeepEqual(gotRange, wantRange) {
+			t.Errorf("dataValidations.default[%d].ranges[0] = %#v, want %#v", i, gotRange, wantRange)
+		}
+	}
+	if _, present := gotBody["baseVersion"]; present {
+		t.Errorf("baseVersion must stay in If-Match, got body value %#v", gotBody["baseVersion"])
 	}
 }
 

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -623,6 +624,238 @@ func TestHeaderParamWithFlagAlias(t *testing.T) {
 	}
 	if !found.Required {
 		t.Error("If-Match header must be required (mandatory base-version guard)")
+	}
+}
+
+// TestDocsSheetP0ResourceSchemas pins the Bot-visible contract for the P0
+// worksheet resources. The request schema teaches these keys while the generic
+// --data transport remains intentionally open; response schemas pin readback.
+func TestDocsSheetP0ResourceSchemas(t *testing.T) {
+	r := MustNew()
+	edit, ok := r.GetOperation("docs.sheet.edit")
+	if !ok || edit.RequestBody == nil {
+		t.Fatal("docs.sheet.edit request schema missing")
+	}
+	for _, field := range []string{"freeze", "filters", "dataValidations"} {
+		property, present := edit.RequestBody.Properties[field]
+		if !present || property.Type != "object" {
+			t.Errorf("docs.sheet.edit request property %q = %#v, want object", field, property)
+		}
+	}
+	cells, present := edit.RequestBody.Properties["cells"]
+	if !present {
+		t.Fatal("docs.sheet.edit request schema missing cells")
+	}
+	for _, want := range []string{`"p":<rich-text object>?`, `"t":<number>?`, "v/f/s/p/t"} {
+		if !strings.Contains(cells.Description, want) {
+			t.Errorf("docs.sheet.edit cells description must document %q; got %q", want, cells.Description)
+		}
+	}
+	for _, field := range []string{"dims", "hyperlinks", "sheets"} {
+		property, present := edit.RequestBody.Properties[field]
+		if !present {
+			t.Errorf("docs.sheet.edit request schema missing %s", field)
+		}
+		if strings.Contains(property.Description, "only non-empty surface") || strings.Contains(property.Description, "combine with any other non-empty") {
+			t.Errorf("docs.sheet.edit %s description must leave the common non-empty rule at operation level: %q", field, property.Description)
+		}
+	}
+	dims := edit.RequestBody.Properties["dims"]
+	for _, want := range []string{
+		"`${logicalId}:c<idx>` / `${logicalId}:r<idx>`",
+		"bare `c<idx>` / `r<idx>` address the legacy default sheet",
+		"Bare and prefixed default-sheet keys are separate stored entries",
+		`{"c0":null,"default:c0":200}`,
+	} {
+		if !strings.Contains(dims.Description, want) {
+			t.Errorf("docs.sheet.edit dims description must document %q; got %q", want, dims.Description)
+		}
+	}
+	filters, present := edit.RequestBody.Properties["filters"]
+	if !present ||
+		!strings.Contains(filters.Description, `filterColumns?:[`) ||
+		!strings.Contains(filters.Description, `"filters":{"filters":[<raw values>]}`) ||
+		!strings.Contains(filters.Description, "ref.startRow is the header row and stays visible") ||
+		!strings.Contains(filters.Description, "filterColumns:[] keeps the range but omits filterColumns on readback") {
+		t.Errorf("docs.sheet.edit filters description must expose a buildable value-filter shape; got %#v", filters)
+	}
+	freeze := edit.RequestBody.Properties["freeze"]
+	if !strings.Contains(freeze.Description, "0 is accepted there but normalizes to -1 on readback") {
+		t.Errorf("docs.sheet.edit freeze description must document zero normalization; got %#v", freeze)
+	}
+	validations, present := edit.RequestBody.Properties["dataValidations"]
+	if !present {
+		t.Fatal("docs.sheet.edit request schema missing dataValidations")
+	}
+	for _, want := range []string{
+		"every validation family, including list, listMultiple, and checkbox",
+		"internal flat `${logicalId}!${uid}` Y.Map shape",
+		"uid unique within that sheet (1–128 characters, no `!` or control characters)",
+		"at least one non-empty ranges:[{startRow,startColumn,endRow,endColumn}] entry",
+		"formula2 as the same number of comma-separated colors",
+		"recommended rendering inputs, not additional server-required fields",
+		"listMultiple cell stores selected labels in v as a JSON-array string",
+		"list cell stores the label directly",
+		"replaces that sheet's entire rule set",
+		"read sheetDataValidations first",
+		"resend every rule to keep",
+		"do not write if the deployed read surface omits any validation family",
+	} {
+		if !strings.Contains(validations.Description, want) {
+			t.Errorf("docs.sheet.edit dataValidations description must document %q; got %q", want, validations.Description)
+		}
+	}
+
+	get, ok := r.GetOperation("docs.sheet.get")
+	if !ok || get.ResponseSchema == nil {
+		t.Fatal("docs.sheet.get response schema missing")
+	}
+	for _, field := range []string{"sheetFreeze", "sheetFilters", "sheetDataValidations"} {
+		property, present := get.ResponseSchema.Properties[field]
+		if !present || property.Type != "object" {
+			t.Errorf("docs.sheet.get response property %q = %#v, want object", field, property)
+		}
+	}
+	readFilters := get.ResponseSchema.Properties["sheetFilters"]
+	if !strings.Contains(readFilters.Description, `filterColumns?:[`) ||
+		!strings.Contains(readFilters.Description, `"filters":{"filters":[<raw values>]}`) ||
+		!strings.Contains(readFilters.Description, "ref.startRow is the header row and stays visible") ||
+		!strings.Contains(readFilters.Description, "empty filterColumns array is omitted on readback") {
+		t.Errorf("docs.sheet.get sheetFilters description must expose a buildable value-filter shape; got %#v", readFilters)
+	}
+	readValidations := get.ResponseSchema.Properties["sheetDataValidations"]
+	for _, want := range []string{
+		"every returned validation family",
+		"including `list`, `listMultiple`, and `checkbox`",
+		"not the internal flat `${logicalId}!${uid}` Y.Map",
+	} {
+		if !strings.Contains(readValidations.Description, want) {
+			t.Errorf("docs.sheet.get sheetDataValidations description must document %q; got %#v", want, readValidations)
+		}
+	}
+	readCells, present := get.ResponseSchema.Properties["sheetCells"]
+	if !present || !strings.Contains(readCells.Description, "{v?,f?,s?,p?,t?}") {
+		t.Errorf("docs.sheet.get sheetCells description must document the full cell shape; got %#v", readCells)
+	}
+	readDims, present := get.ResponseSchema.Properties["sheetDims"]
+	if !present {
+		t.Fatal("docs.sheet.get response schema missing sheetDims")
+	}
+	for _, want := range []string{
+		"`${logicalId}:c<idx>` / `${logicalId}:r<idx>` target a specific tab",
+		"bare `c<idx>` / `r<idx>` address the legacy default sheet",
+		"Reads return keys exactly as stored",
+	} {
+		if !strings.Contains(readDims.Description, want) {
+			t.Errorf("docs.sheet.get sheetDims description must document %q; got %q", want, readDims.Description)
+		}
+	}
+
+	state, ok := r.GetOperation("docs.versions.state")
+	if !ok || state.ResponseSchema == nil {
+		t.Fatal("docs.versions.state response schema missing")
+	}
+	for _, field := range []string{"sheetFreeze", "sheetFilters", "sheetDataValidations"} {
+		property, present := state.ResponseSchema.Properties[field]
+		if !present || property.Type != "object" {
+			t.Errorf("docs.versions.state response property %q = %#v, want object", field, property)
+		}
+		if !strings.Contains(property.Description, "empty {} for a text document") {
+			t.Errorf("docs.versions.state response property %q must document text-doc emptiness; got %#v", field, property)
+		}
+	}
+	// The version-state handler does not decode sheetHyperLinks, sheetMerges, or
+	// sheetList. Remove this guard when that backend response starts returning
+	// those fields and the schema is updated in the same change.
+	for _, field := range []string{"sheetHyperLinks", "sheetMerges", "sheetList"} {
+		if _, present := state.ResponseSchema.Properties[field]; present {
+			t.Errorf("docs.versions.state must not promise backend-absent field %q", field)
+		}
+	}
+
+	rawDocs, err := specsFS.ReadFile("specs/docs.json")
+	if err != nil {
+		t.Fatalf("read embedded docs spec: %v", err)
+	}
+	var rawSpec struct {
+		Paths map[string]struct {
+			Get struct {
+				Description string `json:"description"`
+				Responses   map[string]struct {
+					Content map[string]struct {
+						Schema struct {
+							Properties map[string]struct {
+								Type any `json:"type"`
+							} `json:"properties"`
+						} `json:"schema"`
+					} `json:"content"`
+				} `json:"responses"`
+			} `json:"get"`
+			Patch struct {
+				Description string `json:"description"`
+			} `json:"patch"`
+		} `json:"paths"`
+	}
+	if err := json.Unmarshal(rawDocs, &rawSpec); err != nil {
+		t.Fatalf("decode embedded docs spec: %v", err)
+	}
+	sheetPath, present := rawSpec.Paths["/v1/bot/docs/{docId}/sheet"]
+	if !present {
+		t.Fatal("sheet path missing from embedded docs spec")
+	}
+	nextCursorType := sheetPath.Get.Responses["200"].Content["application/json"].Schema.Properties["nextCursor"].Type
+	if !reflect.DeepEqual(nextCursorType, []any{"string", "null"}) {
+		t.Errorf("docs.sheet.get nextCursor type = %#v, want nullable string union", nextCursorType)
+	}
+	contractText := strings.Join([]string{
+		sheetPath.Get.Description,
+		sheetPath.Patch.Description,
+		validations.Description,
+		readValidations.Description,
+	}, "\n")
+	for _, superseded := range []string{
+		`sheetDataValidations: { "logicalId!uid":`,
+		`Only type:"checkbox" is accepted`,
+		"only checkbox rules are supported",
+	} {
+		if strings.Contains(contractText, superseded) {
+			t.Errorf("embedded docs spec retains superseded validation contract %q", superseded)
+		}
+	}
+	for _, operation := range []struct {
+		name        string
+		description string
+	}{
+		{name: "docs.sheet.get", description: sheetPath.Get.Description},
+		{name: "docs.sheet.edit", description: sheetPath.Patch.Description},
+	} {
+		for _, want := range []string{
+			"raw coordinate rewrite",
+			"reorder the complete selected row block",
+			"use null for destinations that become empty",
+			"does not re-anchor relative formula references",
+			"Any state keyed by or containing coordinates stays at its old coordinates",
+			"row dims",
+			"data-validation ranges",
+			"cell-comment anchors",
+			"freeze panes and filter ranges/columns also remain fixed",
+			"`sheetDims` is one workbook-level map whose keys may be sheet-qualified",
+			"`${logicalId}:c<idx>` / `${logicalId}:r<idx>` targets one tab",
+			"bare `c<idx>` / `r<idx>` addresses the legacy default sheet",
+			"reads return keys exactly as stored",
+			"evaluate `sheetFilters` criteria",
+			"leaves hidden row coordinates unchanged",
+		} {
+			if !strings.Contains(operation.description, want) {
+				t.Errorf("%s description must document %q; got %q", operation.name, want, operation.description)
+			}
+		}
+		if strings.Contains(operation.description, "clear the filter first") {
+			t.Errorf("%s description must not claim clearing a filter preserves the visible subset", operation.name)
+		}
+	}
+	if !strings.Contains(sheetPath.Patch.Description, "Any one surface may be the only non-empty batch member") {
+		t.Errorf("docs.sheet.edit description must allow any standalone non-empty surface; got %q", sheetPath.Patch.Description)
 	}
 }
 

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -380,8 +380,8 @@
     "/v1/bot/docs/{docId}/sheet": {
       "get": {
         "operationId": "docs.sheet.get",
-        "summary": "Read a spreadsheet's live cells + dims + base version (needs reader)",
-        "description": "Reads the LIVE flat cell map of a doc_type 'sheet' (keys `sheetId!row:col`, values {v,f,s}), its column-width / row-height overrides (sheetDims), its cell hyperlinks (sheetHyperLinks), its merged cell ranges (sheetMerges), its sheet tabs / pages (sheetList, logicalId -> {name,order}), and the base-version token that pins the read. Pass that token to `docs sheet edit` as --base-version so the optimistic-concurrency guard can prove the sheet did not change between read and write. doc / board / whiteboard bodies are a different Y.Doc shape and return 409 unsupported_doc_type here. A whole-sheet read of a grid over the 1MB cap returns 413 sheet_too_large; pass --limit (and follow nextCursor via --cursor) to read it in pages instead. In paged mode each page is bounded by both --limit and the byte cap, sheetDims, sheetHyperLinks, sheetMerges and sheetList are returned on the first page only, and the response carries hasMore + nextCursor. A --cursor whose snapshot moved returns 409 sheet_changed (restart from the first page); a bad --cursor returns 400 invalid_cursor; a non-positive --limit returns 400 invalid_limit.",
+        "summary": "Read a spreadsheet's live cells, worksheet resources, and base version (needs reader)",
+        "description": "Reads the LIVE flat cell map of a doc_type 'sheet' (keys `sheetId!row:col`, values {v,f,s,p,t}), column-width / row-height overrides (sheetDims), hyperlinks (sheetHyperLinks), merged ranges (sheetMerges), sheet tabs (sheetList), freeze panes (sheetFreeze), shared filters (sheetFilters), data-validation/dropdown rules (sheetDataValidations), and the base-version token that pins the read. Pass that token to `docs sheet edit` as --base-version so the optimistic-concurrency guard can prove the sheet did not change between read and write. Sorting is a raw coordinate rewrite, not a spreadsheet-native sort: reorder the complete selected row block, carry each cell's complete {v,f,s,p,t} shape to its destination, and use null for destinations that become empty. The server stores `f` verbatim and does not re-anchor relative formula references; rewrite them for the destination or do not sort that range. Any state keyed by or containing coordinates stays at its old coordinates, including row dims, data-validation ranges, hyperlinks, merges, drawings, and cell-comment anchors; freeze panes and filter ranges/columns also remain fixed. Remap every affected resource for which you have an authoritative readable/writable surface, or do not sort the range. `sheetDims` is one workbook-level map whose keys may be sheet-qualified: `${logicalId}:c<idx>` / `${logicalId}:r<idx>` targets one tab, while bare `c<idx>` / `r<idx>` addresses the legacy default sheet; reads return keys exactly as stored. Rows hidden by an active shared filter are still returned and a full rectangle rewrite includes them. To sort only visible rows, evaluate `sheetFilters` criteria first and build a sparse permutation that leaves hidden row coordinates unchanged; clearing the filter does not preserve the visible subset. doc / board / whiteboard bodies are a different Y.Doc shape and return 409 unsupported_doc_type here. A whole-sheet read over the 1 MB byte cap returns 413 sheet_too_large; pass --limit and follow nextCursor via --cursor. In paged mode every page is bounded by both --limit and the byte cap; sheetDims, sheetHyperLinks, sheetMerges, sheetList, sheetFreeze, sheetFilters, and sheetDataValidations are returned on the first page only. A --cursor whose snapshot moved returns 409 sheet_changed; a malformed --cursor returns 400 invalid_cursor; a non-positive --limit returns 400 invalid_limit.",
         "x-octo-risk": "read",
         "parameters": [
           {
@@ -424,11 +424,11 @@
                     },
                     "sheetCells": {
                       "type": "object",
-                      "description": "flat cell map keyed `sheetId!row:col`; each value is {v?,f?,s?}. A page slice in paged mode."
+                      "description": "flat cell map keyed `sheetId!row:col`; each value is {v?,f?,s?,p?,t?}. A page slice in paged mode."
                     },
                     "sheetDims": {
                       "type": "object",
-                      "description": "column-width / row-height overrides keyed c<idx>/r<idx>. Returned on the first page only in paged mode."
+                      "description": "column-width / row-height overrides in one workbook-level map. Keys `${logicalId}:c<idx>` / `${logicalId}:r<idx>` target a specific tab; bare `c<idx>` / `r<idx>` address the legacy default sheet. Reads return keys exactly as stored. Returned on the first page only in paged mode."
                     },
                     "sheetHyperLinks": {
                       "type": "object",
@@ -442,6 +442,18 @@
                       "type": "object",
                       "description": "sheet tabs / pages keyed by logicalId; each value is {name,order}. The first tab's logicalId is 'default'. Returned on the first page only in paged mode."
                     },
+                    "sheetFreeze": {
+                      "type": "object",
+                      "description": "freeze panes keyed by logicalId; each value is {startRow,startColumn,xSplit,ySplit}. An unfrozen axis reads back with startRow/startColumn -1 even when the write used 0. Returned on the first page only in paged mode."
+                    },
+                    "sheetFilters": {
+                      "type": "object",
+                      "description": "shared auto-filter state keyed by logicalId; each value is {ref,filterColumns?:[{\"colId\":<absolute 0-based column>,\"filters\":{\"filters\":[<raw values>]}}]}. ref.startRow is the header row and stays visible; criteria apply to rows below it. An empty filterColumns array is omitted on readback. Returned on the first page only in paged mode."
+                    },
+                    "sheetDataValidations": {
+                      "type": "object",
+                      "description": "data-validation arrays keyed by logicalId; each array can contain every returned validation family, including `list`, `listMultiple`, and `checkbox`. This public shape is not the internal flat `${logicalId}!${uid}` Y.Map. Dropdown formula1 is the serialized option list and formula2 is the comma-separated option-color list. Returned on the first page only in paged mode."
+                    },
                     "baseVersion": {
                       "type": "string",
                       "description": "opaque base64 base-version token; pass to `docs sheet edit --base-version`"
@@ -451,7 +463,7 @@
                       "description": "paged mode: more cells remain after this page"
                     },
                     "nextCursor": {
-                      "type": "string",
+                      "type": ["string", "null"],
                       "description": "paged mode: opaque cursor for the next page (null when hasMore is false); pass back via --cursor"
                     }
                   }
@@ -463,8 +475,8 @@
       },
       "patch": {
         "operationId": "docs.sheet.edit",
-        "summary": "Apply a batch sheet edit — cells / dims / drawings / hyperlinks / merges / sheet tabs (needs writer)",
-        "description": "Applies a batch of cell, dimension, and/or drawing set/delete ops to a doc_type 'sheet' under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs sheet get` via --base-version (sent as the If-Match header); the server rejects with 412 base_version_stale if the live sheet moved since that read. The cells batch is a JSON object `{ \"sheetId!row:col\": {v,f,s} | null }` (a null value deletes the cell). The optional dims batch sets column widths / row heights: a JSON object `{ \"c<idx>\"|\"r<idx>\": <px> | null }` (e.g. `{\"c0\":200,\"r3\":40}`; a null value deletes that dim). The optional drawings batch inserts/removes floating images: a JSON object `{ \"sheetId!drawingId\": <ISheetImage> | null }` (image bytes ride inline as a base64 data URL in `source`; a math formula rides here too as a float-DOM drawing with `drawingType:8`, `componentKey:\"octo-math-formula\"`, and the LaTeX in `data.latex`). The optional hyperlinks batch sets cell links: a JSON object `{ \"sheetId!linkId\": {id,row,column,payload,display?} | null }` (payload is the URL — http/https/mailto or an internal #jump — and the link points at a cell by row/column; put the visible text in that cell's `v`). The optional merges batch merges cell ranges: a JSON object `{ \"logicalId:sr:sc:er:ec\": true | null }` (0-based startRow:startCol:endRow:endCol; e.g. `{\"default:0:0:1:2\":true}` merges the A1:C2 block; a null value un-merges that range). The optional sheets batch manages sheet TABS / pages: a JSON object `{ \"logicalId\": {\"name\":\"<tab name>\",\"order\":<n>} | null }` (set to create / rename / reorder a tab, or null to delete it; read the current tabs from `docs sheet get`'s sheetList — the first tab's logicalId is 'default'; to ADD a sheet, set a NEW logicalId here AND write that sheet's cells with keys `logicalId!row:col`). Provide `cells`, `dims`, `drawings`, `hyperlinks`, `merges`, or `sheets` via --data; at least one must be non-empty. Only doc_type 'sheet' is accepted (doc / board / whiteboard return 409 unsupported_doc_type). Gates: cell/dim/drawing count over the max → 413 too_many_cells, a single cell's payload too large → 413 cell_too_large, missing base version / malformed shape / all batches empty → 400 invalid_body, a cell/dim/drawing/merge/tab violating its contract or key shape → 422 sheet_cell_invalid.",
+        "summary": "Apply a batch sheet edit — cells, layout, filters, validation, and dropdowns (needs writer)",
+        "description": "Applies one atomic spreadsheet batch under a mandatory optimistic-concurrency guard. Pass the base-version token from `docs sheet get` via --base-version (sent as If-Match); stale writes return 412 base_version_stale. Existing surfaces are cells, dims, drawings, hyperlinks, merges, and sheets. P0 worksheet resources are: freeze `{logicalId:{startRow,startColumn,xSplit,ySplit}|null}`, filters `{logicalId:{ref:{startRow,startColumn,endRow,endColumn},filterColumns?:[columns]}|null}`, and dataValidations `{logicalId:[rules]|null}`. The public dataValidations and sheetDataValidations shapes are per-sheet arrays for every validation family, including list, listMultiple, and checkbox; do not send the internal flat `${logicalId}!${uid}` Y.Map shape. The server requires each rule uid to be unique within the sheet, 1–128 characters, free of `!` and control characters, plus at least one non-empty ranges entry. For a working colored `list` or `listMultiple` dropdown, also send type, formula1 (JSON-serialized option labels), formula2 (the same number of comma-separated colors), showDropDown, and renderMode; omit operator. A listMultiple cell stores its selected labels as a JSON-array string, while a list cell stores the label directly. dataValidations is replace-style per logical sheet: read sheetDataValidations first and resend every rule to keep, but do not write if the deployed read surface omits any validation family on that sheet. null removes a freeze/filter/resource entry, and null or [] removes all validation rules for that sheet. An empty filterColumns array is omitted on readback. An unfrozen freeze axis accepts startRow/startColumn 0 but normalizes it to -1. Sorting is a raw coordinate rewrite, not a spreadsheet-native sort: reorder the complete selected row block, carry each cell's complete {v,f,s,p,t} shape to its destination, and use null for destinations that become empty. The server stores `f` verbatim and does not re-anchor relative formula references; rewrite them for the destination or do not sort that range. Any state keyed by or containing coordinates stays at its old coordinates, including row dims, data-validation ranges, hyperlinks, merges, drawings, and cell-comment anchors; freeze panes and filter ranges/columns also remain fixed. Remap every affected resource for which you have an authoritative readable/writable surface, or do not sort the range. `sheetDims` is one workbook-level map whose keys may be sheet-qualified: `${logicalId}:c<idx>` / `${logicalId}:r<idx>` targets one tab, while bare `c<idx>` / `r<idx>` addresses the legacy default sheet; reads return keys exactly as stored. Bare and prefixed keys for the default sheet are separate entries; when migrating a legacy key, read sheetDims and clear the bare twin in the same batch, for example `{\"c0\":null,\"default:c0\":200}`. Rows hidden by an active shared filter still participate in a full rectangle rewrite. To sort only visible rows, evaluate `sheetFilters` criteria first and build a sparse permutation that leaves hidden row coordinates unchanged; clearing the filter does not preserve the visible subset. Any one surface may be the only non-empty batch member, but at least one surface must be non-empty. Only doc_type 'sheet' is accepted. Gates: cell/dim/drawing count over the max → 413 too_many_cells; worksheet-resource key count over the max → 413 too_many_sheet_resources; a single cell's payload too large → 413 cell_too_large; missing base version, malformed shape, or all batches empty → 400 invalid_body; a cell/dim/drawing/hyperlink/merge/tab/freeze/filter/data-validation violating its contract or key shape → 422 sheet_cell_invalid.",
         "x-octo-risk": "write",
         "parameters": [
           {
@@ -495,11 +507,11 @@
                 "properties": {
                   "cells": {
                     "type": "object",
-                    "description": "batch of cell ops keyed by cell key `sheetId!row:col` (e.g. `default!0:0`). Each value is either {\"v\":<string|number|boolean|null>,\"f\":\"<formula>\"?,\"s\":<style object>?} to set the cell, or null to delete it. At least one of v/f/s must be present on a set. Pass via --data."
+                    "description": "batch of cell ops keyed by cell key `sheetId!row:col` (e.g. `default!0:0`). Each value is either {\"v\":<string|number|boolean|null>,\"f\":\"<formula>\"?,\"s\":<style object>?,\"p\":<rich-text object>?,\"t\":<number>?} to set the cell, or null to delete it. At least one of v/f/s/p/t must be present on a set. Pass via --data."
                   },
                   "dims": {
                     "type": "object",
-                    "description": "batch of column-width / row-height ops keyed `c<idx>` (column) or `r<idx>` (row), e.g. `{\"c0\":200,\"r3\":40}`. Each value is a positive pixel number to set, or null to delete that dim. Optional; provide cells, dims, or drawings (at least one non-empty). Pass via --data."
+                    "description": "batch of column-width / row-height ops in one workbook-level map. Use `${logicalId}:c<idx>` / `${logicalId}:r<idx>` to target a specific tab; bare `c<idx>` / `r<idx>` address the legacy default sheet. Bare and prefixed default-sheet keys are separate stored entries: read sheetDims first and clear the bare twin while migrating, for example `{\"c0\":null,\"default:c0\":200}`. Each value is a positive pixel number to set, or null to delete that dim. Optional. Pass via --data."
                   },
                   "drawings": {
                     "type": "object",
@@ -507,7 +519,7 @@
                   },
                   "hyperlinks": {
                     "type": "object",
-                    "description": "batch of cell-hyperlink ops keyed `${sheetId}!${linkId}` (e.g. `default!lnk1`). Each value is {id (== the key's linkId), row, column (0-based cell anchor), payload:\"<url>\" (http/https/mailto or an internal #jump), display?:\"<label>\"} to set, or null to delete. The link lives outside cell data and points at a cell by row/column; put the cell's visible text in that cell's `v`. Optional; provide cells, dims, drawings, or hyperlinks (at least one non-empty). Pass via --data."
+                    "description": "batch of cell-hyperlink ops keyed `${sheetId}!${linkId}` (e.g. `default!lnk1`). Each value is {id (== the key's linkId), row, column (0-based cell anchor), payload:\"<url>\" (http/https/mailto or an internal #jump), display?:\"<label>\"} to set, or null to delete. The link lives outside cell data and points at a cell by row/column; put the cell's visible text in that cell's `v`. Optional. Pass via --data."
                   },
                   "merges": {
                     "type": "object",
@@ -515,7 +527,19 @@
                   },
                   "sheets": {
                     "type": "object",
-                    "description": "batch of sheet-TAB (page) ops keyed by logicalId. Value {name,order} to create / rename / reorder a tab, or null to delete it. Read the current tabs from `docs sheet get`'s sheetList (logicalId -> {name,order}); the first tab's logicalId is 'default'. To ADD a sheet: set a NEW logicalId here AND write that sheet's cells with keys `${logicalId}!row:col`. Optional; provide any of cells / dims / drawings / hyperlinks / merges / sheets (at least one non-empty). Pass via --data."
+                    "description": "batch of sheet-TAB (page) ops keyed by logicalId. Value {name,order} to create / rename / reorder a tab, or null to delete it. Read the current tabs from `docs sheet get`'s sheetList (logicalId -> {name,order}); the first tab's logicalId is 'default'. To ADD a sheet: set a NEW logicalId here AND write that sheet's cells with keys `${logicalId}!row:col`. Optional. Pass via --data."
+                  },
+                  "freeze": {
+                    "type": "object",
+                    "description": "batch of freeze-pane configs keyed by logicalId. Value {startRow,startColumn,xSplit,ySplit}; startRow/startColumn are the first scrollable row/column and normally equal ySplit/xSplit when freezing the first N rows/columns. Use -1 for the start coordinate of an unfrozen axis; 0 is accepted there but normalizes to -1 on readback. null unfreezes that sheet. Optional. Pass via --data."
+                  },
+                  "filters": {
+                    "type": "object",
+                    "description": "batch of shared auto-filter snapshots keyed by logicalId. Value {ref:{startRow,startColumn,endRow,endColumn},filterColumns?:[{\"colId\":<absolute 0-based column>,\"filters\":{\"filters\":[<raw values>]}}]}. ref.startRow is the header row and stays visible; criteria apply to rows below it. colId is not an offset from ref.startColumn. Sending filterColumns:[] keeps the range but omits filterColumns on readback. null removes the filter. Optional. Pass via --data."
+                  },
+                  "dataValidations": {
+                    "type": "object",
+                    "description": "replace-style data-validation arrays keyed by logicalId. This public REST shape covers every validation family, including list, listMultiple, and checkbox; do not use the internal flat `${logicalId}!${uid}` Y.Map shape. The server requires each rule to have a uid unique within that sheet (1–128 characters, no `!` or control characters) and at least one non-empty ranges:[{startRow,startColumn,endRow,endColumn}] entry. It replaces that sheet's entire rule set, so read sheetDataValidations first and resend every rule to keep; do not write if the deployed read surface omits any validation family. For a working colored dropdown, use type 'list' or 'listMultiple', formula1 as a JSON string array of labels, formula2 as the same number of comma-separated colors, showDropDown:true, renderMode:2, and no operator. These dropdown fields are recommended rendering inputs, not additional server-required fields. A listMultiple cell stores selected labels in v as a JSON-array string; a list cell stores the label directly. The server strips operator from otherwise-valid list rules. null or [] removes all rules for the sheet. Optional. Pass via --data."
                   }
                 }
               }
@@ -979,7 +1003,7 @@
       "get": {
         "operationId": "docs.versions.state",
         "summary": "Read a version's decoded content snapshot (read-only preview; needs reader)",
-        "description": "Returns the version decoded to structured content, kind-selected by the doc's doc_type. A document/sheet decodes to ProseMirror JSON ({kind:'document', doc, sheetCells, sheetDims, schemaVersion, docVersionSeq}); a board decodes to an Excalidraw scene ({kind:'board', scene, schemaVersion, docVersionSeq}). This is a read-only preview of a past snapshot, not the live document, and cannot be written.",
+        "description": "Returns the version decoded to structured content, kind-selected by the doc's doc_type. A document/sheet decodes to ProseMirror JSON plus the spreadsheet maps exposed by this endpoint ({kind:'document', doc, sheetCells, sheetDims, sheetFreeze, sheetFilters, sheetDataValidations, schemaVersion, docVersionSeq}); every sheet map is an empty {} for a text document. A board decodes to an Excalidraw scene ({kind:'board', scene, schemaVersion, docVersionSeq}). This is a read-only preview of a past snapshot, not the live document, and cannot be written.",
         "x-octo-risk": "read",
         "parameters": [
           { "name": "docId", "in": "path", "required": true, "schema": { "type": "string" } },
@@ -997,6 +1021,9 @@
                     "doc": { "type": "object", "description": "document/sheet only: the snapshot body as ProseMirror document JSON" },
                     "sheetCells": { "type": "object", "description": "document/sheet only: flat cell map keyed `sheetId!row:col` (empty {} for a text document)" },
                     "sheetDims": { "type": "object", "description": "document/sheet only: column-width / row-height overrides (empty {} for a text document)" },
+                    "sheetFreeze": { "type": "object", "description": "document/sheet only: freeze panes keyed by logicalId (empty {} for a text document)" },
+                    "sheetFilters": { "type": "object", "description": "document/sheet only: shared filter range and criteria keyed by logicalId (empty {} for a text document)" },
+                    "sheetDataValidations": { "type": "object", "description": "document/sheet only: per-sheet arrays containing every data-validation family, including dropdowns and checkboxes (empty {} for a text document)" },
                     "scene": { "type": "object", "description": "board only: the decoded Excalidraw scene ({elements in z-order, files})" },
                     "schemaVersion": { "type": "integer" },
                     "docVersionSeq": { "type": "integer" }

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-docs
 version: 0.2.0
-description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheet cells (dims + images), read and batch-edit whiteboard scenes, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
+description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheets including cells, layout, shared filters, sorting, freeze panes, and validation/dropdowns, read and batch-edit whiteboard scenes, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
@@ -21,7 +21,7 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 
 | Your task | Read |
 |---|---|
-| Read/edit a **spreadsheet** (`doc_type: sheet`): cells, formulas, styles, column widths / row heights (dims), floating **images**, paged reads, xlsx export | **`sheet.md`** |
+| Read/edit a **spreadsheet** (`doc_type: sheet`): cells, formulas, styles, layout, floating **images**, freeze panes, shared filters, sorting, data validation/dropdowns, paged reads, xlsx export | **`sheet.md`** |
 | Read/edit a rich-text **document body** (`doc_type: doc`): incremental block ops | **`doc.md`** |
 | Read/edit a **whiteboard** (`doc_type: board`): scene elements/files, image export | **`board.md`** |
 | Continue from a searchable **HTML document** (`doc_type: html`): resolve its document reference, then use immutable versions/drafts/assets/comments | **`../octo-html/SKILL.md`** |
@@ -99,8 +99,8 @@ Pagination depends on the endpoint's response contract:
 
 `docs attachments upload` (binary helper), invites, access-requests, and
 link-card are out of scope here. Body editing is limited to `doc_type: doc`
-incremental block ops (`doc.md`), `doc_type: sheet` cell/dims/drawings batches
-(`sheet.md`), and `doc_type: board` scene batches (`board.md`). `doc_type: html`
+incremental block ops (`doc.md`), the spreadsheet batches documented in
+`sheet.md`, and `doc_type: board` scene batches (`board.md`). `doc_type: html`
 belongs to the separate `html` domain, uses its returned document reference, and
 is published as
 immutable versions; it cannot be read or edited through these three body

--- a/skills/octo-docs/common.md
+++ b/skills/octo-docs/common.md
@@ -99,10 +99,13 @@ kind — a document/sheet as `{kind:"document", doc, sheetCells, sheetDims, ...}
 board as `{kind:"board", scene, ...}`. It is a preview, not the live document, and
 is not writable. To read the **live** content, use `docs content get` (`doc.md`),
 `docs sheet get` (`sheet.md`), or `docs scene get` (`board.md`).
+For a text document, every returned sheet map (`sheetCells`, `sheetDims`,
+`sheetFreeze`, `sheetFilters`, and `sheetDataValidations`) is an empty `{}`.
 
 `restore` is non-destructive and records a safety snapshot first, so it is itself
 undoable. For a sheet, restore rolls back the full grid — cells, column-width /
-row-height dims, AND floating images — to the target version.
+row-height dims, floating images, hyperlinks, merges, sheet tabs, freeze panes,
+shared filters, and data-validation rules — to the target version.
 Schema: `octo-cli schema docs.versions.restore`.
 
 ---

--- a/skills/octo-docs/sheet.md
+++ b/skills/octo-docs/sheet.md
@@ -1,8 +1,9 @@
-# octo-docs — Spreadsheet cells, dims & images (`doc_type: sheet`)
+# octo-docs — Spreadsheet cells, layout & rules (`doc_type: sheet`)
 
 Read this when the target is a **spreadsheet** (`doc_type: sheet`) and you need to
 read or edit its cells, column widths / row heights, floating images, hyperlinks,
-merged ranges, sheet tabs, or export it.
+merged ranges, sheet tabs, freeze panes, shared filters, sorting, data
+validation/dropdowns, or export it.
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`. Auth & space rules are in
 `SKILL.md`.
 
@@ -13,18 +14,24 @@ octo-cli docs export <docId> --export-format xlsx -o spreadsheet.xlsx
 ```
 
 A spreadsheet stores a flat cell map on the Y.Doc, keyed `sheetId!row:col` (e.g.
-`default!0:0`), with values `{v,f,s}` — `v` a string/number/boolean/null, `f` an
-optional formula, `s` an opaque resolved style object. (Cells authored in the web
-may also carry Univer's `p` rich-text snapshot and `t` cell-type; both round-trip
-untouched.) Same read-token-then-guarded-write discipline as the body surface.
+`default!0:0`), with values `{v,f,s,p,t}` — `v` a string/number/boolean/null,
+`f` an optional formula, `s` an opaque resolved style object, `p` Univer's
+rich-text snapshot, and `t` the cell type. All five fields round-trip untouched.
+Same read-token-then-guarded-write discipline as the body surface.
 
 ```bash
-# Read the LIVE cells + dims + hyperlinks + merges + sheet tabs + baseVersion
+# Read the LIVE cells + dims + hyperlinks + merges + sheet tabs + freeze +
+# filters + validation/dropdown rules + baseVersion
 # (reader). Response:
-#   { docId, sheetCells: { "sheetId!row:col": {v,f,s} }, sheetDims: { "c<idx>|r<idx>": px },
+#   { docId, sheetCells: { "sheetId!row:col": {v,f,s,p,t} },
+#     sheetDims: { "${logicalId}:c<idx>|${logicalId}:r<idx>|c<idx>|r<idx>": px },
 #     sheetHyperLinks: { "sheetId!linkId": {id,row,column,payload,display?} },
 #     sheetMerges: { "logicalId:sr:sc:er:ec": true },
-#     sheetList: { "logicalId": {name,order} }, baseVersion }
+#     sheetList: { "logicalId": {name,order} },
+#     sheetFreeze: { "logicalId": {startRow,startColumn,xSplit,ySplit} },
+#     sheetFilters: { "logicalId": {ref,filterColumns?:[{colId,filters}]} },
+#     sheetDataValidations: { "logicalId": [rules of every validation type] },
+#     baseVersion }
 octo-cli docs sheet get <docId>
 
 # Batch-edit cells (writer). --base-version is REQUIRED and is sent as the
@@ -32,20 +39,189 @@ octo-cli docs sheet get <docId>
 # A cell value of null DELETES that cell.
 octo-cli docs sheet edit <docId> --base-version "<token>" \
   --data '{"cells":{"default!0:0":{"v":"hi"},"default!1:0":null}}'
+```
 
-# Set column widths / row heights via the optional `dims` batch, keyed
-# `c<idx>` (column) or `r<idx>` (row) -> pixels; a null value deletes a dim.
-# Provide cells, dims, or drawings (at least one non-empty). These are the same
-# `sheetDims` values `docs sheet get` returns.
+### Freeze panes
+
+Freeze rows and columns with one compact record per worksheet. Coordinates are
+0-based. `xSplit` is the number of frozen columns and `ySplit` the number of
+frozen rows. `startColumn` / `startRow` are the first scrollable column / row, so
+freezing the first N columns / rows normally uses N for both the start and split
+on that axis. Use `-1` as the `start*` value for an unfrozen axis. The server
+also accepts `0` on an unfrozen axis but normalizes it to `-1` on readback.
+
+```bash
+# Freeze the header row and first column. Read a fresh baseVersion first.
+octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
+  "freeze":{"default":{"startRow":1,"startColumn":1,"xSplit":1,"ySplit":1}}
+}'
+
+# Freeze only the header row (column axis remains unfrozen).
 octo-cli docs sheet edit <docId> --base-version "<token>" \
-  --data '{"dims":{"c0":200,"r3":40,"c5":null}}'
+  --data '{"freeze":{"default":{"startRow":1,"startColumn":-1,"xSplit":0,"ySplit":1}}}'
+
+# Freeze only the first column (row axis remains unfrozen).
+octo-cli docs sheet edit <docId> --base-version "<token>" \
+  --data '{"freeze":{"default":{"startRow":-1,"startColumn":1,"xSplit":1,"ySplit":0}}}'
+
+# Remove all frozen panes from the default sheet.
+octo-cli docs sheet edit <docId> --base-version "<token>" \
+  --data '{"freeze":{"default":null}}'
+```
+
+### Shared filter and sorting
+
+A filter has a 0-based rectangular `ref`. Its first row is the header row and
+is intentionally kept visible; criteria apply to the data rows below it. The
+example below keeps rows whose column B raw value is `待处理`. This is a value
+filter, not a font-color filter—cell font color does not decide whether a row
+matches. `colId` is the absolute 0-based worksheet column, not an offset from
+`ref.startColumn`. Filter state is shared, so collaborators see the same hidden
+rows. If you send `filterColumns:[]`, the server keeps the filter range but omits
+`filterColumns` from readback.
+
+```bash
+octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
+  "filters":{"default":{
+    "ref":{"startRow":0,"startColumn":0,"endRow":100,"endColumn":1},
+    "filterColumns":[{"colId":1,"filters":{"filters":["待处理"]}}]
+  }}
+}'
+
+# Remove the filter range and its criteria.
+octo-cli docs sheet edit <docId> --base-version "<token>" \
+  --data '{"filters":{"default":null}}'
+```
+
+Sorting is different: there is no durable `sort` rule. It is a raw coordinate
+rewrite, not a spreadsheet-native sort. Read the current cells, move the complete
+selected row block, and carry every cell's complete `{v,f,s,p,t}` shape to its
+destination in one guarded edit. Use `null` for destinations that become empty;
+omitting them leaves old cells in place. The server stores `f` verbatim and does
+not re-anchor relative formula references. Rewrite relative references for each
+destination, or do not sort that range through this API. Never sort only the key
+column; move every cell in each selected row so values, styles, rich text, and
+cell types stay together.
+
+The same raw-coordinate rule applies to any state keyed by or containing a
+coordinate: row `dims`, `sheetDataValidations` ranges, `sheetHyperLinks`,
+`sheetMerges`, drawings, and cell comments all stay at their old coordinates.
+Freeze panes and filter ranges/columns also remain fixed, which is normally the
+intended behavior. Remap affected row dims, validation ranges, hyperlink anchors,
+and merge keys in the same atomic edit; because `dataValidations` is replace-
+style, resend every rule you need to keep. `sheetDims` is one workbook-level map
+whose keys may be sheet-qualified. When sorting a non-default tab, remap that
+tab's `${logicalId}:r<idx>` keys; bare `r<idx>` keys address the legacy default
+sheet. Reads return dimension keys exactly as stored.
+Bare and prefixed keys for the default sheet are distinct stored entries. When
+migrating a legacy bare key, read `sheetDims` first and clear the bare twin in
+the same batch, for example `{"c0":null,"default:c0":200}`; otherwise both
+entries remain and downstream precedence is undefined.
+Drawings are not returned by `docs sheet get`, and cell comments are managed
+outside the sheet-edit surface, so do not sort an affected range unless you
+already have authoritative metadata and a safe way to preserve those anchors.
+
+Rows hidden by an active shared filter still appear in `docs sheet get`. A full
+rectangle rewrite therefore includes them. To sort only visible rows, evaluate
+the current `sheetFilters` criteria before editing and build a sparse permutation
+that leaves hidden row coordinates unchanged; clearing the filter does not
+preserve the visible subset.
+
+```bash
+# Example result of sorting two A:D data rows by column A ascending. The old
+# second row had an empty C cell, so its new destination is explicitly deleted.
+# Column D held row-relative formulas; each f is rewritten for its destination.
+# Every non-null value shown must come from the immediately preceding sheet get.
+octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
+  "cells":{
+    "default!1:0":{"v":"a"},"default!1:1":{"v":"row-a"},"default!1:2":null,"default!1:3":{"f":"=LEN(B2)"},
+    "default!2:0":{"v":"b"},"default!2:1":{"v":"row-b"},"default!2:2":{"v":"kept-with-row-b"},"default!2:3":{"f":"=LEN(B3)"}
+  }
+}'
+```
+
+### Single-select and multi-select dropdown lists
+
+Dropdown lists are stored as data-validation rules. The public REST contract is
+one array per logical sheet for every validation family; an array may mix
+`list`, `listMultiple`, `checkbox`, and any other rules returned by the server.
+Do not send the internal Y.Map's flat `${logicalId}!${uid}` key shape through
+`dataValidations`; checkbox is not the sole supported rule family.
+
+The server requires every rule to have a unique `uid` within the sheet and at
+least one non-empty `ranges:[{startRow,startColumn,endRow,endColumn}]` entry. A
+`uid` is 1–128 characters and must contain neither `!` nor control characters.
+For a working colored dropdown, use `type:"list"` for a single selection or
+`type:"listMultiple"` for multiple selections; set `formula1` to a
+JSON-serialized string array, `formula2` to the same-length comma-separated
+color list, `showDropDown:true`, and `renderMode:2`. Those dropdown fields are
+recommended client-rendering inputs, not additional server-required fields.
+Do not add an `operator` to either list type. A multi-select cell value uses the
+same serialized JSON-array form (for example `"[\"待处理\",\"已完成\"]"`),
+while a single-select cell stores the selected label directly.
+
+`dataValidations` is replace-style per logical sheet: the array you send
+replaces that sheet's entire rule set. Before adding or changing a dropdown,
+read `sheetDataValidations` with `docs sheet get`, merge the intended change,
+and resend every existing rule you need to keep. Do not make a replace-style
+write if the deployed read surface cannot enumerate every validation family on
+that sheet: a filtered read cannot preserve omitted rules.
+
+```bash
+# One atomic edit creates both dropdown types and sets initial values. This
+# array is complete only when the sheet has no other rules; otherwise start
+# from sheetDataValidations and include every existing rule you need to keep.
+octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
+  "cells":{
+    "default!1:0":{"v":"待处理"},
+    "default!1:1":{"v":"[\"待处理\",\"已完成\"]"}
+  },
+  "dataValidations":{"default":[
+    {
+      "uid":"bot-status-single","type":"list",
+      "formula1":"[\"待处理\",\"处理中\",\"已完成\"]",
+      "formula2":"#E4F4FE,#FEF0E6,#EFFBD0",
+      "showDropDown":true,"renderMode":2,
+      "ranges":[{"startRow":1,"startColumn":0,"endRow":100,"endColumn":0}]
+    },
+    {
+      "uid":"bot-status-multiple","type":"listMultiple",
+      "formula1":"[\"待处理\",\"处理中\",\"已完成\"]",
+      "formula2":"#E4F4FE,#FEF0E6,#EFFBD0",
+      "showDropDown":true,"renderMode":2,
+      "ranges":[{"startRow":1,"startColumn":1,"endRow":100,"endColumn":1}]
+    }
+  ]}
+}'
+
+# Replace all rules on the sheet with an empty set (null works too).
+octo-cli docs sheet edit <docId> --base-version "<token>" \
+  --data '{"dataValidations":{"default":[]}}'
+```
+
+Each successful edit returns a new `baseVersion`; use that new value for the
+next edit. Reusing an older token correctly fails with `412 base_version_stale`.
+
+### Column widths, row heights, and images
+
+```bash
+# Set column widths / row heights via the optional `dims` batch. Use
+# `${logicalId}:c<idx>` / `${logicalId}:r<idx>` for a specific tab; bare
+# `c<idx>` / `r<idx>` addresses the legacy default sheet. The two forms are
+# separate stored keys, so clear a legacy bare twin while migrating. A null
+# deletes a dim.
+# `dims` may be the only non-empty surface in a guarded batch; across the whole
+# request, at least one sheet edit surface must be non-empty.
+# These are the same `sheetDims` values `docs sheet get` returns.
+octo-cli docs sheet edit <docId> --base-version "<token>" \
+  --data '{"dims":{"c0":null,"default:c0":200,"default:r3":40,"default:c5":null}}'
 
 # Insert / remove a FLOATING IMAGE via the optional `drawings` batch, keyed
 # `${sheetId}!${drawingId}`. The value is a serialized Univer ISheetImage with
 # the bytes inline as a base64 data URL in `source`; `drawingId` MUST equal the
 # key's id. A null value deletes that image. `transform` is the pixel box;
-# `sheetTransform` anchors it to a cell range (from/to). NOT returned by
-# `docs sheet get` (the read surface is cells+dims only).
+# `sheetTransform` anchors it to a cell range (from/to). Drawings are the one
+# worksheet resource not returned by `docs sheet get`.
 octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
   "drawings": { "default!img1": {
     "drawingId": "img1", "drawingType": 0, "imageSourceType": "BASE64",
@@ -80,10 +256,10 @@ octo-cli docs sheet edit <docId> --base-version "<token>" --data '{
 
 ### Cell hyperlinks — the `hyperlinks` batch
 
-A cell hyperlink is its OWN edit surface (a fourth batch alongside cells/dims/
-drawings), NOT a cell field: a link lives in the `sheetHyperLinks` map and points
-back at a cell by `row`/`column`. Put the visible text in the cell's `v`
-separately. Each entry is keyed `${sheetId}!${linkId}` (linkId alnum/`-`/`_`) and
+A cell hyperlink is its OWN edit surface, not a cell field: a link lives in the
+`sheetHyperLinks` map and points back at a cell by `row`/`column`. Put the
+visible text in the cell's `v` separately. Each entry is keyed
+`${sheetId}!${linkId}` (linkId alnum/`-`/`_`) and
 is `{ id, row, column, payload, display? }` where `id` MUST equal the key's linkId,
 `payload` is the URL (only `http`/`https`/`mailto`, or an internal `#…` jump — other
 schemes are rejected), and `display` is an optional label. A null value deletes a
@@ -217,9 +393,11 @@ via `--number ... --pattern ...`. Common cases (all round-trip verified):
 A whole-sheet `docs sheet get` of a grid over the server's ~1MB read cap returns
 `413 sheet_too_large`. Pass `--limit <n>` to read it in pages instead: each
 response carries `hasMore` and an opaque `nextCursor`; feed that back via
-`--cursor` until `hasMore` is false. `sheetDims` comes back on the first page
-only. Each page is bounded by both `--limit` and the byte cap, so no page
-exceeds ~1MB regardless of `--limit`.
+`--cursor` until `hasMore` is false. Paging slices only the cells; `sheetDims`,
+`sheetHyperLinks`, `sheetMerges`, `sheetList`,
+`sheetFreeze`, `sheetFilters`, and `sheetDataValidations` all come back on the
+first page only. Each page is bounded by both `--limit` and the byte cap, so no
+page exceeds ~1MB regardless of `--limit`.
 
 ```bash
 cursor=""
@@ -238,25 +416,38 @@ sheet changed since your `docs sheet get`, an edit is rejected with
 sheet is written between pages your `--cursor` is rejected with
 `409 sheet_changed` (restart from the first page for a consistent snapshot).
 Other gates: `409 unsupported_doc_type` (target is a doc/board/whiteboard),
-`413 too_many_cells` / `413 cell_too_large` (write size caps),
+`413 too_many_cells` / `413 too_many_sheet_resources` / `413 cell_too_large`
+(write size caps),
 `400 invalid_body` (missing base version or malformed shape),
 `400 invalid_limit` / `400 invalid_cursor` (bad pagination params), and
-`422 sheet_cell_invalid` (a cell/dim/drawing/hyperlink/merge/tab violates its
-contract or key shape).
+`422 sheet_cell_invalid` (a cell/dim/drawing/hyperlink/merge/tab/freeze/filter/
+data-validation violates its contract or key shape). The server removes an
+`operator` from otherwise-valid `list` / `listMultiple` rules; omit it so the
+request and readback are identical.
 
 ## Exporting a sheet to Excel (.xlsx)
 
-There is no server-side sheet export endpoint. A bot exports by **reading the
-sheet and serializing it locally**: `docs sheet get` returns everything needed —
-`sheetCells` (`{v,f,s}` per cell) and `sheetDims` (column widths / row heights) —
-so feed those into whatever spreadsheet library the bot's runtime has (e.g.
-`xlsx-js-style` in Node, `openpyxl` in Python): map `default!r:c` → row r / col c,
-write `v` (or `f` as a formula), apply `s` as the cell style, and set widths from
-`c<idx>` / heights from `r<idx>`. For a large grid, page the read with
-`--limit`/`--cursor` and stream rows into the workbook. Merged ranges come back in
-`sheetMerges` (`logicalId:sr:sc:er:ec`) and the tabs in `sheetList`, so an export can
-carry values + styles + dimensions + merges across every sheet; only floating images
-/ formulas stay write-only (not in the read surface).
+For a standard workbook export, use the server-backed command shown above:
+`octo-cli docs export <docId> --export-format xlsx -o spreadsheet.xlsx`.
+Only when custom reconstruction is required should a bot read the sheet and
+serialize it locally: `docs sheet get` returns the readable worksheet state —
+`sheetCells` (`{v,f,s,p,t}` per cell), `sheetDims` (column widths / row heights),
+and the other returned worksheet maps. Feed those into the spreadsheet library
+available in the bot's runtime (for example, `xlsx-js-style` in Node or
+`openpyxl` in Python): split each `${logicalId}!r:c` key into its worksheet ID
+and 0-based row / column, create or select that worksheet, write `v` (or `f` as
+a formula), apply `s` as the cell style, preserve `p` rich text and `t` cell type
+when the library supports them. `sheetDims` is one workbook-level map whose keys
+may be sheet-qualified: split `${logicalId}:c<idx>` / `${logicalId}:r<idx>` and
+route each width or height to that worksheet. Bare `c<idx>` / `r<idx>` keys
+belong to the legacy default sheet. Reads return all keys exactly as stored; do
+not duplicate unqualified dimensions across every tab. Translate `sheetFreeze`,
+`sheetFilters`, and `sheetDataValidations` into the library's freeze-pane,
+auto-filter, and data-validation APIs when supported. For a large grid, page the
+read with `--limit`/`--cursor` and stream rows into the workbook. Merged ranges
+come back in `sheetMerges` (`logicalId:sr:sc:er:ec`) and tabs in `sheetList`, so an
+export can carry each sheet's values, formulas, styles, merges, and worksheet resources;
+only drawings remain write-only.
 
 ## Commenting on a cell
 

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -46,14 +46,19 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 	if !strings.Contains(content, "external-image ingest") {
 		t.Error("SKILL.md must route external-image ingest guidance to common.md")
 	}
+	for _, capability := range []string{"freeze panes", "shared filters", "sorting", "data validation/dropdowns"} {
+		if !strings.Contains(content, capability) {
+			t.Errorf("SKILL.md must advertise spreadsheet capability %q and route it to sheet.md", capability)
+		}
+	}
 
 	// The reference files are embedded (ride the */*.md glob) and each leads with
 	// its surface's read/edit commands.
 	refChecks := map[string][]string{
 		"octo-docs/doc.md":    {"docs content get", "docs content edit", `"attachId": "att_xxx"`, `"width": 300`},
-		"octo-docs/sheet.md":  {"docs sheet get", "docs sheet edit"},
+		"octo-docs/sheet.md":  {"docs sheet get", "docs sheet edit", `"freeze"`, `"filters"`, `"dataValidations"`, `"listMultiple"`, "`dims` may be the only non-empty surface", "octo-cli docs export <docId> --export-format xlsx", "`${logicalId}!r:c`", "first scrollable", "normalizes it to `-1` on readback", "absolute 0-based worksheet column", "`filterColumns:[]`", "font-color filter", `{"c0":null,"default:c0":200}`, "412 base_version_stale", "413 too_many_sheet_resources"},
 		"octo-docs/board.md":  {"docs scene get", "docs scene edit"},
-		"octo-docs/common.md": {"docs comments add", "docs versions restore", "docs members set", "docs attachments presign", "/attachments/ingest", `"attachId": "att_xxx"`, `"width": 300`},
+		"octo-docs/common.md": {"docs comments add", "docs versions restore", "docs members set", "docs attachments presign", "/attachments/ingest", `"attachId": "att_xxx"`, `"width": 300`, "every returned sheet map", "floating images, hyperlinks, merges, sheet tabs, freeze panes"},
 	}
 	for path, needles := range refChecks {
 		rb, err := FS.ReadFile(path)
@@ -66,6 +71,133 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 			if !strings.Contains(rc, n) {
 				t.Errorf("%s must document %q", path, n)
 			}
+		}
+		if path == "octo-docs/sheet.md" && strings.Contains(rc, "{v,f,s}") {
+			t.Error("octo-docs/sheet.md must not describe the cell shape as only {v,f,s}; p and t must be preserved")
+		}
+		if path == "octo-docs/sheet.md" && strings.Contains(rc, "There is no server-side sheet export endpoint") {
+			t.Error("octo-docs/sheet.md must not deny the built-in docs export xlsx endpoint")
+		}
+		if path == "octo-docs/sheet.md" && strings.Contains(rc, "clear the filter first") {
+			t.Error("octo-docs/sheet.md must not claim clearing a filter preserves the visible subset")
+		}
+		if path == "octo-docs/sheet.md" && strings.Contains(rc, "a fourth batch") {
+			t.Error("octo-docs/sheet.md must not use the obsolete four-surface count")
+		}
+	}
+}
+
+func TestOctoDocsSheetSortingContract(t *testing.T) {
+	rb, err := FS.ReadFile("octo-docs/sheet.md")
+	if err != nil {
+		t.Fatalf("read octo-docs/sheet.md: %v", err)
+	}
+	content := string(rb)
+	start := strings.Index(content, "Sorting is different:")
+	end := strings.Index(content, "### Single-select and multi-select dropdown lists")
+	if start < 0 || end <= start {
+		t.Fatalf("sorting section bounds missing: start=%d end=%d", start, end)
+	}
+	sorting := strings.Join(strings.Fields(content[start:end]), " ")
+	for _, want := range []string{
+		"raw coordinate rewrite",
+		"move the complete selected row block",
+		"complete `{v,f,s,p,t}` shape",
+		"destinations that become empty",
+		"stores `f` verbatim and does not re-anchor relative formula references",
+		"row `dims`",
+		"`sheetDataValidations` ranges",
+		"`sheetHyperLinks`",
+		"`sheetMerges`",
+		"drawings",
+		"cell comments",
+		"`sheetDims` is one workbook-level map",
+		"keys may be sheet-qualified",
+		"`${logicalId}:r<idx>` keys",
+		"bare `r<idx>` keys address the legacy default sheet",
+		"Reads return dimension keys exactly as stored",
+		"evaluate the current `sheetFilters` criteria",
+		"leaves hidden row coordinates unchanged",
+		`"default!1:2":null`,
+		`"f":"=LEN(B2)"`,
+		`"f":"=LEN(B3)"`,
+	} {
+		if !strings.Contains(sorting, want) {
+			t.Errorf("spreadsheet sorting section must document %q", want)
+		}
+	}
+	if strings.Contains(sorting, "clear the filter first") {
+		t.Error("sorting section must not claim clearing a filter preserves the visible subset")
+	}
+}
+
+func TestOctoDocsSheetDimsExportContract(t *testing.T) {
+	rb, err := FS.ReadFile("octo-docs/sheet.md")
+	if err != nil {
+		t.Fatalf("read octo-docs/sheet.md: %v", err)
+	}
+	content := string(rb)
+	start := strings.Index(content, "## Exporting a sheet to Excel (.xlsx)")
+	end := strings.Index(content, "## Commenting on a cell")
+	if start < 0 || end <= start {
+		t.Fatalf("export section bounds missing: start=%d end=%d", start, end)
+	}
+	exporting := strings.Join(strings.Fields(content[start:end]), " ")
+	for _, want := range []string{
+		"`sheetDims` is one workbook-level map",
+		"`${logicalId}:c<idx>` / `${logicalId}:r<idx>`",
+		"route each width or height to that worksheet",
+		"Bare `c<idx>` / `r<idx>` keys belong to the legacy default sheet",
+		"Reads return all keys exactly as stored",
+		"do not duplicate unqualified dimensions across every tab",
+	} {
+		if !strings.Contains(exporting, want) {
+			t.Errorf("spreadsheet export section must document %q", want)
+		}
+	}
+}
+
+func TestOctoDocsSheetDropdownContract(t *testing.T) {
+	rb, err := FS.ReadFile("octo-docs/sheet.md")
+	if err != nil {
+		t.Fatalf("read octo-docs/sheet.md: %v", err)
+	}
+	content := string(rb)
+	start := strings.Index(content, "### Single-select and multi-select dropdown lists")
+	end := strings.Index(content, "### Column widths, row heights, and images")
+	if start < 0 || end <= start {
+		t.Fatalf("dropdown section bounds missing: start=%d end=%d", start, end)
+	}
+	dropdowns := strings.Join(strings.Fields(content[start:end]), " ")
+	for _, want := range []string{
+		"one array per logical sheet for every validation family",
+		"may mix `list`, `listMultiple`, `checkbox`",
+		"internal Y.Map's flat `${logicalId}!${uid}` key shape",
+		`type:"list"`,
+		`type:"listMultiple"`,
+		"`formula1` to a JSON-serialized string array",
+		"`formula2` to the same-length comma-separated color list",
+		"`uid` is 1–128 characters",
+		"neither `!` nor control characters",
+		"at least one non-empty `ranges:[{startRow,startColumn,endRow,endColumn}]` entry",
+		"recommended client-rendering inputs, not additional server-required fields",
+		"multi-select cell value uses the same serialized JSON-array form",
+		"`dataValidations` is replace-style per logical sheet",
+		"read `sheetDataValidations`",
+		"include every existing rule you need to keep",
+		"deployed read surface cannot enumerate every validation family",
+	} {
+		if !strings.Contains(dropdowns, want) {
+			t.Errorf("spreadsheet dropdown section must document %q", want)
+		}
+	}
+	for _, superseded := range []string{
+		`sheetDataValidations: { "logicalId!uid":`,
+		"Only `type:\"checkbox\"` is accepted",
+		"only checkbox rules are supported",
+	} {
+		if strings.Contains(content, superseded) {
+			t.Errorf("spreadsheet skill retains superseded validation contract %q", superseded)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Teach the built-in Octo Docs skill and registry schema how to use the spreadsheet P0 capabilities exposed by the docs backend.

## Changes

- expose `freeze`, `filters`, and `dataValidations` in `docs sheet get/edit`
- document whole-row sorting with complete cell-object preservation
- document single-select `list` and multi-select `listMultiple` dropdown contracts
- document the unified validation contract: public REST uses per-sheet arrays for all rule families, while the Y.Map alone uses per-rule `${logicalId}!${uid}` keys
- document optimistic-concurrency behavior and `412 base_version_stale`
- add registry and embedded-skill regression coverage, including negative guards against the superseded flat-map / checkbox-only wording

## Motivation

Bots previously had no supported CLI contract for the spreadsheet P0 features, even though the product UI and backend now expose them. This change makes the capabilities discoverable to a cold-start bot.

Depends on backend MR !123: https://codex.mlamp.cn/dmwork/octo-docs-backend/-/merge_requests/123

For this delivery, MR !123 is the authoritative contract: REST reads and writes per-sheet arrays that may contain `list`, `listMultiple`, `checkbox`, and other validation families, while persistence expands those rules into per-rule Y.Map entries. The checkbox-only flat REST contract in backend MR !124 / CLI PR #154 is incompatible and must not be combined with this delivery without reconciliation.

## Testing

- [x] `jq empty internal/registry/specs/docs.json`
- [x] `go test ./internal/registry ./skills ./cmd/service -count=1`
- [x] `go test ./... -count=1`
- [x] `go test ./cmd/service -race -count=1`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] negative mutations for the flat-map and checkbox-only contract guards fail as intended
- [x] rebuilt CLI exposes the revised schema and embedded Sheet skill
- [x] cold-start bot E2E passed against the real Docker backend, including stale-version rejection and restart persistence

## Checklist

- [x] Code is in English (comments, commit messages, variable names)
- [x] New commands added to README Command Reference table — N/A, no new CLI command
- [x] CLAUDE.md command list updated if commands changed — N/A, no command change
- [x] New features include tests
- [x] Embedded skill and registry documentation updated
- [x] No unrelated changes included

## COMPREHENSION

The CLI remains a generic schema-driven transport. The load-bearing change is the embedded `docs.sheet.edit` schema and `octo-docs` guidance: clients must read a fresh `baseVersion`, preserve full row cell objects while sorting, use one complete per-sheet array when replacing data-validation rules, encode multi-select cell values as JSON-array strings, and omit numeric `operator` fields from list validation rules. The backend MR supplies the corresponding mixed-rule API contract and per-rule persistence.
