### PR TITLE
feat(docs): add sheet find and replace command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`octo-cli docs sheet replace`** — performs one server-side, optimistic-
+  concurrency-guarded find-and-replace over workbook values or formulas, with
+  optional worksheet/range, case, and whole-cell controls. **Minimum rollout
+  dependency:** release only after `octo-docs-backend` MR !132 is merged and
+  deployed; on a mixed-version environment where this route returns 404, fall
+  back to `docs sheet get` plus an explicit `docs sheet edit` batch.
 - **`octo-cli marketplace plugin` family (unified plugin surface)** — one command
   family over the backend's unified `/plugins/*` API, replacing the retired
   per-type `skill` / `mcp` / `marketplace expert` / `marketplace squad` surfaces

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
   for that origin. Mail never uses a separate token or base-URL environment
   variable.
 
-## Command Structure (12 active domains, 322 operations)
+## Command Structure (12 active domains, 323 operations)
 
 Service commands are auto-registered. The hand-written leaves are `schema`, `version`, `api` (generic passthrough), `config`, `auth`, and the cobra-generated `completion`.
 
@@ -80,7 +80,7 @@ octo-cli drive     browse
                im-transfer create
 octo-cli docs      create | list | search | get | rename | delete | forward-grant
                content  get|edit
-               sheet    get|edit
+               sheet    get|edit|replace
                scene    get|edit|export
                members  list|set|remove
                share    get|set

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Key properties:
 
 | Domain    | Ops | Purpose                                                        |
 |-----------|-----|----------------------------------------------------------------|
-| `docs`    | 32  | Documents, spreadsheets & whiteboards — lifecycle, full-text search, body content, sheet cells (paged read), board scenes, members, comments, versions, attachments |
+| `docs`    | 33  | Documents, spreadsheets & whiteboards — lifecycle, full-text search, body content, sheet cells (paged read and atomic replace), board scenes, members, comments, versions, attachments |
 | `html`    | 20  | Interactive HTML documents (octo-doc, **separate backend** from `docs`) — publish immutable versions, drafts, per-doc share codes & per-uid grants, media assets, inline comments, agent element read/replace |
 | `drive`   | 43  | Network drive — spaces & members, folder/file tree, full-text search, two-phase blob upload & signed download, online-document mounts, share links, invites, IM-attachment transfer. Plus 3 composite commands (`upload file`, `download file`, `share create`) for 46 leaves total |
 | `matter`  | 14  | Todos/tasks — **temporarily withheld** while the backend API stabilizes |

--- a/cmd/service/docs_test.go
+++ b/cmd/service/docs_test.go
@@ -39,7 +39,7 @@ func TestDocs_TreeShape(t *testing.T) {
 
 	groups := map[string][]string{
 		"content":     {"get", "edit"},
-		"sheet":       {"get", "edit"},
+		"sheet":       {"get", "edit", "replace"},
 		"scene":       {"get", "edit", "export"},
 		"members":     {"list", "set", "remove"},
 		"share":       {"get", "set"},
@@ -80,6 +80,7 @@ func TestDocs_RegistryShape(t *testing.T) {
 		"docs.content.edit":        {"PATCH", "/v1/bot/docs/{docId}/content"},
 		"docs.sheet.get":           {"GET", "/v1/bot/docs/{docId}/sheet"},
 		"docs.sheet.edit":          {"PATCH", "/v1/bot/docs/{docId}/sheet"},
+		"docs.sheet.replace":       {"POST", "/v1/bot/docs/{docId}/sheet/replace"},
 		"docs.scene.get":           {"GET", "/v1/bot/docs/{docId}/scene"},
 		"docs.scene.edit":          {"PATCH", "/v1/bot/docs/{docId}/scene"},
 		"docs.members.list":        {"GET", "/v1/bot/docs/{docId}/members"},
@@ -1142,6 +1143,150 @@ func TestDocsSheetEdit_SendsCellsBatchAndIfMatch(t *testing.T) {
 	// The base version travels in the header, not the JSON body.
 	if _, present := gotBody["baseVersion"]; present {
 		t.Errorf("baseVersion must not be duplicated into the JSON body; got %v", gotBody["baseVersion"])
+	}
+}
+
+// TestDocsSheetReplace_SendsAtomicRequestAndIfMatch checks that the generated
+// replace command delegates matching and mutation to the backend instead of
+// downloading and rewriting the workbook inside the thin CLI.
+func TestDocsSheetReplace_SendsAtomicRequestAndIfMatch(t *testing.T) {
+	var gotMethod, gotPath, gotIfMatch string
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotIfMatch = r.Header.Get("If-Match")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"d1","matchedCells":2,"replacedCells":2,"replacements":3,"baseVersion":"NEXT"}`))
+	})
+	payload := `{"findString":"old","replaceString":"new","findBy":"value","caseSensitive":true,"matchesTheWholeCell":false,"logicalId":"default","range":{"startRow":1,"startColumn":2,"endRow":3,"endColumn":4}}`
+	root.SetArgs([]string{"docs", "sheet", "replace", "d1", "--base-version", "BV_ABC==", "--data", payload})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/bot/docs/d1/sheet/replace" {
+		t.Fatalf("got %s %s, want POST /v1/bot/docs/d1/sheet/replace", gotMethod, gotPath)
+	}
+	if gotIfMatch != "BV_ABC==" {
+		t.Fatalf("If-Match = %q, want BV_ABC==", gotIfMatch)
+	}
+	if gotBody["findString"] != "old" || gotBody["replaceString"] != "new" || gotBody["findBy"] != "value" {
+		t.Fatalf("find/replace body = %#v", gotBody)
+	}
+	if gotBody["caseSensitive"] != true || gotBody["matchesTheWholeCell"] != false || gotBody["logicalId"] != "default" {
+		t.Fatalf("replace options = %#v", gotBody)
+	}
+	rangeBody, ok := gotBody["range"].(map[string]any)
+	if !ok || rangeBody["startRow"] != float64(1) || rangeBody["startColumn"] != float64(2) || rangeBody["endRow"] != float64(3) || rangeBody["endColumn"] != float64(4) {
+		t.Fatalf("range = %#v, want inclusive 0-based C2:E4", gotBody["range"])
+	}
+	if _, present := gotBody["baseVersion"]; present {
+		t.Fatalf("baseVersion must only be sent as If-Match; body = %#v", gotBody)
+	}
+}
+
+func TestDocsSheetReplace_RequiresBaseVersion(t *testing.T) {
+	called := false
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+	root.SetArgs([]string{"docs", "sheet", "replace", "d1", "--data", `{"findString":"old","replaceString":"new"}`})
+	if err := root.Execute(); err == nil || !strings.Contains(err.Error(), "required flag") {
+		t.Fatalf("missing --base-version error = %v, want required flag error", err)
+	}
+	if called {
+		t.Fatal("server must not be called when --base-version is missing")
+	}
+}
+
+func TestDocsSheetReplace_UsesKebabCaseFlags(t *testing.T) {
+	var gotBody map[string]any
+	root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"docId":"d1","matchedCells":1,"replacedCells":1,"replacements":1,"baseVersion":"NEXT"}`))
+	})
+	root.SetArgs([]string{
+		"docs", "sheet", "replace", "d1", "--base-version", "BV",
+		"--find-string", "Old", "--replace-string", "New", "--find-by", "value",
+		"--case-sensitive", "--matches-the-whole-cell", "--logical-id", "default",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	expect := map[string]any{
+		"findString": "Old", "replaceString": "New", "findBy": "value",
+		"caseSensitive": true, "matchesTheWholeCell": true, "logicalId": "default",
+	}
+	if !reflect.DeepEqual(gotBody, expect) {
+		t.Fatalf("body = %#v, want %#v", gotBody, expect)
+	}
+}
+
+func TestDocsSheetReplace_AllowsEmptyReplacement(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "data",
+			args: []string{"--data", `{"findString":"old","replaceString":""}`},
+		},
+		{
+			name: "promoted flag",
+			args: []string{"--find-string", "old", "--replace-string", ""},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody map[string]any
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+					t.Fatalf("decode request: %v", err)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"docId":"d1","matchedCells":1,"replacedCells":1,"replacements":1,"baseVersion":"NEXT"}`))
+			})
+			args := []string{"docs", "sheet", "replace", "d1", "--base-version", "BV"}
+			root.SetArgs(append(args, tc.args...))
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if value, present := gotBody["replaceString"]; !present || value != "" {
+				t.Fatalf("replaceString = %#v (present %t), want explicit empty string", value, present)
+			}
+		})
+	}
+}
+
+func TestDocsSheetReplace_ValidatesRequiredBodyAndFindBy(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want string
+	}{
+		{name: "replaceString is required", data: `{"findString":"old"}`, want: "replaceString"},
+		{name: "findBy enum", data: `{"findString":"old","replaceString":"new","findBy":"style"}`, want: "ENUM_NOT_ALLOWED"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			root, _, _ := rootWithService(t, func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			})
+			root.SetArgs([]string{"docs", "sheet", "replace", "d1", "--base-version", "BV", "--data", tc.data})
+			err := root.Execute()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want text %q", err, tc.want)
+			}
+			if called {
+				t.Fatal("invalid replacement request must not reach the server")
+			}
+		})
 	}
 }
 

--- a/cmd/service/enum_vocab_test.go
+++ b/cmd/service/enum_vocab_test.go
@@ -161,6 +161,9 @@ var requestSideVocabularies = []vocabulary{
 	{op: "docs.versions.list", in: "query", field: "kind",
 		want: []string{"all", "auto", "manual"},
 		why:  "octo-docs-backend version kind filter"},
+	{op: "docs.sheet.replace", in: "body", field: "findBy",
+		want: []string{"value", "formula"},
+		why:  "paired octo-docs-backend src/api/routes/docSheet.ts parseSheetReplaceBody accepts exactly value|formula"},
 
 	// --- html ---
 	{op: "html.grant.add", in: "body", field: "role",

--- a/docs/octo-cli-search-command-tree.md
+++ b/docs/octo-cli-search-command-tree.md
@@ -11,10 +11,10 @@ octo-cli
 │
 ├─【service 域 · spec 自动注册】
 │
-├─ docs (31) ─ 文档 / 表格 / 白板
-│    ├─ 直接        create · list · get · rename · delete · forward-grant
+├─ docs (33) ─ 文档 / 表格 / 白板
+│    ├─ 直接        create · list · get · search · rename · delete · forward-grant
 │    ├─ content     get · edit
-│    ├─ sheet       get · edit
+│    ├─ sheet       get · edit · replace
 │    ├─ scene       get · edit · export
 │    ├─ members     list · set · remove
 │    ├─ share       get · set

--- a/internal/registry/loader_test.go
+++ b/internal/registry/loader_test.go
@@ -45,7 +45,7 @@ func TestAllDomainOperationCounts(t *testing.T) {
 		"file":        4,
 		"bot":         6,
 		"event":       2,
-		"docs":        32,
+		"docs":        33,
 		"drive":       43,
 		"html":        21,
 		"marketplace": 25,

--- a/internal/registry/specs/docs.json
+++ b/internal/registry/specs/docs.json
@@ -577,6 +577,109 @@
         }
       }
     },
+    "/v1/bot/docs/{docId}/sheet/replace": {
+      "post": {
+        "operationId": "docs.sheet.replace",
+        "summary": "Find and replace spreadsheet values or formulas atomically (needs writer)",
+        "description": "Finds and replaces every match on the server in one optimistic-concurrency-guarded edit. Pass the baseVersion from `docs sheet get` through --base-version. Scope defaults to the whole workbook; pass logicalId for one worksheet, or logicalId plus an inclusive 0-based range for a selection. range without logicalId is rejected. findBy is `value` by default or `formula`; formula cells can match their cached display value in value mode but are changed only in formula mode. caseSensitive and matchesTheWholeCell default to false. The server trims findString like the spreadsheet UI, treats replacement text literally (including `$` sequences), preserves cell metadata, and reports matchedCells, replacedCells, and total replacements. An empty replaceString is allowed. A stale token returns 412 base_version_stale; protected cells return 403 protected_range; generated batches over the write limits return 413 too_many_cells or cell_too_large.",
+        "x-octo-risk": "write",
+        "parameters": [
+          {
+            "name": "docId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "required": true,
+            "x-octo-flag": "base-version",
+            "schema": { "type": "string" },
+            "description": "base-version token from 'docs sheet get' (sent as the If-Match header; required)"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["findString", "replaceString"],
+                "properties": {
+                  "findString": {
+                    "type": "string",
+                    "x-octo-flag": "find-string",
+                    "description": "literal text to find; leading/trailing whitespace is trimmed and the result must be non-empty"
+                  },
+                  "replaceString": {
+                    "type": "string",
+                    "x-octo-flag": "replace-string",
+                    "description": "literal replacement text; may be empty"
+                  },
+                  "findBy": {
+                    "type": "string",
+                    "x-octo-flag": "find-by",
+                    "enum": ["value", "formula"],
+                    "default": "value",
+                    "description": "search displayed/raw values or formula source text"
+                  },
+                  "caseSensitive": {
+                    "type": "boolean",
+                    "x-octo-flag": "case-sensitive",
+                    "default": false,
+                    "description": "match letter case exactly; defaults to false"
+                  },
+                  "matchesTheWholeCell": {
+                    "type": "boolean",
+                    "x-octo-flag": "matches-the-whole-cell",
+                    "default": false,
+                    "description": "require the complete stored value to match; rich-text streams include paragraph terminators and therefore do not match"
+                  },
+                  "logicalId": {
+                    "type": "string",
+                    "x-octo-flag": "logical-id",
+                    "description": "optional worksheet logical id; omit for the whole workbook"
+                  },
+                  "range": {
+                    "type": "object",
+                    "description": "optional inclusive 0-based selection; requires logicalId",
+                    "required": ["startRow", "startColumn", "endRow", "endColumn"],
+                    "properties": {
+                      "startRow": { "type": "integer", "minimum": 0 },
+                      "startColumn": { "type": "integer", "minimum": 0 },
+                      "endRow": { "type": "integer", "minimum": 0 },
+                      "endColumn": { "type": "integer", "minimum": 0 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Replacement result and current/new base version",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "docId": { "type": "string" },
+                    "matchedCells": { "type": "integer" },
+                    "replacedCells": { "type": "integer" },
+                    "replacements": { "type": "integer" },
+                    "bytes": { "type": "integer", "description": "present when the sheet changed" },
+                    "baseVersion": { "type": "string" },
+                    "newDocVersionSeq": { "type": "integer", "description": "present when the sheet changed" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/bot/docs/{docId}/scene": {
       "get": {
         "operationId": "docs.scene.get",

--- a/skills/octo-docs/SKILL.md
+++ b/skills/octo-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: octo-docs
 version: 0.2.0
-description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheets including cells, layout, shared filters, sorting, freeze panes, and validation/dropdowns, read and batch-edit whiteboard scenes, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
+description: Docs domain — create and govern documents, read and incrementally edit a doc's live body, read and batch-edit spreadsheets including find & replace, cells, layout, shared filters, sorting, freeze panes, and validation/dropdowns, read and batch-edit whiteboard scenes, members and sharing, inline comments, versions/snapshots, and attachment metadata as a bot. Load after octo-shared.
 metadata:
   requires:
     bins: ["octo-cli"]
@@ -21,7 +21,7 @@ All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`.
 
 | Your task | Read |
 |---|---|
-| Read/edit a **spreadsheet** (`doc_type: sheet`): cells, formulas, styles, layout, floating **images**, freeze panes, shared filters, sorting, data validation/dropdowns, paged reads, xlsx export | **`sheet.md`** |
+| Read/edit a **spreadsheet** (`doc_type: sheet`): find & replace, cells, formulas, styles, layout, floating **images**, freeze panes, shared filters, sorting, data validation/dropdowns, paged reads, xlsx export | **`sheet.md`** |
 | Read/edit a rich-text **document body** (`doc_type: doc`): incremental block ops | **`doc.md`** |
 | Read/edit a **whiteboard** (`doc_type: board`): scene elements/files, image export | **`board.md`** |
 | Continue from a searchable **HTML document** (`doc_type: html`): resolve its document reference, then use immutable versions/drafts/assets/comments | **`../octo-html/SKILL.md`** |
@@ -57,7 +57,7 @@ slug for old documents; callers do not infer the distinction from mount state.
 ```bash
 # Create an empty doc (caller becomes owner/admin). A new doc has NO body —
 # seed a `doc` with `docs content edit` (doc.md), a `sheet` with
-# `docs sheet edit` (sheet.md), a `board` with `docs scene edit` (board.md).
+# `docs sheet edit` / `docs sheet replace` (sheet.md), a `board` with `docs scene edit` (board.md).
 octo-cli docs create [--title "Runbook"] [--folderId f_123] [--docType doc|sheet|board]
 
 # List docs you own or are a member of. Page-based (see the pagination note below).
@@ -113,5 +113,5 @@ Any operation's parameters + response schema come from the embedded registry:
 ```bash
 octo-cli schema docs.create
 octo-cli schema docs.search
-octo-cli schema docs.content.edit     # + docs.sheet.edit / docs.scene.edit / docs.comments.add / …
+octo-cli schema docs.content.edit     # + docs.sheet.edit / docs.sheet.replace / docs.scene.edit / docs.comments.add / …
 ```

--- a/skills/octo-docs/sheet.md
+++ b/skills/octo-docs/sheet.md
@@ -3,7 +3,7 @@
 Read this when the target is a **spreadsheet** (`doc_type: sheet`) and you need to
 read or edit its cells, column widths / row heights, floating images, hyperlinks,
 merged ranges, sheet tabs, freeze panes, shared filters, sorting, checkbox and
-dropdown validation rules, or export it.
+dropdown validation rules, run find & replace, or export it.
 All commands call `$OCTO_API_BASE_URL/v1/bot/docs/*`. Auth & space rules are in
 `SKILL.md`.
 
@@ -41,6 +41,48 @@ octo-cli docs sheet get <docId>
 octo-cli docs sheet edit <docId> --base-version "<token>" \
   --data '{"cells":{"default!0:0":{"v":"hi"},"default!1:0":null}}'
 ```
+
+### Find and replace
+
+Prefer the server-side replace command when the endpoint is available. It
+computes one complete replacement batch against the `baseVersion` you read and
+commits it atomically; a concurrent edit returns `412 base_version_stale`. If
+this command returns 404 in a mixed-version environment, fall back to `docs
+sheet get` plus an explicit `docs sheet edit` batch.
+
+```bash
+# Whole workbook, values, case-insensitive substring match (the defaults).
+octo-cli docs sheet replace <docId> --base-version "<token>" \
+  --data '{"findString":"old","replaceString":"new"}'
+
+# One worksheet and one inclusive, 0-based selection (C2:E10).
+octo-cli docs sheet replace <docId> --base-version "<token>" --data '{
+  "findString":"=SUM(","replaceString":"=AVERAGE(","findBy":"formula",
+  "caseSensitive":true,"matchesTheWholeCell":false,
+  "logicalId":"default",
+  "range":{"startRow":1,"startColumn":2,"endRow":9,"endColumn":4}
+}'
+
+# Delete matching text by using an empty replacement string.
+octo-cli docs sheet replace <docId> --base-version "<token>" \
+  --data '{"findString":"obsolete","replaceString":""}'
+```
+
+Scope rules: omit both `logicalId` and `range` for the whole workbook; send only
+`logicalId` for one worksheet; send both for a rectangular selection. A `range`
+without `logicalId` is invalid. `findBy` is `value` or `formula`. In value mode a
+formula cell may count in `matchedCells` through its cached display value, but it
+is only writable in formula mode, so `replacedCells` can be smaller. The server
+trims `findString`, which must remain non-empty. Formula mode uses substring matching over formula source text.
+A short string such as `SUM` also matches
+`SUMIF` and `SUMPRODUCT`, so use an unambiguous string or a narrow selection and
+read the formulas back afterwards. Value mode searches stored raw values, not
+formatted display text; booleans are `1` and `0`. Whole-cell matching does not
+match rich-text cells because their stored streams include paragraph terminators.
+Replacement text is literal, including `$` sequences. The response also includes
+the total occurrence count in `replacements` and a fresh `baseVersion`; when
+nothing is replaceable, no version or Yjs update is created and the original base
+version is returned.
 
 ### Freeze panes
 
@@ -569,4 +611,5 @@ A sheet cell comment anchors to the cell key, not a text range — see
 ```bash
 octo-cli schema docs.sheet.get
 octo-cli schema docs.sheet.edit
+octo-cli schema docs.sheet.replace
 ```

--- a/skills/skills_test.go
+++ b/skills/skills_test.go
@@ -46,7 +46,7 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 	if !strings.Contains(content, "external-image ingest") {
 		t.Error("SKILL.md must route external-image ingest guidance to common.md")
 	}
-	for _, capability := range []string{"freeze panes", "shared filters", "sorting", "data validation/dropdowns"} {
+	for _, capability := range []string{"find & replace", "freeze panes", "shared filters", "sorting", "data validation/dropdowns"} {
 		if !strings.Contains(content, capability) {
 			t.Errorf("SKILL.md must advertise spreadsheet capability %q and route it to sheet.md", capability)
 		}
@@ -56,7 +56,7 @@ func TestOctoDocsSkillEmbedded(t *testing.T) {
 	// its surface's read/edit commands.
 	refChecks := map[string][]string{
 		"octo-docs/doc.md":    {"docs content get", "docs content edit", `"attachId": "att_xxx"`, `"width": 300`},
-		"octo-docs/sheet.md":  {"docs sheet get", "docs sheet edit", `"freeze"`, `"filters"`, `"dataValidations"`, `"listMultiple"`, "`dims` may be the only non-empty surface", "octo-cli docs export <docId> --export-format xlsx", "`${logicalId}!r:c`", "first scrollable", "normalizes it to `-1` on readback", "absolute 0-based worksheet column", "column G raw value", "`filterColumns:[]`", "`enabledColumns`", "G:M backing range", "enables only G and M", "replace-style per logical sheet", "read `sheetFilters` first", "`enabledColumns:[]` is rejected", "does not restrict reads or writes", "font-color filter", `{"c0":null,"default:c0":200}`, "`rowCount`", "`columnCount`", "20 columns (A-T)", "0..9999", "first page only", "outside the effective boundary for that tab", "422 sheet_cell_invalid", "412 base_version_stale", "413 too_many_sheet_resources"},
+		"octo-docs/sheet.md":  {"docs sheet get", "docs sheet edit", "docs sheet replace", "find & replace", "mixed-version environment", "trims `findString`", "substring matching over formula source text", `"freeze"`, `"filters"`, `"dataValidations"`, `"listMultiple"`, "`dims` may be the only non-empty surface", "octo-cli docs export <docId> --export-format xlsx", "`${logicalId}!r:c`", "first scrollable", "normalizes it to `-1` on readback", "absolute 0-based worksheet column", "column G raw value", "`filterColumns:[]`", "`enabledColumns`", "G:M backing range", "enables only G and M", "replace-style per logical sheet", "read `sheetFilters` first", "`enabledColumns:[]` is rejected", "does not restrict reads or writes", "font-color filter", `{"c0":null,"default:c0":200}`, "`rowCount`", "`columnCount`", "20 columns (A-T)", "0..9999", "first page only", "outside the effective boundary for that tab", "422 sheet_cell_invalid", "412 base_version_stale", "413 too_many_sheet_resources"},
 		"octo-docs/board.md":  {"docs scene get", "docs scene edit"},
 		"octo-docs/common.md": {"docs comments add", "docs versions restore", "docs members set", "docs attachments presign", "/attachments/ingest", `"attachId": "att_xxx"`, `"width": 300`, "every returned sheet map", "`sheetList`", "`rowCount` / `columnCount`", "floating images, hyperlinks, merges, sheet tabs, freeze panes"},
 	}


### PR DESCRIPTION
## Summary

- expose docs sheet replace as a generated CLI command
- support workbook, worksheet, and inclusive 0-based selection scopes
- document value/formula search, case sensitivity, whole-cell matching, empty replacements, baseVersion concurrency, and result counters
- ship the workflow in the embedded octo-docs skill for cold-start agents

## Linked Spec

No matching octo-cli issue was found. Backend contract: https://codex.mlamp.cn/dmwork/octo-docs-backend/-/merge_requests/132
Frontend surface: https://codex.mlamp.cn/dmwork/octo-web-enterprise/octo-docs-module/-/merge_requests/89

## How verified

- go test ./...
- go vet ./...
- go build ./cmd/octo-cli
- real CLI to Docker backend replacement returned matchedCells=1, replacedCells=1, replacements=1
- a no-context Agent loaded the embedded skill, performed the scoped replacement, read it back, and cleaned the test cell

## COMPREHENSION

1. **What does this change actually do to the load-bearing path?**
   It registers the backend sheet replacement endpoint in the embedded command schema and documents the concurrency-safe workflow, so agents send one guarded server-side replacement request instead of reconstructing a workbook locally.

2. **What could break because of it?**
   Registry generation could expose the wrong path or flags, the If-Match token could be omitted, or the embedded skill could omit required scope semantics. The backend endpoint must land before this command is usable outside the local paired environment.

3. **How do you know it works?**
   Unit and schema tests cover command generation and request shape; a real Docker-backed CLI run and an independent cold-start Agent both completed scoped replace and readback successfully.